### PR TITLE
feat: [P4ADEV-2469] chip colors debt position

### DIFF
--- a/src/routes/DebtPositionDetail/DebtPositionDetail.tsx
+++ b/src/routes/DebtPositionDetail/DebtPositionDetail.tsx
@@ -48,6 +48,7 @@ type InstallmentRow = {
   amount: number;
   expirationDate: string;
   status: string;
+  chip: { label: string; color: ChipOwnProps['color'] } | undefined;
 };
 
 const DebtPositionDetail = () => {
@@ -143,9 +144,8 @@ const DebtPositionDetail = () => {
       expirationDate: installment.dueDate
         ? format(parseISO(installment.dueDate), 'dd/MM/yyyy')
         : 'N/A',
-      status: installment.status
-        ? getStatusChipProps(installment.status).label
-        : 'N/A'
+      status: installment.status || '',
+      chip: installment.status ? getStatusChipProps(installment.status) : undefined
     };
   };
 
@@ -244,7 +244,8 @@ const DebtPositionDetail = () => {
             />
           )}
         </Box>
-      ))}
+      )
+      )}
 
       <Timeline.Drawer
         title={t('debtPositionDetail.timeline.title')}

--- a/src/routes/DebtPositionDetail/components/PaymentOptionSection.test.tsx
+++ b/src/routes/DebtPositionDetail/components/PaymentOptionSection.test.tsx
@@ -32,7 +32,11 @@ const mockOptionData: PaymentOptionDisplayData = {
       subject: 'Test Installment',
       amount: 2500,
       expirationDate: '2025-12-31',
-      status: 'Unpaid'
+      status: 'UNPAID',
+      chip: {
+        label: 'Unpaid',
+        color: 'info',
+      }
     },
     {
       id: 2,
@@ -40,7 +44,11 @@ const mockOptionData: PaymentOptionDisplayData = {
       subject: 'Test Installment 2',
       amount: 2500,
       expirationDate: '2026-01-31',
-      status: 'Reported'
+      status: 'REPORTED',
+      chip: {
+        label: 'Reported',
+        color: 'success',
+      }
     }
   ]
 };
@@ -144,7 +152,11 @@ describe('PaymentOptionSection Component', () => {
           subject: 'Test Paid',
           amount: 2500,
           expirationDate: '2025-12-31',
-          status: 'Paid'
+          status: 'PAID',
+          chip: {
+            label: 'Paid',
+            color: 'success',
+          }
         },
         {
           id: 2,
@@ -152,7 +164,11 @@ describe('PaymentOptionSection Component', () => {
           subject: 'Test Unpaid',
           amount: 2500,
           expirationDate: '2026-01-31',
-          status: 'Unpaid'
+          status: 'UNPAID',
+          chip: {
+            label: 'Unpaid',
+            color: 'info',
+          }
         },
         {
           id: 3,
@@ -160,7 +176,11 @@ describe('PaymentOptionSection Component', () => {
           subject: 'Test Other Status',
           amount: 2500,
           expirationDate: '2026-02-28',
-          status: 'Other Status'
+          status: 'OTHER',
+          chip: {
+            label: 'Other Status',
+            color: 'default',
+          }
         }
       ]
     };
@@ -177,12 +197,12 @@ describe('PaymentOptionSection Component', () => {
     expect(paidChip).toHaveClass('MuiChip-colorSuccess');
 
     const unpaidChip = screen.getByText('Unpaid').closest('.MuiChip-root');
-    expect(unpaidChip).toHaveClass('MuiChip-colorError');
+    expect(unpaidChip).toHaveClass('MuiChip-colorInfo');
 
     const otherStatusChip = screen
       .getByText('Other Status')
       .closest('.MuiChip-root');
-    expect(otherStatusChip).toHaveClass('MuiChip-colorInfo');
+    expect(otherStatusChip).toHaveClass('MuiChip-colorDefault');
   });
 
   it('hides footer when installments length is 5 or less', () => {
@@ -203,7 +223,11 @@ describe('PaymentOptionSection Component', () => {
           subject: `Test Installment ${index + 1}`,
           amount: 1000,
           expirationDate: '2025-12-31',
-          status: 'Unpaid'
+          status: 'UNPAID',
+          chip: {
+            label: 'Unpaid',
+            color: 'info'
+          }
         }))
     };
 

--- a/src/routes/DebtPositionDetail/components/PaymentOptionSection.tsx
+++ b/src/routes/DebtPositionDetail/components/PaymentOptionSection.tsx
@@ -4,8 +4,7 @@ import {
   Accordion,
   AccordionSummary,
   Typography,
-  Chip,
-  ChipProps
+  Chip
 } from '@mui/material';
 import { theme } from '@pagopa/mui-italia';
 import { t } from 'i18next';
@@ -29,16 +28,6 @@ export const PaymentOptionSection = ({
   };
 
   const navigate = useNavigate();
-
-  const getChipColorForStatus = (status: string): ChipProps['color'] => {
-    if (status === t('commons.paid')) {
-      return 'success';
-    }
-    if (status === t('commons.unpaid')) {
-      return 'error';
-    }
-    return 'info';
-  };
 
   const renderInstallmentColumns = (): Array<GridColDef> => [
     {
@@ -73,8 +62,7 @@ export const PaymentOptionSection = ({
       flex: 0.5,
       type: 'string',
       renderCell: (params: GridRenderCellParams) => {
-        const chipColor = getChipColorForStatus(params.row.status);
-        return <Chip label={params.row.status} color={chipColor} />;
+        return <Chip label={params.row.chip.label} color={params.row.chip.color} variant="outlined" />;
       }
     },
     {

--- a/src/routes/DebtPositionDetail/components/PaymentOptionSection.tsx
+++ b/src/routes/DebtPositionDetail/components/PaymentOptionSection.tsx
@@ -59,7 +59,7 @@ export const PaymentOptionSection = ({
     {
       field: 'status',
       headerName: 'Stato',
-      flex: 0.5,
+      flex: 1,
       type: 'string',
       renderCell: (params: GridRenderCellParams) => {
         return <Chip label={params.row.chip.label} color={params.row.chip.color} variant="outlined" />;

--- a/src/utils/style.tsx
+++ b/src/utils/style.tsx
@@ -21,16 +21,6 @@ const customTheme = createTheme({
         })
       }
     },
-    MuiChip: {
-      ...theme?.components?.MuiChip,
-      styleOverrides: {
-        root: ({ ownerState, theme }) => ({
-          ...(ownerState.color === 'success' && {
-            backgroundColor: theme.palette.success.extraLight
-          })
-        })
-      }
-    },
     MuiInputLabel: {
       styleOverrides: {
         asterisk: { color: theme.palette.error.dark }


### PR DESCRIPTION
This PR fix an inappropriate behavior of the debpositions' chips. A little refactoring bring a more useful use of chips colors.

#### List of Changes
- drop status as translated string
- set chip as new prop
- pass the chip prop from the parent to the children row in debtposition detail

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
