### PR TITLE
fix: [P4ADEV-2368] Debt-types without superadmin guard

### DIFF
--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -63,6 +63,12 @@ export const Sidebar: React.FC = () => {
       end: true
     },
     {
+      label: t('commons.routes.DEBT_POSITIONS'),
+      icon: ReceiptLongIcon,
+      route: PageRoutes.DEBT_POSITIONS,
+      end: true
+    },
+    {
       label: t('commons.routes.FLOWS'),
       icon: RotatedAltRouteIcon,
       // route: '/flows',
@@ -95,12 +101,6 @@ export const Sidebar: React.FC = () => {
   const additionalItems = [];
 
   if (superAdmin) {
-    menuItems.splice(1, 0, {
-      label: t('commons.routes.DEBT_POSITIONS'),
-      icon: ReceiptLongIcon,
-      route: PageRoutes.DEBT_POSITIONS,
-      end: true
-    });
 
     additionalItems.push(
       {


### PR DESCRIPTION
The "Dovuti" section could be accessed also by operators.

#### List of Changes
- remove "superAdmin" guard for DebTypes
 
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
