### PR TITLE
feat: [P4ADEV-1839] Broker Config & Overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@ HELP.md
 !**/src/main/**/target/
 !**/src/test/**/target/
 
+# testing
+/coverage
+/test_reports
+
 #**/src/main/resources/application-local*.properties
 
 ### STS ###

--- a/package.json
+++ b/package.json
@@ -38,10 +38,12 @@
     "@eslint/js": "^9.13.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.1.0",
+    "@testing-library/react-hooks": "^8.0.1",
     "@types/node": "^22.9.1",
     "@types/react": "^19.0.6",
     "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^4.3.3",
+    "@vitest/coverage-v8": "2.1.8",
     "dotenv": "^16.4.5",
     "eslint": "^9.13.0",
     "eslint-config-prettier": "^9.1.0",
@@ -61,6 +63,7 @@
     "typescript-eslint": "^8.11.0",
     "vite": "^5.4.10",
     "vitest": "^2.1.8",
+    "vitest-dom": "^0.1.1",
     "zodock": "^0.1.0"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,10 +18,8 @@ import TelematicReceipt from './routes/TelematicReceipt';
 import TelematicReceiptExportFlowThankYouPage from './routes/TelematicReceiptExportFlowThankYouPage';
 
 
-
 const router = createBrowserRouter([
   {
-    
     element: <ApiClient client={utils.apiClient} />,
     children: [
       {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,13 @@ import { RouteHandleObject } from './models/Breadcrumbs';
 import Home from './routes/Home';
 import { PageRoutes } from './routes/routes';
 import { Theme } from './utils/theme';
-import { Navigate, RouterProvider, createBrowserRouter, useRouteError } from 'react-router-dom';
+import {
+  Navigate,
+  RouterProvider,
+  ScrollRestoration,
+  createBrowserRouter,
+  useRouteError
+} from 'react-router-dom';
 import TelematicReceiptFlowExportOverview from './routes/TelematicReceiptFlowExportOverview';
 import { ApiClient } from './components/ApiClient';
 import { theme } from '@pagopa/mui-italia';
@@ -16,7 +22,8 @@ import TelematicReceiptExportFlowReservation from './routes/TelematicReceiptExpo
 import TelematicReceiptSearchResults from './routes/TelematicReceiptSearchResults';
 import TelematicReceipt from './routes/TelematicReceipt';
 import TelematicReceiptExportFlowThankYouPage from './routes/TelematicReceiptExportFlowThankYouPage';
-
+import { Overlay } from './components/Overlay';
+import { useStore } from './store/GlobalStore';
 
 const router = createBrowserRouter([
   {
@@ -33,7 +40,7 @@ const router = createBrowserRouter([
         path: PageRoutes.HOME,
         element: <Layout />,
         handle: {
-          backButton: false,
+          backButton: false
         } as RouteHandleObject,
         children: [
           {
@@ -41,19 +48,21 @@ const router = createBrowserRouter([
             element: <Home />,
             // TEMPORARY ERROR ELEMENT
             errorElement: <ErrorFallback />
-          },
+          }
         ]
       },
       {
-        path:PageRoutes.TELEMATIC_RECEIPT_EXPORT_OVERVIEW,
+        path: PageRoutes.TELEMATIC_RECEIPT_EXPORT_OVERVIEW,
         element: <Layout />,
         handle: {
-          crumbs: {elements: [
-            { name: 'flows', fontWeight: 600, color: theme.palette.text.primary },
-            { name: 'telematicreceipt', color: theme.palette.text.primary },
-            { name: 'telematicReceiptFlowExportOverview', color: theme.palette.text.disabled }
-          ]},
-          backButton: true,
+          crumbs: {
+            elements: [
+              { name: 'flows', fontWeight: 600, color: theme.palette.text.primary },
+              { name: 'telematicreceipt', color: theme.palette.text.primary },
+              { name: 'telematicReceiptFlowExportOverview', color: theme.palette.text.disabled }
+            ]
+          },
+          backButton: true
         } as RouteHandleObject,
         children: [
           {
@@ -61,20 +70,20 @@ const router = createBrowserRouter([
             element: <TelematicReceiptFlowExportOverview />,
             // TEMPORARY ERROR ELEMENT
             errorElement: <ErrorFallback />
-          },
+          }
         ]
       },
       {
-        path:PageRoutes.TELEMATIC_RECEIPT,
+        path: PageRoutes.TELEMATIC_RECEIPT,
         element: <Layout />,
         handle: {
           crumbs: {
             elements: [
-              { name: 'flows', fontWeight:600, color: theme.palette.text.primary },
+              { name: 'flows', fontWeight: 600, color: theme.palette.text.primary },
               { name: 'telematicreceipt', color: theme.palette.text.disabled }
             ]
           },
-          backButton: false,
+          backButton: false
         } as RouteHandleObject,
         children: [
           {
@@ -82,11 +91,11 @@ const router = createBrowserRouter([
             element: <TelematicReceipt />,
             // TEMPORARY ERROR ELEMENT
             errorElement: <ErrorFallback />
-          },
+          }
         ]
       },
       {
-        path:PageRoutes.TELEMATIC_RECEIPT_SEARCH_RESULTS,
+        path: PageRoutes.TELEMATIC_RECEIPT_SEARCH_RESULTS,
         element: <Layout />,
         handle: {
           crumbs: {
@@ -96,7 +105,7 @@ const router = createBrowserRouter([
               { name: 'telematicreceiptsearchresults', color: theme.palette.text.disabled }
             ]
           },
-          backButton: true,
+          backButton: true
         } as RouteHandleObject,
         children: [
           {
@@ -104,17 +113,17 @@ const router = createBrowserRouter([
             element: <TelematicReceiptSearchResults />,
             // TEMPORARY ERROR ELEMENT
             errorElement: <ErrorFallback />
-          },
+          }
         ]
       },
       {
-        path:PageRoutes.TELEMATIC_RECEIPT_EXPORT_FLOW_RESERVATION,
+        path: PageRoutes.TELEMATIC_RECEIPT_EXPORT_FLOW_RESERVATION,
         element: <Layout />,
         handle: {
           backButton: true,
           sidebar: {
             visibile: false
-          },
+          }
         } as RouteHandleObject,
         children: [
           {
@@ -122,17 +131,17 @@ const router = createBrowserRouter([
             element: <TelematicReceiptExportFlowReservation />,
             // TEMPORARY ERROR ELEMENT
             errorElement: <ErrorFallback />
-          },
+          }
         ]
       },
       {
-        path:PageRoutes.TELEMATIC_RECEIPT_EXPORT_FLOW_THANK_YOU_PAGE,
+        path: PageRoutes.TELEMATIC_RECEIPT_EXPORT_FLOW_THANK_YOU_PAGE,
         element: <Layout />,
         handle: {
           backButton: false,
           sidebar: {
             visibile: false
-          },
+          }
         } as RouteHandleObject,
         children: [
           {
@@ -140,20 +149,25 @@ const router = createBrowserRouter([
             element: <TelematicReceiptExportFlowThankYouPage />,
             // TEMPORARY ERROR ELEMENT
             errorElement: <ErrorFallback />
-          },
+          }
         ]
       }
     ]
   }
 ]);
 
-
-export const App = () => (
-  <ErrorBoundary fallback={<ErrorFallback onReset={() => window.location.replace('/')} />}>
-    <Theme>
-      <RouterProvider router={router} />
-    </Theme>
-  </ErrorBoundary>
-);
+export const App = () => {
+  const {
+    state: { appState }
+  } = useStore();
+  return (
+    <ErrorBoundary fallback={<ErrorFallback onReset={() => window.location.replace('/')} />}>
+      <Theme>
+        <Overlay visible={appState.loading} />
+        <RouterProvider router={router} />
+      </Theme>
+    </ErrorBoundary>
+  );
+};
 
 export default App;

--- a/src/api/brokers.ts
+++ b/src/api/brokers.ts
@@ -3,16 +3,17 @@ import utils from '../utils';
 import { parseAndLog } from '../utils/loaders';
 import { configFESchema } from '../../generated/zod-schema';
 
-export const getBrokersConfig = () => {
+const getBrokersConfig = (options = {}) => {
   return useQuery({
     queryKey: ['brokersConfig'],
     queryFn: async () => {
       const { data: config } = await utils.apiClient.brokers.getBrokerConfig();
       if (config) {
-        parseAndLog(configFESchema, config);
+        parseAndLog(configFESchema, { ...config, brokerId: config?.brokerId ?? '' });
       }
       return config;
-    }
+    },
+    ...options
   });
 };
 

--- a/src/api/brokers.ts
+++ b/src/api/brokers.ts
@@ -9,7 +9,7 @@ const getBrokersConfig = (options = {}) => {
     queryFn: async () => {
       const { data: config } = await utils.apiClient.brokers.getBrokerConfig();
       if (config) {
-        parseAndLog(configFESchema, { ...config, brokerId: config?.brokerId ?? '' });
+        parseAndLog(configFESchema, config);
       }
       return config;
     },

--- a/src/api/brokers.ts
+++ b/src/api/brokers.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import utils from '../utils';
+import { parseAndLog } from '../utils/loaders';
+import { configFESchema } from '../../generated/zod-schema';
+
+export const getBrokersConfig = () => {
+  return useQuery({
+    queryKey: ['brokersConfig'],
+    queryFn: async () => {
+      const { data: config } = await utils.apiClient.brokers.getBrokerConfig();
+      if (config) {
+        parseAndLog(configFESchema, config);
+      }
+      return config;
+    }
+  });
+};
+
+export default {
+  getBrokersConfig
+};

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -15,7 +15,6 @@ export const Footer = () => {
   const { language, changeLanguage } = useLanguage();
 
   const configFe = useFeConfig();
-  console.debug('Footer configFe', configFe);
 
   return (
     <MUIFooter

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,10 +1,13 @@
 import lang from '../../translations/lang';
 import { Footer as MUIFooter } from '@pagopa/mui-italia';
 import { useLanguage } from '../../hooks/useLanguage';
-
+import { useFeConfig } from '../../hooks/useFeConfig';
 
 export const Footer = () => {
   const { language, changeLanguage } = useLanguage();
+
+  const configFe = useFeConfig();
+  console.debug('Footer configFe', configFe);
 
   return (
     <MUIFooter
@@ -12,7 +15,8 @@ export const Footer = () => {
       companyLink={{ ariaLabel: 'PagoPA SPA' }}
       legalInfo={
         <>
-          <b>PagoPA S.p.A.</b> - Società per azioni con socio unico - Capitale sociale di euro 1,000,000 interamente versato - Sede legale in Roma, Piazza Colonna 370, <br />
+          <b>PagoPA S.p.A.</b> - Società per azioni con socio unico - Capitale sociale di euro
+          1,000,000 interamente versato - Sede legale in Roma, Piazza Colonna 370, <br />
           CAP 00187 - N. di iscrizione a Registro Imprese di Roma, CF e P.IVA 15376371009
         </>
       }

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -3,6 +3,14 @@ import { Footer as MUIFooter } from '@pagopa/mui-italia';
 import { useLanguage } from '../../hooks/useLanguage';
 import { useFeConfig } from '../../hooks/useFeConfig';
 
+const LegalInfoFallback = () => (
+  <>
+    <b>PagoPA S.p.A.</b> - Società per azioni con socio unico - Capitale sociale di euro 1,000,000
+    interamente versato - Sede legale in Roma, Piazza Colonna 370, <br />
+    CAP 00187 - N. di iscrizione a Registro Imprese di Roma, CF e P.IVA 15376371009
+  </>
+);
+
 export const Footer = () => {
   const { language, changeLanguage } = useLanguage();
 
@@ -13,35 +21,30 @@ export const Footer = () => {
     <MUIFooter
       loggedUser={true}
       companyLink={{ ariaLabel: 'PagoPA SPA' }}
-      legalInfo={
-        <>
-          <b>PagoPA S.p.A.</b> - Società per azioni con socio unico - Capitale sociale di euro
-          1,000,000 interamente versato - Sede legale in Roma, Piazza Colonna 370, <br />
-          CAP 00187 - N. di iscrizione a Registro Imprese di Roma, CF e P.IVA 15376371009
-        </>
-      }
+      legalInfo={<>{configFe?.footerDescText ?? <LegalInfoFallback />}</>}
       postLoginLinks={[
         {
           label: 'Informativa Privacy',
           ariaLabel: 'Informativa Privacy',
-          href: '',
+          href: configFe?.footerPrivacyInfoUrl,
           linkType: 'external'
         },
         {
           label: 'Diritto alla protezione dei dati personali',
           ariaLabel: 'Diritto alla protezione dei dati personali',
+          href: configFe?.footerGDPRUrl,
           linkType: 'external'
         },
         {
           label: 'Termini e condizioni d’uso',
           ariaLabel: 'Termini e condizioni d’uso',
-          href: '',
+          href: configFe?.footerTermsCondUrl,
           linkType: 'external'
         },
         {
           label: 'Accessibilità',
           ariaLabel: 'Accessibilità',
-          href: '',
+          href: configFe?.footerAccessibilityUrl,
           linkType: 'external'
         }
       ]}

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -41,7 +41,7 @@ export const Header = (props: HeaderProps) => {
 
   /* Mocked data */
   /* TO-DO call a service */
-  const jwtUser: JwtUser | undefined = 
+  const jwtUser: JwtUser | undefined =
     {
       id: 'marcopolo',
       name: 'Marco',
@@ -72,12 +72,12 @@ export const Header = (props: HeaderProps) => {
     title: 'Piattaforma Unitaria',
     productUrl: '#pu',
     linkType: 'internal'
-    
+
   };
 
   const onSelectedParty = (id: string) => {
     setState(STATE.ORGANIZATION_ID, id);
-  }; 
+  };
 
   return (
     <>

--- a/src/components/Overlay/index.tsx
+++ b/src/components/Overlay/index.tsx
@@ -1,16 +1,29 @@
 import { CircularProgress, Grid, Portal } from '@mui/material';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 export const Overlay = ({ visible }: { visible: boolean }): React.ReactElement => {
-  document.body.style.overflow = visible ? 'hidden' : 'auto';
+
+  useEffect(() => {
+    if (visible) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'auto';
+    }
+
+    return () => {
+      document.body.style.overflow = 'auto';
+    };
+  }, [visible]);
+
   return visible ? (
     <Portal>
-      <Grid sx={style.overlay} />
+      <Grid sx={style.overlay} data-testid="overlay-background" />
       <Grid sx={style.background} alignItems="center" justifyContent="center" container>
         <CircularProgress
           sx={{ position: 'absolute', top: '40%' }}
           color="primary"
-          role="loadingSpinner"
+          role="status"
+          aria-live="assertive"
           size="50px"
         />
       </Grid>

--- a/src/components/Overlay/index.tsx
+++ b/src/components/Overlay/index.tsx
@@ -1,0 +1,42 @@
+import { CircularProgress, Grid, Portal } from '@mui/material';
+import React from 'react';
+
+export const Overlay = ({ visible }: { visible: boolean }): React.ReactElement => {
+  document.body.style.overflow = visible ? 'hidden' : 'auto';
+  return visible ? (
+    <Portal>
+      <Grid sx={style.overlay} />
+      <Grid sx={style.background} alignItems="center" justifyContent="center" container>
+        <CircularProgress
+          sx={{ position: 'absolute', top: '40%' }}
+          color="primary"
+          role="loadingSpinner"
+          size="50px"
+        />
+      </Grid>
+    </Portal>
+  ) : (
+    <React.Fragment />
+  );
+};
+
+const style = {
+  background: {
+    backgroundColor: 'background.default'
+  },
+  overlay: {
+    position: 'fixed',
+    display: 'flex',
+    WebkitBoxAlign: 'center',
+    alignItems: 'center',
+    WebkitBoxPack: 'center',
+    justifyContent: 'center',
+    inset: '0px',
+    WebkitTapHighlightColor: 'transparent',
+    backgroundColor: 'rgba(23, 50, 77, 0.7)',
+    margin: 0,
+    height: '100%',
+    overflow: 'hidden',
+    zIndex: 10
+  }
+};

--- a/src/components/Overlay/overlay.test.tsx
+++ b/src/components/Overlay/overlay.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import { Overlay } from '../Overlay';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import 'vitest-dom/extend-expect';
+
+describe('Overlay Component', () => {
+  beforeEach(() => {
+    vi.spyOn(document.body.style, 'setProperty'); // Spy on body overflow manipulation
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('should render the loading spinner and background when visible is true', () => {
+    render(<Overlay visible={true} />);
+
+    // Check if the CircularProgress spinner is in the document
+    const spinner = screen.getByRole('status');
+    expect(spinner).toBeInTheDocument();
+
+    // Check if the background overlay is visible
+    const overlay = screen.getByTestId('overlay-background');
+    expect(overlay).toBeInTheDocument();
+  });
+
+  it('should not render anything when visible is false', () => {
+    render(<Overlay visible={false} />);
+
+    // Check that no elements related to the overlay or spinner are rendered
+    const spinner = screen.queryByRole('status');
+    const overlay = screen.queryByTestId('overlay-background');
+
+    expect(spinner).not.toBeInTheDocument();
+    expect(overlay).not.toBeInTheDocument();
+  });
+
+  it('should set body overflow to "hidden" when visible is true', () => {
+    render(<Overlay visible={true} />);
+
+    expect(getComputedStyle(document.body).overflow).toBe('hidden');
+  });
+
+  it('should reset body overflow to "auto" when visible is false', () => {
+    render(<Overlay visible={false} />);
+
+    expect(getComputedStyle(document.body).overflow).toBe('auto');
+  });
+
+  it('should clean up body overflow when unmounted', () => {
+    const { unmount } = render(<Overlay visible={true} />);
+    unmount();
+
+    expect(getComputedStyle(document.body).overflow).toBe('auto');
+  });
+});

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -9,7 +9,7 @@ import {
   useTheme,
   Tooltip,
   useMediaQuery,
-  type Theme,
+  type Theme
 } from '@mui/material';
 import { SidebarMenuItem } from './SidebarMenuItem';
 import { useTranslation } from 'react-i18next';
@@ -18,13 +18,15 @@ import CloseIcon from '@mui/icons-material/Close';
 import ViewSidebarIcon from '@mui/icons-material/ViewSidebar';
 import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
 import AltRouteIcon from '@mui/icons-material/AltRoute';
+import DnsIcon from '@mui/icons-material/Dns';
+import PeopleIcon from '@mui/icons-material/People';
+import DashboardIcon from '@mui/icons-material/Dashboard';
 import { sidebarStyles } from './sidebar.styles';
 import { PageRoutes } from '../../routes/routes';
 import { ISidebarMenuItem } from '../../models/SidebarMenuItem';
 import useCollapseMenu from '../../hooks/useCollapseMenu';
 
 export const Sidebar: React.FC = () => {
-  
   const { t } = useTranslation();
   const theme = useTheme();
   const lg = useMediaQuery((theme: Theme) => theme.breakpoints.up('lg'));
@@ -32,7 +34,6 @@ export const Sidebar: React.FC = () => {
   const { collapsed, changeMenuState, setCollapsed, setOverlay, overlay } = useCollapseMenu(!lg);
 
   const [selectedTarget, setSelectedTarget] = useState('');
-
 
   useEffect(() => {
     setOverlay(!(lg || collapsed));
@@ -42,11 +43,8 @@ export const Sidebar: React.FC = () => {
   const styles = sidebarStyles(theme, collapsed);
 
   const RotatedAltRouteIcon = () => {
-    return (
-      <AltRouteIcon sx={{ transform: 'rotate(90deg)' }} />
-    );
+    return <AltRouteIcon sx={{ transform: 'rotate(90deg)' }} />;
   };
-  
 
   const menuItems: Array<ISidebarMenuItem> = [
     {
@@ -76,15 +74,35 @@ export const Sidebar: React.FC = () => {
           label: t('menu.subitem'),
           route: '/flows/item2',
           end: true
-        },
+        }
       ]
+    }
+  ];
+
+  const additionalItems = [
+    {
+      label: t('menu.entities'),
+      icon: DnsIcon,
+      route: '/debtpositions',
+      end: true
+    },
+    {
+      label: t('menu.users'),
+      icon: PeopleIcon,
+      route: '/debtpositions',
+      end: true
+    },
+    {
+      label: t('menu.deptstypes'),
+      icon: DashboardIcon,
+      route: '/debtpositions',
+      end: true
     }
   ];
 
   return (
     <>
-      <Box sx={styles.container} 
-        component="aside">
+      <Box sx={styles.container} component="aside">
         <Grid
           alignItems="normal"
           display="flex"
@@ -116,6 +134,23 @@ export const Sidebar: React.FC = () => {
             aria-hidden={collapsed && !lg}
             aria-label={t('menu.description')}>
             {menuItems.map((item, index) => (
+              <SidebarMenuItem
+                onClick={() => !lg && setCollapsed(true) && setSelectedTarget('')}
+                selectedTarget={selectedTarget}
+                setSelectedTarget={setSelectedTarget}
+                collapsed={collapsed}
+                item={item}
+                key={index}
+              />
+            ))}
+          </List>
+          <Divider orientation="horizontal" flexItem sx={{ display: lg ? 'block' : 'none' }} />
+          <List
+            sx={styles.list}
+            component="ol"
+            aria-hidden={collapsed && !lg}
+            aria-label={t('menu.description')}>
+            {additionalItems.map((item, index) => (
               <SidebarMenuItem
                 onClick={() => !lg && setCollapsed(true) && setSelectedTarget('')}
                 selectedTarget={selectedTarget}

--- a/src/hooks/useFeConfig.test.ts
+++ b/src/hooks/useFeConfig.test.ts
@@ -1,0 +1,106 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useFeConfig } from './useFeConfig';
+import brokers from '../api/brokers';
+import { setLoading } from '../store/AppStateStore';
+import { setConfigFe } from '../store/ConfigFeStore';
+import { useStore } from '../store/GlobalStore';
+import { ConfigFE } from '../../generated/apiClient';
+import { State } from '../store/types';
+
+vi.mock('../api/brokers', () => ({
+  default: {
+    getBrokersConfig: vi.fn()
+  }
+}));
+vi.mock('../store/AppStateStore', () => ({
+  setLoading: vi.fn()
+}));
+vi.mock('../store/ConfigFeStore', () => ({
+  setConfigFe: vi.fn()
+}));
+vi.mock('../store/GlobalStore', () => ({
+  useStore: vi.fn()
+}));
+
+describe('useFeConfig', () => {
+  it('should return configFe from the store when it is already set', () => {
+    const mockConfigFe = { key: 'value' };
+    vi.mocked(useStore).mockReturnValue({
+      state: { configFe: mockConfigFe as unknown as ConfigFE } as unknown as State,
+      setState: vi.fn()
+    });
+    vi.mocked(brokers.getBrokersConfig).mockReturnValue({
+      data: null as unknown as ConfigFE,
+      isLoading: false,
+      isError: false,
+      isSuccess: false
+    } as unknown as ReturnType<typeof brokers.getBrokersConfig>);
+
+    const { result } = renderHook(useFeConfig);
+
+    expect(result.current).toEqual(mockConfigFe);
+    expect(brokers.getBrokersConfig).toHaveBeenCalledWith({ enabled: false });
+  });
+
+  it('should fetch config when configFe is not set', () => {
+    const mockData = { key: 'newValue' };
+    vi.mocked(useStore).mockReturnValue({
+      state: { configFe: null as unknown as ConfigFE } as unknown as State,
+      setState: vi.fn()
+    });
+
+    vi.mocked(brokers.getBrokersConfig).mockReturnValue({
+      data: mockData as unknown as ConfigFE,
+      isLoading: false,
+      isError: false,
+      isSuccess: true
+    } as ReturnType<typeof brokers.getBrokersConfig>);
+
+    const { result } = renderHook(useFeConfig);
+
+    expect(result.current).toBeNull();
+    expect(setLoading).toHaveBeenCalledWith(false);
+    expect(setConfigFe).toHaveBeenCalledWith(mockData);
+  });
+
+  it('should set loading state when fetching config', () => {
+    vi.mocked(useStore).mockReturnValue({
+      state: { configFe: null as unknown as ConfigFE } as unknown as State,
+      setState: vi.fn()
+    });
+    vi.mocked(brokers.getBrokersConfig).mockReturnValue({
+      data: null as unknown as ConfigFE,
+      isLoading: true,
+      isError: false,
+      isSuccess: false
+    } as unknown as ReturnType<typeof brokers.getBrokersConfig>);
+
+    renderHook(useFeConfig);
+
+    expect(setLoading).toHaveBeenCalledWith(true);
+    expect(setConfigFe).not.toHaveBeenCalled();
+  });
+
+  it('should log error when fetching config fails', () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(useStore).mockReturnValue({
+      state: { configFe: null as unknown as ConfigFE } as unknown as State,
+      setState: vi.fn()
+    });
+    vi.mocked(brokers.getBrokersConfig).mockReturnValue({
+      data: null as unknown as ConfigFE,
+      isLoading: false,
+      isError: true,
+      isSuccess: false
+    } as unknown as ReturnType<typeof brokers.getBrokersConfig>);
+
+    renderHook(useFeConfig);
+
+    expect(setLoading).toHaveBeenCalledWith(false);
+    expect(setConfigFe).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to fetch fe config');
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/src/hooks/useFeConfig.tsx
+++ b/src/hooks/useFeConfig.tsx
@@ -1,0 +1,12 @@
+import brokers from '../api/brokers';
+
+export const useFeConfig = () => {
+  const { data, isError } = brokers.getBrokersConfig();
+
+  if (isError) {
+    // TODO handle config error
+    // throw new Error('Failed to fetch config');
+  }
+
+  return data;
+};

--- a/src/hooks/useFeConfig.tsx
+++ b/src/hooks/useFeConfig.tsx
@@ -1,12 +1,32 @@
+import { useEffect } from 'react';
 import brokers from '../api/brokers';
+import { setLoading } from '../store/AppStateStore';
+import { setConfigFe } from '../store/ConfigFeStore';
+import { useStore } from '../store/GlobalStore';
 
 export const useFeConfig = () => {
-  const { data, isError } = brokers.getBrokersConfig();
+  const {
+    state: { configFe }
+  } = useStore();
 
-  if (isError) {
-    // TODO handle config error
-    // throw new Error('Failed to fetch config');
-  }
+  const { data, isLoading, isError, isSuccess } = brokers.getBrokersConfig({
+    enabled: !configFe
+  });
 
-  return data;
+  useEffect(() => {
+    if (!configFe) {
+      setLoading(isLoading);
+
+      if (isSuccess && data) {
+        setConfigFe(data);
+      }
+
+      if (isError) {
+        // TODO: Handle error (e.g., show a toast)
+        console.error('Failed to fetch fe config');
+      }
+    }
+  }, [data, isLoading, isError, isSuccess]);
+
+  return configFe;
 };

--- a/src/hooks/useUserInfo.tsx
+++ b/src/hooks/useUserInfo.tsx
@@ -13,7 +13,7 @@ export const useUserInfo = () => {
   };
   const user: UserMemo = { name: data.name, familyName: data.familyName, userId: data.userId };
   setState(STATE.USER_INFO, user);
-  
+
 
   return { userInfo: state.userInfo };
 };

--- a/src/models/AppState.ts
+++ b/src/models/AppState.ts
@@ -1,0 +1,4 @@
+
+export type AppState = {
+	loading: boolean;
+};

--- a/src/routes/Home/index.tsx
+++ b/src/routes/Home/index.tsx
@@ -1,14 +1,9 @@
 import { Typography } from '@mui/material';
 
 const Home = () => {
-  
-
-
   return (
     <>
-      <Typography variant="h3" >
-          HOME
-      </Typography>
+      <Typography variant="h3">HOME</Typography>
     </>
   );
 };

--- a/src/store/AppStateStore.test.ts
+++ b/src/store/AppStateStore.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, vi, expect } from 'vitest';
+import { AppState } from '../models/AppState';
+import { appState, setAppState, setLoading, toggleLoading } from './AppStateStore';
+
+vi.mock('@preact/signals-react', async () => {
+  const actual =
+    await vi.importActual<typeof import('@preact/signals-react')>('@preact/signals-react');
+  return {
+    ...actual,
+    signal: vi.fn(actual.signal)
+  };
+});
+
+describe('AppState Store', () => {
+  it('should initialize appState with the default value', () => {
+    expect(appState.value).toEqual({ loading: false });
+  });
+
+  it('setAppState should update the appState to the provided new state', () => {
+    const newState: AppState = { loading: true };
+    setAppState(newState);
+
+    expect(appState.value).toEqual(newState);
+  });
+
+  it('setLoading should update only the loading property in appState', () => {
+    const initialState: AppState = { loading: false };
+    appState.value = initialState; // Reset the state for this test
+
+    setLoading(true);
+
+    expect(appState.value).toEqual({ loading: true });
+  });
+
+  it('toggleLoading should invert the current loading state', () => {
+    appState.value = { loading: false }; // Ensure initial state
+    toggleLoading();
+
+    expect(appState.value).toEqual({ loading: true });
+
+    toggleLoading();
+
+    expect(appState.value).toEqual({ loading: false });
+  });
+});

--- a/src/store/AppStateStore.ts
+++ b/src/store/AppStateStore.ts
@@ -1,0 +1,16 @@
+import { signal } from '@preact/signals-react';
+import { AppState } from '../models/AppState';
+
+export const appState = signal<AppState>({ loading: false });
+
+export function setAppState(newState: AppState) {
+  appState.value = newState;
+}
+
+export function setLoading(newState: AppState['loading']) {
+  appState.value.loading = newState;
+}
+
+export function toggleLoading() {
+  setLoading(!appState.value.loading);
+}

--- a/src/store/ConfigFeStore.ts
+++ b/src/store/ConfigFeStore.ts
@@ -1,0 +1,10 @@
+import { signal } from '@preact/signals-react';
+import { ConfigFE } from '../../generated/apiClient';
+
+// Initialize the persistent store
+export const configFeState = signal<ConfigFE | undefined>(undefined);
+
+// Function to update the user info
+export function setConfigFe(newState: ConfigFE | undefined) {
+  configFeState.value = newState;
+}

--- a/src/store/ConfigFeStore.ts
+++ b/src/store/ConfigFeStore.ts
@@ -1,10 +1,8 @@
 import { signal } from '@preact/signals-react';
 import { ConfigFE } from '../../generated/apiClient';
 
-// Initialize the persistent store
 export const configFeState = signal<ConfigFE | undefined>(undefined);
 
-// Function to update the user info
 export function setConfigFe(newState: ConfigFE | undefined) {
   configFeState.value = newState;
 }

--- a/src/store/GlobalStore.test.tsx
+++ b/src/store/GlobalStore.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+import { STATE } from './types';
+import { setOrganizationId } from './OrganizationIdStore';
+import { setUserInfo } from './UserInfoStore';
+import { useStore, StoreProvider } from './GlobalStore';
+import 'vitest-dom/extend-expect';
+
+vi.mock('./OrganizationIdStore', () => ({
+  setOrganizationId: vi.fn(),
+  organizationIdState: { state: { value: null } }
+}));
+
+vi.mock('./UserInfoStore', () => ({
+  setUserInfo: vi.fn(),
+  userInfoState: { state: { value: null } }
+}));
+
+vi.mock('./ConfigFeStore', () => ({
+  configFeState: { value: null }
+}));
+
+vi.mock('./AppStateStore', () => ({
+  appState: { value: { loading: false } }
+}));
+
+describe('StoreContext', () => {
+  it('should provide combined state to children', () => {
+    const TestComponent = () => {
+      const { state } = useStore();
+      return <div data-testid="app-state">{JSON.stringify(state)}</div>;
+    };
+
+    render(
+      <StoreProvider>
+        <TestComponent />
+      </StoreProvider>
+    );
+
+    const appStateElement = screen.getByTestId('app-state');
+    expect(appStateElement).toHaveTextContent(
+      JSON.stringify({
+        [STATE.APP_STATE]: { loading: false },
+        [STATE.CONFIG_FE]: null,
+        [STATE.ORGANIZATION_ID]: null,
+        [STATE.USER_INFO]: null
+      })
+    );
+  });
+
+  it('should call setOrganizationId when setting ORGANIZATION_ID', () => {
+    const TestComponent = () => {
+      const { setState } = useStore();
+      setState(STATE.ORGANIZATION_ID, { id: 'org123' });
+      return null;
+    };
+
+    render(
+      <StoreProvider>
+        <TestComponent />
+      </StoreProvider>
+    );
+
+    expect(setOrganizationId).toHaveBeenCalledWith({ id: 'org123' });
+  });
+
+  it('should call setUserInfo when setting USER_INFO', () => {
+    const TestComponent = () => {
+      const { setState } = useStore();
+      setState(STATE.USER_INFO, { name: 'John Doe' });
+      return null;
+    };
+
+    render(
+      <StoreProvider>
+        <TestComponent />
+      </StoreProvider>
+    );
+
+    expect(setUserInfo).toHaveBeenCalledWith({ name: 'John Doe' });
+  });
+
+  it('should throw an error if useStore is used outside of StoreProvider', () => {
+    const TestComponent = () => {
+      useStore();
+      return null;
+    };
+
+    expect(() => render(<TestComponent />)).toThrowError(
+      'useStore must be used within a StoreProvider'
+    );
+  });
+});

--- a/src/store/GlobalStore.tsx
+++ b/src/store/GlobalStore.tsx
@@ -4,16 +4,17 @@ import { organizationIdState, setOrganizationId } from './OrganizationIdStore';
 import { OrganizationIdMemo } from '../models/Organization';
 import { UserInfo } from '../models/User';
 import { setUserInfo, userInfoState } from './UserInfoStore';
-import { configFeState, setConfigFe } from './ConfigFeStore';
-import { ConfigFE } from '../../generated/apiClient';
+import { configFeState } from './ConfigFeStore';
+import { appState } from './AppStateStore';
 
 const StoreContext = createContext<StoreContextProps | undefined>(undefined);
 
 export const StoreProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const combinedState: State = {
+    [STATE.APP_STATE]: appState?.value,
+    [STATE.CONFIG_FE]: configFeState?.value,
     [STATE.ORGANIZATION_ID]: organizationIdState.state?.value,
-    [STATE.USER_INFO]: userInfoState.state?.value,
-    [STATE.CONFIG_FE]: configFeState?.value
+    [STATE.USER_INFO]: userInfoState.state?.value
   };
 
   const setState = (key: STATE, value: unknown) => {
@@ -22,9 +23,6 @@ export const StoreProvider: React.FC<{ children: ReactNode }> = ({ children }) =
     }
     if (key === STATE.USER_INFO) {
       setUserInfo(value as UserInfo);
-    }
-    if (key === STATE.CONFIG_FE) {
-      setConfigFe(value as ConfigFE);
     }
   };
 

--- a/src/store/GlobalStore.tsx
+++ b/src/store/GlobalStore.tsx
@@ -4,13 +4,16 @@ import { organizationIdState, setOrganizationId } from './OrganizationIdStore';
 import { OrganizationIdMemo } from '../models/Organization';
 import { UserInfo } from '../models/User';
 import { setUserInfo, userInfoState } from './UserInfoStore';
+import { configFeState, setConfigFe } from './ConfigFeStore';
+import { ConfigFE } from '../../generated/apiClient';
 
 const StoreContext = createContext<StoreContextProps | undefined>(undefined);
 
 export const StoreProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const combinedState: State = {
     [STATE.ORGANIZATION_ID]: organizationIdState.state?.value,
-    [STATE.USER_INFO]: userInfoState.state?.value
+    [STATE.USER_INFO]: userInfoState.state?.value,
+    [STATE.CONFIG_FE]: configFeState?.value
   };
 
   const setState = (key: STATE, value: unknown) => {
@@ -19,6 +22,9 @@ export const StoreProvider: React.FC<{ children: ReactNode }> = ({ children }) =
     }
     if (key === STATE.USER_INFO) {
       setUserInfo(value as UserInfo);
+    }
+    if (key === STATE.CONFIG_FE) {
+      setConfigFe(value as ConfigFE);
     }
   };
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,9 +1,11 @@
 import { UserMemo } from '../models/User';
 import { OrganizationIdMemo } from '../models/Organization';
+import { ConfigFE } from '../../generated/apiClient';
 
 export interface State {
   [STATE.USER_INFO]: UserMemo | undefined;
   [STATE.ORGANIZATION_ID]: OrganizationIdMemo | undefined;
+  [STATE.CONFIG_FE]: ConfigFE | undefined;
 }
 
 export interface StoreContextProps {
@@ -13,5 +15,6 @@ export interface StoreContextProps {
 
 export enum STATE {
   USER_INFO = 'userInfo',
+  CONFIG_FE = 'configFe',
   ORGANIZATION_ID = 'organizationId'
 }

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,11 +1,13 @@
 import { UserMemo } from '../models/User';
 import { OrganizationIdMemo } from '../models/Organization';
 import { ConfigFE } from '../../generated/apiClient';
+import { AppState } from '../models/AppState';
 
 export interface State {
   [STATE.USER_INFO]: UserMemo | undefined;
   [STATE.ORGANIZATION_ID]: OrganizationIdMemo | undefined;
   [STATE.CONFIG_FE]: ConfigFE | undefined;
+  [STATE.APP_STATE]: AppState;
 }
 
 export interface StoreContextProps {
@@ -14,6 +16,7 @@ export interface StoreContextProps {
 }
 
 export enum STATE {
+  APP_STATE = 'appState',
   USER_INFO = 'userInfo',
   CONFIG_FE = 'configFe',
   ORGANIZATION_ID = 'organizationId'

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -15,7 +15,10 @@
         "debtpositions": "Dovuti",
         "flows": "Flussi",
         "telematicreceipt": "Ricevute Telematiche",
-        "subitem": "Item"
+        "subitem": "Item",
+				"entities": "Enti gestiti",
+				"users": "Utenti",
+				"deptstypes": "Tipi dovuti"
     },
     "sidebar": {
     "collapse": "Comprimi il menu",
@@ -114,4 +117,4 @@
     "closeButton": "Chiudi"
   }
 }
-  
+

--- a/src/utils/loaders.ts
+++ b/src/utils/loaders.ts
@@ -3,14 +3,18 @@ import { ZodSchema } from 'zod';
 import * as zodSchema from '../../generated/zod-schema';
 import utils from '.';
 
-const parseAndLog = <T>(schema: ZodSchema, data: T, throwError: boolean = true): void | never => {
+export const parseAndLog = <T>(
+  schema: ZodSchema,
+  data: T,
+  throwError: boolean = true
+): void | never => {
   const result = schema.safeParse(data);
   if (!result.success) {
     console.error(result.error.issues);
     if (throwError) throw result.error;
   }
 };
-  
+
 const getOrganizations = () => {
   return useQuery({
     queryKey: ['organizations'],
@@ -27,3 +31,4 @@ const getOrganizations = () => {
 export default {
   getOrganizations
 };
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@ampproject/remapping@^2.2.0":
+"@ampproject/remapping@^2.2.0", "@ampproject/remapping@^2.3.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.3.0.tgz#ed441b6fa600072520ce18b43d2c8cc8caecc7f4"
   integrity sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==
@@ -119,6 +119,13 @@
   dependencies:
     "@babel/types" "^7.26.0"
 
+"@babel/parser@^7.25.4":
+  version "7.26.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.26.5.tgz#6fec9aebddef25ca57a935c86dbb915ae2da3e1f"
+  integrity sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==
+  dependencies:
+    "@babel/types" "^7.26.5"
+
 "@babel/plugin-transform-react-jsx-self@^7.24.7":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.25.9.tgz#c0b6cae9c1b73967f7f9eb2fca9536ba2fad2858"
@@ -169,6 +176,19 @@
   dependencies:
     "@babel/helper-string-parser" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
+
+"@babel/types@^7.25.4", "@babel/types@^7.26.5":
+  version "7.26.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.5.tgz#7a1e1c01d28e26d1fe7f8ec9567b3b92b9d07747"
+  integrity sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.25.9"
+    "@babel/helper-validator-identifier" "^7.25.9"
+
+"@bcoe/v8-coverage@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
+  integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
@@ -539,6 +559,11 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
+"@istanbuljs/schema@^0.1.2":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
+  integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
+
 "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz#dcce6aff74bdf6dad1a95802b69b04a2fcb1fb36"
@@ -571,7 +596,7 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
+"@jridgewell/trace-mapping@^0.3.23", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
   version "0.3.25"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
   integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
@@ -922,6 +947,14 @@
     lz-string "^1.5.0"
     pretty-format "^27.0.2"
 
+"@testing-library/react-hooks@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@^16.1.0":
   version "16.1.0"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-16.1.0.tgz#aa0c61398bac82eaf89776967e97de41ac742d71"
@@ -1155,6 +1188,24 @@
     "@types/babel__core" "^7.20.5"
     react-refresh "^0.14.2"
 
+"@vitest/coverage-v8@2.1.8":
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/@vitest/coverage-v8/-/coverage-v8-2.1.8.tgz#738527e6e79cef5004248452527e272e0df12284"
+  integrity sha512-2Y7BPlKH18mAZYAW1tYByudlCYrQyl5RGvnnDYJKW5tCiO5qg3KSAy3XAxcxKz900a0ZXxWtKrMuZLe3lKBpJw==
+  dependencies:
+    "@ampproject/remapping" "^2.3.0"
+    "@bcoe/v8-coverage" "^0.2.3"
+    debug "^4.3.7"
+    istanbul-lib-coverage "^3.2.2"
+    istanbul-lib-report "^3.0.1"
+    istanbul-lib-source-maps "^5.0.6"
+    istanbul-reports "^3.1.7"
+    magic-string "^0.30.12"
+    magicast "^0.3.5"
+    std-env "^3.8.0"
+    test-exclude "^7.0.1"
+    tinyrainbow "^1.2.0"
+
 "@vitest/expect@2.1.8":
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-2.1.8.tgz#13fad0e8d5a0bf0feb675dcf1d1f1a36a1773bc1"
@@ -1332,6 +1383,11 @@ aria-query@5.3.0:
   dependencies:
     dequal "^2.0.3"
 
+aria-query@^5.3.0:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.2.tgz#93f81a43480e33a338f19163a3d10a50c01dcd59"
+  integrity sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==
+
 array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
@@ -1486,6 +1542,11 @@ chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+chalk@^5.3.0:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.4.1.tgz#1b48bf0963ec158dce2aacf69c093ae2dd2092d8"
+  integrity sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==
 
 chardet@^0.7.0:
   version "0.7.0"
@@ -1663,6 +1724,11 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.5:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==
+
 cssstyle@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-4.1.0.tgz#161faee382af1bafadb6d3867a92a19bcb4aea70"
@@ -1750,6 +1816,11 @@ dom-accessibility-api@^0.5.9:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
   integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
+
+dom-accessibility-api@^0.6.1:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz#993e925cc1d73f2c662e7d75dd5a5445259a8fd8"
+  integrity sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==
 
 dom-helpers@^5.0.1:
   version "5.2.1"
@@ -2186,7 +2257,7 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob@^10.3.7:
+glob@^10.3.7, glob@^10.4.1:
   version "10.4.5"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.5.tgz#f4d9f0b90ffdbab09c9d77f5f29b4262517b0956"
   integrity sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==
@@ -2265,6 +2336,11 @@ html-encoding-sniffer@^4.0.0:
   integrity sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==
   dependencies:
     whatwg-encoding "^3.1.1"
+
+html-escaper@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
+  integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
 html-parse-stringify@^3.0.1:
   version "3.0.1"
@@ -2349,6 +2425,11 @@ indent-string@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
+indent-string@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-5.0.0.tgz#4fd2980fccaf8622d14c64d694f4cf33c81951a5"
+  integrity sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==
 
 inherits@^2.0.3, inherits@^2.0.4:
   version "2.0.4"
@@ -2483,6 +2564,37 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
+istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz#2d166c4b0644d43a39f04bf6c2edd1e585f31756"
+  integrity sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==
+
+istanbul-lib-report@^3.0.0, istanbul-lib-report@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz#908305bac9a5bd175ac6a74489eafd0fc2445a7d"
+  integrity sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==
+  dependencies:
+    istanbul-lib-coverage "^3.0.0"
+    make-dir "^4.0.0"
+    supports-color "^7.1.0"
+
+istanbul-lib-source-maps@^5.0.6:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz#acaef948df7747c8eb5fbf1265cb980f6353a441"
+  integrity sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.23"
+    debug "^4.1.1"
+    istanbul-lib-coverage "^3.0.0"
+
+istanbul-reports@^3.1.7:
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.1.7.tgz#daed12b9e1dca518e15c056e1e537e741280fa0b"
+  integrity sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==
+  dependencies:
+    html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
+
 jackspeak@^3.1.2:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.3.tgz#8833a9d89ab4acde6188942bd1c53b6390ed5a8a"
@@ -2612,6 +2724,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -2666,6 +2783,22 @@ magic-string@^0.30.12:
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.0"
 
+magicast@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/magicast/-/magicast-0.3.5.tgz#8301c3c7d66704a0771eb1bad74274f0ec036739"
+  integrity sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==
+  dependencies:
+    "@babel/parser" "^7.25.4"
+    "@babel/types" "^7.25.4"
+    source-map-js "^1.2.0"
+
+make-dir@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-4.0.0.tgz#c3c2307a771277cd9638305f915c29ae741b614e"
+  integrity sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==
+  dependencies:
+    semver "^7.5.3"
+
 make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
@@ -2705,6 +2838,11 @@ mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+min-indent@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
+  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
 minimatch@^3.1.2:
   version "3.1.2"
@@ -3063,6 +3201,13 @@ react-dom@^18.3.1:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
 
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-i18next@^14.1.0:
   version "14.1.3"
   resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-14.1.3.tgz#85525c4294ef870ddd3f5d184e793cae362f47cb"
@@ -3145,6 +3290,14 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+redent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-4.0.0.tgz#0c0ba7caabb24257ab3bb7a4fd95dd1d5c5681f9"
+  integrity sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==
+  dependencies:
+    indent-string "^5.0.0"
+    strip-indent "^4.0.0"
 
 reftools@^1.1.9:
   version "1.1.9"
@@ -3295,7 +3448,7 @@ semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.6.0, semver@^7.6.3:
+semver@^7.5.3, semver@^7.6.0, semver@^7.6.3:
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
@@ -3381,7 +3534,7 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-source-map-js@^1.2.1:
+source-map-js@^1.2.0, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
@@ -3478,6 +3631,13 @@ strip-ansi@^7.0.1:
   dependencies:
     ansi-regex "^6.0.1"
 
+strip-indent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-4.0.0.tgz#b41379433dd06f5eae805e21d631e07ee670d853"
+  integrity sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==
+  dependencies:
+    min-indent "^1.0.1"
+
 strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
@@ -3566,6 +3726,15 @@ synckit@^0.9.1:
   dependencies:
     "@pkgr/core" "^0.1.0"
     tslib "^2.6.2"
+
+test-exclude@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-7.0.1.tgz#20b3ba4906ac20994e275bbcafd68d510264c2a2"
+  integrity sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==
+  dependencies:
+    "@istanbuljs/schema" "^0.1.2"
+    glob "^10.4.1"
+    minimatch "^9.0.4"
 
 threads@^1.7.0:
   version "1.7.0"
@@ -3828,6 +3997,18 @@ vite@^5.0.0, vite@^5.4.10:
     rollup "^4.20.0"
   optionalDependencies:
     fsevents "~2.3.3"
+
+vitest-dom@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/vitest-dom/-/vitest-dom-0.1.1.tgz#a8e44a2662e557d86b84c916f62d9ce4b2eb90b1"
+  integrity sha512-n/bonR2hcRHCE5hlzG/P0yTXTUXx/gPtsaeUWP86ADfwo/+dHDpnTTV14qY7+kevsUbOZFYECu77MXY7AA0QSA==
+  dependencies:
+    aria-query "^5.3.0"
+    chalk "^5.3.0"
+    css.escape "^1.5.1"
+    dom-accessibility-api "^0.6.1"
+    lodash-es "^4.17.21"
+    redent "^4.0.0"
 
 vitest@^2.1.8:
   version "2.1.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,7 +133,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.25.9"
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.23.2", "@babel/runtime@^7.23.9", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.23.2", "@babel/runtime@^7.23.9", "@babel/runtime@^7.25.7", "@babel/runtime@^7.26.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7":
   version "7.26.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.0.tgz#8600c2f595f277c60815256418b85356a65173c1"
   integrity sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==
@@ -673,6 +673,11 @@
   resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.19.tgz#c941954dd24393fdce5f07830d44440cf4ab6c80"
   integrity sha512-6XpZEM/Q3epK9RN8ENoXuygnqUQxE+siN/6rGRi2iwJPgBUR25mphYQ9ZI87plGh58YoZ5pp40bFvKYOCDJ3tA==
 
+"@mui/types@^7.2.21":
+  version "7.2.21"
+  resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.21.tgz#63f50874eda8e4a021a69aaa8ba9597369befda2"
+  integrity sha512-6HstngiUxNqLU+/DPqlUJDIPbzUBxIVHb1MmXP0eTWDIROiCR2viugXpEif0PPe2mLqqakPzzRClWAnK+8UJww==
+
 "@mui/utils@^5.15.14", "@mui/utils@^5.16.5", "@mui/utils@^5.16.6":
   version "5.16.6"
   resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.16.6.tgz#905875bbc58d3dcc24531c3314a6807aba22a711"
@@ -684,6 +689,38 @@
     clsx "^2.1.1"
     prop-types "^15.8.1"
     react-is "^18.3.1"
+
+"@mui/utils@^5.16.6 || ^6.0.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-6.4.0.tgz#817d8135794b8741ad0267b90dc656361f1c0030"
+  integrity sha512-woOTATWNsTNR3YBh2Ixkj3l5RaxSiGoC9G8gOpYoFw1mZM77LWJeuMHFax7iIW4ahK0Cr35TF9DKtrafJmOmNQ==
+  dependencies:
+    "@babel/runtime" "^7.26.0"
+    "@mui/types" "^7.2.21"
+    "@types/prop-types" "^15.7.14"
+    clsx "^2.1.1"
+    prop-types "^15.8.1"
+    react-is "^19.0.0"
+
+"@mui/x-data-grid@^7.23.5":
+  version "7.23.6"
+  resolved "https://registry.yarnpkg.com/@mui/x-data-grid/-/x-data-grid-7.23.6.tgz#d2130fe43ced507cb441144cdb01ba8b9efe10d7"
+  integrity sha512-NcCZH99ZBLRlCcfLwwhCkVowNZHgjy0XZ/c6EuTRMSZl1UqF8ouwitP1ZfAa1idDIWCHFhxo446U/93aGMqOyQ==
+  dependencies:
+    "@babel/runtime" "^7.25.7"
+    "@mui/utils" "^5.16.6 || ^6.0.0"
+    "@mui/x-internals" "7.23.6"
+    clsx "^2.1.1"
+    prop-types "^15.8.1"
+    reselect "^5.1.1"
+
+"@mui/x-internals@7.23.6":
+  version "7.23.6"
+  resolved "https://registry.yarnpkg.com/@mui/x-internals/-/x-internals-7.23.6.tgz#01b5fddf7a0045abefd6337561e6f3989baeab23"
+  integrity sha512-hT1Pa4PNCnxwiauPbYMC3p4DiEF1x05Iu4C1MtC/jMJ1LtthymLmTuQ6ZQ53/R9FeqK6sYd6A6noR+vNMjp5DA==
+  dependencies:
+    "@babel/runtime" "^7.25.7"
+    "@mui/utils" "^5.16.6 || ^6.0.0"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -981,6 +1018,11 @@
   version "15.7.13"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.13.tgz#2af91918ee12d9d32914feb13f5326658461b451"
   integrity sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==
+
+"@types/prop-types@^15.7.14":
+  version "15.7.14"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.14.tgz#1433419d73b2a7ebfc6918dcefd2ec0d5cd698f2"
+  integrity sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==
 
 "@types/react-dom@^19.0.3":
   version "19.0.3"
@@ -3044,6 +3086,11 @@ react-is@^18.3.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
+react-is@^19.0.0:
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.0.0.tgz#d6669fd389ff022a9684f708cf6fa4962d1fea7a"
+  integrity sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g==
+
 react-refresh@^0.14.2:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.2.tgz#3833da01ce32da470f1f936b9d477da5c7028bf9"
@@ -3113,6 +3160,11 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
+reselect@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-5.1.1.tgz#c766b1eb5d558291e5e550298adb0becc24bb72e"
+  integrity sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==
 
 resolve-from@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- Broker config api call
- useFeConfig hook caches 
  feConfig in a signal
- Overlay component
- basic app state store
- adds missing sidebar items
- useConfigFe refactoring
- overlay visible during GET
  broker/config
- unit tests
- adds some tesing dependencies tools

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Broker Config is needed to render additional information about the current client config.
#### How Has This Been Tested?
- visual testing
- unit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate)
![Screen Shot 2025-01-20 at 11 11 17](https://github.com/user-attachments/assets/787e1d1e-e862-40ec-9620-0f16405d0b0b)

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
