### PR TITLE
fix: [P4ADEV-2422] Drop unuseful monetyformat

### DIFF
--- a/src/routes/TelematicReceiptDetail/index.tsx
+++ b/src/routes/TelematicReceiptDetail/index.tsx
@@ -9,7 +9,6 @@ import TitleComponent from '../../components/TitleComponent/TitleComponent';
 import DetailContainer, {
   DetailData
 } from '../../components/DetailContainer/DetailContainer';
-import { moneyFormat } from '../../utils/formatters';
 
 export const TelematicReceiptDetail = () => {
   const { t } = useTranslation();
@@ -35,7 +34,7 @@ export const TelematicReceiptDetail = () => {
     },
     {
       label: t('commons.amount'),
-      value: moneyFormat(data?.paymentAmountCents as number)
+      value: (data?.paymentAmountCents as number) || 0
     },
     {
       label: t('commons.reason'),


### PR DESCRIPTION
This fix use a moneyformat "embedded" in the detail components instead using an "external" one.

#### List of Changes

- drop moneyformat

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
