### PR TITLE
chore: [P4ADEV-2146] adds bump to pr title check

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -16,5 +16,5 @@ jobs:
     steps:
       - uses: Slashgear/action-check-pr-title@860e8dc639f8e60335a6f5e8936ba67ed2536890 # v4.3.0
         with:
-          regexp: '(feat|fix|chore|ci|test|build|docs|perf|refactor|breaking): \[P4ADEV(-[0-9]{2,4})?\] .+'
+          regexp: '((feat|fix|chore|ci|test|build|docs|perf|refactor|breaking): \[P4ADEV(-[0-9]{2,4})?\] .+)|(Bump .+)'
           helpMessage: "Example: 'feat: [P4ADEV-1041] example of title'"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Adds bump to pr-title-check regexp
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
PRs opened by renovate-pagopa were not passing the rexexp, causing the pr to fail
#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Editing this pr title as "Bump *" causes the check to be green 
#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
