### PR TITLE
feat: [P4ADEV-1878] Align breadcrumbs with backbutton

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -63,7 +63,7 @@ const Breadcrumbs = ({ separator, crumbs }: BreadcrumbsProps) => {
         <BreadcrumbsMUI
           separator={separator}
           aria-label={t('app.routes.breadcrumbs')}
-          sx={{ paddingBlock: 1, marginBottom: 1 }}>
+          sx={{ paddingBlock: 1 }}>
           {mdUp ? (
             crumbs.elements.map((r, i) => <Breadcrumb crumb={r} key={i} />)
           ) : (

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,4 +1,4 @@
-import { Container, Grid } from '@mui/material';
+import { Box, Container, Grid, Stack } from '@mui/material';
 import { grey } from '@mui/material/colors';
 import { Outlet, ScrollRestoration, useMatches } from 'react-router-dom';
 import { BackButton } from '../BackButton';
@@ -53,10 +53,15 @@ export function Layout() {
             flexBasis={'50vh'}>
             {sidebar?.visible ? <Sidebar /> : null}
             <Grid item bgcolor={grey['100']} padding={3} height={'100%'} xs paddingX={sidePadding}>
+              <Stack direction="row" 
+                     justifyContent="flex-start"
+                     alignItems="center"
+                     spacing={2}>
               {backButton && <BackButton onClick={backButtonFunction} text={backButtonText} />}
               {crumbs && (
                 <Breadcrumbs crumbs={crumbs} separator={<NavigateNext fontSize="small" />} />
               )}
+              </Stack>
               <Outlet />
             </Grid>
           </Grid>


### PR DESCRIPTION
This PR try to align the back button with breadcrumbs

#### List of Changes
- Tuning style for breadcrumbs and wrap it in Stack with tback button

#### Motivation and Context
Cosmetic fix

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
