### PR TITLE
fix: Drop "p" tag as allowed tag in footer

### DIFF
--- a/src/components/Markdown/index.tsx
+++ b/src/components/Markdown/index.tsx
@@ -6,7 +6,7 @@ type MarkdownTextProps = {
 };
 
 const allowedTags = {
-  tagNames: ['strong', 'em', 'p', 'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'br']
+  tagNames: ['strong', 'em', 'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'br']
 };
 
 export const Markdown = ({ children: markdown }: MarkdownTextProps) => (

--- a/src/components/Markdown/markdown.test.tsx
+++ b/src/components/Markdown/markdown.test.tsx
@@ -18,7 +18,7 @@ describe('MarkdownText Component', () => {
     const markdown = '[link](phishing)';
     render(<Markdown>{markdown}</Markdown>);
 
-    expect(screen.getByText('link').tagName).toBe('P');
+    expect(screen.getByText('link').tagName).toBe('DIV');
     expect(screen.queryByText('A')).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
Mui-Italia footer's displays the legal text in a "p" tag... so passing a "p" in a "p" results as malformed html.

#### List of Changes

- drop "p" tag in allowed list

#### Motivation and Context
To obtain a valid html

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
