### PR TITLE
feat: [P4ADEV-1900] Add token management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,7 +61,7 @@ const routesDef = [
       {
         path: `${deployPath}/auth-callback`,
         element: <AuthCallback />,
-        loader: ({}) => postToken()
+        loader: () => postToken()
       },
       ...flowsRoutes,
       ...importRoutes,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,8 @@ import { exportRoutes } from './routes/export';
 import { debtTypesRoutes } from './routes/debtTypes';
 import { responsesRoutes } from './routes/responses';
 import { debtPositionsRoutes } from './routes/debtPositions';
+import AuthCallback from './routes/AuthCallback';
+import { postToken } from './api/token';
 
 const deployPath = config.deployPath;
 
@@ -55,6 +57,11 @@ const routesDef = [
             } as RouteHandleObject
           }
         ]
+      },
+      {
+        path: `${deployPath}/auth-callback`,
+        element: <AuthCallback />,
+        loader: ({}) => postToken()
       },
       ...flowsRoutes,
       ...importRoutes,

--- a/src/api/token.test.ts
+++ b/src/api/token.test.ts
@@ -7,54 +7,54 @@ import { postToken } from './token';
 
 
 vi.mock('./utils', () => {
-    const originalModule = vi.importActual('utils');
-    return {
-      ...originalModule,
-      apiClient: {
-        bff: {
-            token: {
-                postToken: vi.fn()
-            }
+  const originalModule = vi.importActual('utils');
+  return {
+    ...originalModule,
+    apiClient: {
+      bff: {
+        token: {
+          postToken: vi.fn()
         }
       }
-    };
+    }
+  };
 });
 
 
 describe('get Token API ', () => {
 
-    const fakeSelfCareToken = '123456789abc';
+  const fakeSelfCareToken = '123456789abc';
 
-    it('returns Token correctly', async () => {
+  it('returns Token correctly', async () => {
 
-      globalThis.location = {
-            ...globalThis.location,
-            href: `http://sito.it/auth-callback#${fakeSelfCareToken}`
-        };
+    globalThis.location = {
+      ...globalThis.location,
+      href: `http://sito.it/auth-callback#${fakeSelfCareToken}`
+    };
 
-      const dataMock = createMock(accessTokenSchema);
+    const dataMock = createMock(accessTokenSchema);
 
-      const apiMock = vi
-        .spyOn(utils.apiClient.bff, 'postToken')
-        .mockResolvedValue({ data: dataMock } as AxiosResponse);
-      const token = await postToken();
+    const apiMock = vi
+      .spyOn(utils.apiClient.bff, 'postToken')
+      .mockResolvedValue({ data: dataMock } as AxiosResponse);
+    const token = await postToken();
 
-      expect(apiMock).toHaveBeenCalledWith(
-        { idToken : fakeSelfCareToken },
-      );
-      expect(token).toEqual(dataMock);
-    });
+    expect(apiMock).toHaveBeenCalledWith(
+      { idToken : fakeSelfCareToken },
+    );
+    expect(token).toEqual(dataMock);
+  });
 
-    it('should return null on failure', async () => {
-        globalThis.location = {
-            ...globalThis.location,
-            href: `http://sito.it/auth-callback`
-        };
+  it('should return null on failure', async () => {
+    globalThis.location = {
+      ...globalThis.location,
+      href: 'http://sito.it/auth-callback'
+    };
   
-        vi.mocked(utils.apiClient.bff.postToken).mockRejectedValue(new Error());
-        const result = await postToken();
+    vi.mocked(utils.apiClient.bff.postToken).mockRejectedValue(new Error());
+    const result = await postToken();
   
-        expect(result).toBe(null);
-    });
+    expect(result).toBe(null);
+  });
 
 });

--- a/src/api/token.test.ts
+++ b/src/api/token.test.ts
@@ -1,0 +1,60 @@
+import utils from '../utils';
+import { AxiosResponse } from 'axios';
+import { describe, expect, it, vi } from 'vitest';
+import { accessTokenSchema } from '../../generated/zod-schema';
+import { createMock } from 'zodock';
+import { postToken } from './token';
+
+
+vi.mock('./utils', () => {
+    const originalModule = vi.importActual('utils');
+    return {
+      ...originalModule,
+      apiClient: {
+        bff: {
+            token: {
+                postToken: vi.fn()
+            }
+        }
+      }
+    };
+});
+
+
+describe('get Token API ', () => {
+
+    const fakeSelfCareToken = '123456789abc';
+
+    it('returns Token correctly', async () => {
+
+      globalThis.location = {
+            ...globalThis.location,
+            href: `http://sito.it/auth-callback#${fakeSelfCareToken}`
+        };
+
+      const dataMock = createMock(accessTokenSchema);
+
+      const apiMock = vi
+        .spyOn(utils.apiClient.bff, 'postToken')
+        .mockResolvedValue({ data: dataMock } as AxiosResponse);
+      const token = await postToken();
+
+      expect(apiMock).toHaveBeenCalledWith(
+        { idToken : fakeSelfCareToken },
+      );
+      expect(token).toEqual(dataMock);
+    });
+
+    it('should return null on failure', async () => {
+        globalThis.location = {
+            ...globalThis.location,
+            href: `http://sito.it/auth-callback`
+        };
+  
+        vi.mocked(utils.apiClient.bff.postToken).mockRejectedValue(new Error());
+        const result = await postToken();
+  
+        expect(result).toBe(null);
+    });
+
+});

--- a/src/api/token.ts
+++ b/src/api/token.ts
@@ -1,0 +1,17 @@
+import utils from '../utils';
+import { parseAndLog } from '../utils/loaders';
+import { accessTokenSchema } from '../../generated/zod-schema';
+
+export const postToken = async () => {
+    const currentUrl = new URL(window.location.href);
+    const idToken = currentUrl.hash.replace('#', '') || '';
+  
+    try {
+      const { data: token } = await utils.apiClient.bff.postToken({idToken});
+      
+      parseAndLog(accessTokenSchema, token);
+      return token;
+    } catch {
+      return null;
+    }
+  };

--- a/src/api/token.ts
+++ b/src/api/token.ts
@@ -3,15 +3,15 @@ import { parseAndLog } from '../utils/loaders';
 import { accessTokenSchema } from '../../generated/zod-schema';
 
 export const postToken = async () => {
-    const currentUrl = new URL(window.location.href);
-    const idToken = currentUrl.hash.replace('#', '') || '';
+  const currentUrl = new URL(window.location.href);
+  const idToken = currentUrl.hash.replace('#', '') || '';
   
-    try {
-      const { data: token } = await utils.apiClient.bff.postToken({idToken});
+  try {
+    const { data: token } = await utils.apiClient.bff.postToken({idToken});
       
-      parseAndLog(accessTokenSchema, token);
-      return token;
-    } catch {
-      return null;
-    }
-  };
+    parseAndLog(accessTokenSchema, token);
+    return token;
+  } catch {
+    return null;
+  }
+};

--- a/src/routes/AuthCallback/index.test.tsx
+++ b/src/routes/AuthCallback/index.test.tsx
@@ -11,7 +11,7 @@ vi.mock('react-router', async (importOriginal) => ({
 describe('AutchCallback Page', () => {
 
   afterEach(() => {
-        vi.clearAllMocks();
+    vi.clearAllMocks();
   });
       
   it('renders Auth callback without crashing', async () => {
@@ -22,6 +22,6 @@ describe('AutchCallback Page', () => {
     
     render(
       <AuthCallback />
-          );
+    );
   });
 });

--- a/src/routes/AuthCallback/index.test.tsx
+++ b/src/routes/AuthCallback/index.test.tsx
@@ -1,0 +1,27 @@
+import { afterEach, describe, it, vi } from 'vitest';
+import AuthCallback from './index';
+import { render } from '@testing-library/react';
+
+vi.mock('react-router', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useLoaderData: vi.fn( () => ({ access_token: 'mocked-access-token' }) )
+}));
+
+
+describe('AutchCallback Page', () => {
+
+  afterEach(() => {
+        vi.clearAllMocks();
+  });
+      
+  it('renders Auth callback without crashing', async () => {
+    globalThis.location = {
+      ...globalThis.location,
+      replace: vi.fn()
+    };
+    
+    render(
+      <AuthCallback />
+          );
+  });
+});

--- a/src/routes/AuthCallback/index.tsx
+++ b/src/routes/AuthCallback/index.tsx
@@ -7,7 +7,7 @@ export default function AuthCallback() {
   const result = useLoaderData() as Awaited<ReturnType<typeof postToken>>;
 
   if (result?.access_token) {
-    window.localStorage.setItem('accessToken', result.access_token)
+    window.localStorage.setItem('accessToken', result.access_token);
     window.location.replace('/piattaformaunitaria');
   } else {
     window.location.replace('/piattaformaunitaria#error');

--- a/src/routes/AuthCallback/index.tsx
+++ b/src/routes/AuthCallback/index.tsx
@@ -1,0 +1,21 @@
+import { Box, CircularProgress } from '@mui/material';
+import { useLoaderData } from 'react-router';
+import { postToken } from '../../api/token';
+
+export default function AuthCallback() {
+
+  const result = useLoaderData() as Awaited<ReturnType<typeof postToken>>;
+
+  if (result?.access_token) {
+    window.localStorage.setItem('accessToken', result.access_token)
+    window.location.replace('/piattaformaunitaria');
+  } else {
+    window.location.replace('/piattaformaunitaria#error');
+  }
+
+  return (
+    <Box width={'100vw'} height={'100vh'} alignContent={'center'} textAlign={'center'}>
+      <CircularProgress /> 
+    </Box>
+  );
+}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -64,7 +64,7 @@ const config: Config = {
   fileshareURL: VITE_FILESHARE_APIHOST,
   deployPath: VITE_DEPLOY_PATH,
   /** This array is populated by paths that don't need a auth token */
-  tokenHeaderExcludePaths: ['/token/']
+  tokenHeaderExcludePaths: ['/auth-callback']
 };
 
 export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
   ],
   "compilerOptions": {
     "baseUrl": ".",
+    "lib": ["dom", "esnext"],
     "paths": {
       "src/*": ["./src/*"],
     }


### PR DESCRIPTION
This PR add a new route called "auth-callback" that accept an incoming token and obtain a new one from the BFF. If it's ok this token is stored in the localStorage.

#### List of Changes

- add a new route authCallback
- add a new handler in the api folder that call the bff service postToken
- unit tests

#### Motivation and Context
With this PR we can handle access token form SelfCare.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
