### PR TITLE
fix: [P4ADEV-2375] set first page on grid filter

### DIFF
--- a/src/hooks/useDebtPositionsSearch.tsx
+++ b/src/hooks/useDebtPositionsSearch.tsx
@@ -80,6 +80,7 @@ export const useDebtPositionSearch = ({
 
   const applyFilters = useCallback(() => {
     query.mutate(filterToRequest());
+    handlePageChange(1);
   }, [filterToRequest, query]);
 
   return {

--- a/src/hooks/useReportingSearch.tsx
+++ b/src/hooks/useReportingSearch.tsx
@@ -80,6 +80,7 @@ export const useReportingSearch = ({
 
   const applyFilters = useCallback(() => {
     query.mutate(filterToRequest());
+    handlePageChange(1);
   }, [filterToRequest, query]);
 
   return {

--- a/src/hooks/useTelematicReceiptsSearch.tsx
+++ b/src/hooks/useTelematicReceiptsSearch.tsx
@@ -66,6 +66,7 @@ export const useTelematicReceiptSearch = ({
 
   const applyFilters = useCallback(() => {
     query.mutate(filterToRequest());
+    handlePageChange(1);
   }, [filterToRequest, query]);
 
   return {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- sets page to 1 on filter for the followiing grid
  - DebtPosition ( both IUV and DebtPositons)
  - Reporting
  - TelematicReceipts
 
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Before this pr user would remain on the last page after appliyng a filter, causing issues like showing an empty first page.
#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Visual testing
#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
