### PR TITLE
feat: [P4ADEV-2619] creazione step 3 rata unica singolo beneficiario

### DIFF
--- a/src/components/Wizard/PaperContent.test.tsx
+++ b/src/components/Wizard/PaperContent.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen } from '@testing-library/react';
+import { describe, test, expect, vi } from 'vitest';
+import PaperContent from './PaperContent';
+
+// Mock dell'icona predefinita
+vi.mock('@mui/icons-material/MenuBook', () => ({
+  default: () => <div data-testid="book-icon">BookIcon</div>
+}));
+
+describe('PaperContent', () => {
+  // Test del rendering con titolo e contenuto
+  test('renders correctly with title and children', () => {
+    render(
+      <PaperContent title="Test Title">
+        <div data-testid="child-content">Child Content</div>
+      </PaperContent>
+    );
+
+    // Verifica che il titolo sia renderizzato
+    const titleElement = screen.getByText('Test Title');
+    expect(titleElement).toBeInTheDocument();
+    expect(titleElement.tagName).toBe('H6');
+
+    // Verifica che l'icona predefinita sia renderizzata
+    const iconElement = screen.getByTestId('book-icon');
+    expect(iconElement).toBeInTheDocument();
+
+    // Verifica che il contenuto figlio sia renderizzato
+    expect(screen.getByTestId('child-content')).toBeInTheDocument();
+    expect(screen.getByText('Child Content')).toBeInTheDocument();
+
+    // Verifica che l'icona e il titolo siano nello stesso container
+    const iconParent = iconElement.parentElement;
+    expect(iconParent).not.toBeNull();
+    if (iconParent) {
+      // Verifica che il container dell'icona sia anche il parent o un antenato del titolo
+      expect(
+        iconParent.contains(titleElement) ||
+          iconParent.parentElement?.contains(titleElement)
+      ).toBeTruthy();
+    }
+  });
+
+  // Test del rendering con icona personalizzata
+  test('renders correctly with custom icon', () => {
+    const CustomIcon = () => <div data-testid="custom-icon">CustomIcon</div>;
+
+    render(
+      <PaperContent title="Test Title" icon={<CustomIcon />}>
+        <div data-testid="child-content">Child Content</div>
+      </PaperContent>
+    );
+
+    // Verifica che l'icona personalizzata sia renderizzata
+    const customIconElement = screen.getByTestId('custom-icon');
+    expect(customIconElement).toBeInTheDocument();
+    expect(screen.getByText('CustomIcon')).toBeInTheDocument();
+
+    // Verifica che l'icona predefinita NON sia renderizzata
+    expect(screen.queryByTestId('book-icon')).toBeNull();
+
+    // Verifica che il titolo sia renderizzato
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
+  });
+
+  // Test del rendering con solo titolo (senza figli)
+  test('renders correctly with only title', () => {
+    render(
+      <PaperContent title="Test Title">
+        <></>
+      </PaperContent>
+    );
+
+    // Verifica che il titolo sia renderizzato
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
+
+    // Verifica che l'icona predefinita sia renderizzata
+    expect(screen.getByTestId('book-icon')).toBeInTheDocument();
+
+    // Verifica che non ci siano figli aggiuntivi oltre l'header
+    expect(screen.queryByTestId('child-content')).toBeNull();
+  });
+
+  // Test del rendering con titolo vuoto
+  test('renders correctly with empty title', () => {
+    render(
+      <PaperContent title="">
+        <div data-testid="child-content">Child Content</div>
+      </PaperContent>
+    );
+
+    // Verifica che l'icona predefinita sia renderizzata
+    expect(screen.getByTestId('book-icon')).toBeInTheDocument();
+
+    // Verifica che il contenuto figlio sia renderizzato
+    expect(screen.getByTestId('child-content')).toBeInTheDocument();
+
+    // Verifica che il titolo vuoto sia renderizzato in un elemento Typography
+    const titleElements = screen.getAllByRole('heading', { level: 6 });
+    expect(titleElements.length).toBeGreaterThan(0);
+    expect(titleElements[0].textContent).toBe('');
+  });
+
+  // Test aggiuntivo per verificare la presenza del Paper e del suo stile
+  test('renders Paper with correct styling', () => {
+    render(
+      <PaperContent title="Test Title">
+        <></>
+      </PaperContent>
+    );
+
+    // Verifica la presenza del Paper
+    const paperElement = screen
+      .getByText('Test Title')
+      .closest('div[class*="MuiPaper"]');
+    expect(paperElement).not.toBeNull();
+
+    // Verifica che il Paper contenga il titolo e l'icona
+    if (paperElement) {
+      expect(paperElement.textContent).toContain('Test Title');
+      expect(paperElement.textContent).toContain('BookIcon');
+    }
+  });
+});

--- a/src/components/Wizard/PaperContent.tsx
+++ b/src/components/Wizard/PaperContent.tsx
@@ -1,0 +1,26 @@
+import { Box, Paper, Typography } from '@mui/material';
+import BookIcon from '@mui/icons-material/MenuBook';
+
+type PaperContentProps = {
+  title: string;
+  icon?: React.ReactNode;
+  children: React.ReactNode;
+};
+
+const PaperContent = ({
+  title,
+  icon = <BookIcon color="action" sx={{ mr: 1 }} />,
+  children
+}: PaperContentProps) => {
+  return (
+    <Paper variant="outlined" sx={{ p: 3, mt: 2 }}>
+      <Box display="flex" alignItems="center" mb={2}>
+        {icon}
+        <Typography variant="h6">{title}</Typography>
+      </Box>
+      {children}
+    </Paper>
+  );
+};
+
+export default PaperContent;

--- a/src/components/Wizard/SectionBox.tsx
+++ b/src/components/Wizard/SectionBox.tsx
@@ -2,7 +2,7 @@ import { Box, Typography } from '@mui/material';
 import { PropsWithChildren } from 'react';
 import BookIcon from '@mui/icons-material/MenuBook';
 
-type Props = {
+type SectionBoxProps = {
   title?: string;
   hideHeader?: boolean;
 };
@@ -11,7 +11,7 @@ const SectionBox = ({
   title,
   children,
   hideHeader = false
-}: PropsWithChildren<Props>) => {
+}: PropsWithChildren<SectionBoxProps>) => {
   return (
     <Box sx={{ borderColor: 'divider' }} borderRadius={2} p={3} mt={3}>
       {!hideHeader && title && (

--- a/src/components/Wizard/WizardStepButtons.test.tsx
+++ b/src/components/Wizard/WizardStepButtons.test.tsx
@@ -7,6 +7,7 @@ vi.mock('react-i18next', () => ({
   useTranslation: vi.fn(() => ({
     t: (key: string) => {
       if (key === 'commons.back') return 'Indietro';
+      if (key === 'commons.continue') return 'Continua';
       return key;
     }
   }))

--- a/src/components/Wizard/WizardStepButtons.tsx
+++ b/src/components/Wizard/WizardStepButtons.tsx
@@ -8,6 +8,7 @@ type Props = {
   disableNext?: boolean;
   disableBack?: boolean;
   nextLabel?: string;
+  backLabel?: string;
 };
 
 const WizardStepButtons = ({
@@ -15,9 +16,11 @@ const WizardStepButtons = ({
   onNext,
   disableNext,
   disableBack = false,
-  nextLabel = 'Continua'
+  nextLabel = 'commons.continue',
+  backLabel = 'commons.back'
 }: Props) => {
   const { t } = useTranslation();
+
   return (
     <Box mt={4} display="flex" justifyContent="space-between">
       <Button
@@ -26,10 +29,10 @@ const WizardStepButtons = ({
         disabled={disableBack}
         startIcon={<ArrowBack />}
       >
-        {t('commons.back')}
+        {t(backLabel)}
       </Button>
       <Button variant="contained" onClick={onNext} disabled={disableNext}>
-        {nextLabel}
+        {t(nextLabel)}
       </Button>
     </Box>
   );

--- a/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizard.tsx
+++ b/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizard.tsx
@@ -11,6 +11,7 @@ import Step3 from './components/Step3';
 type Step1Data = {
   debtPositionType: {
     value: string;
+    flagMandatoryDueDate: boolean;
     readonly: boolean;
   };
   description: {
@@ -79,6 +80,7 @@ type Step3Data = {
     value: boolean;
     readonly: boolean;
   };
+  flagMandatoryDueDate: boolean;
 };
 
 type FormData = {
@@ -138,6 +140,7 @@ const DebtPositionCreateWizard = () => {
     step1: {
       debtPositionType: {
         value: '',
+        flagMandatoryDueDate: false,
         readonly: false
       },
       description: {
@@ -203,7 +206,8 @@ const DebtPositionCreateWizard = () => {
       isMultibeneficiary: {
         value: false,
         readonly: false
-      }
+      },
+      flagMandatoryDueDate: false
     }
   });
 
@@ -255,9 +259,15 @@ const DebtPositionCreateWizard = () => {
       return (
         <Component
           key={`step-${key}`}
-          data={formData.step3}
+          data={{
+            ...formData.step3,
+            flagMandatoryDueDate:
+              formData.step1.debtPositionType.flagMandatoryDueDate
+          }}
           setData={(data) => setFormData((prev) => ({ ...prev, step3: data }))}
-          onNext={() => setStep(index + 1)}
+          onNext={() => {
+            setStep(index + 1);
+          }}
           onBack={() => setStep(index - 1)}
         />
       );

--- a/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizard.tsx
+++ b/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizard.tsx
@@ -59,7 +59,19 @@ type Step2Data = {
 };
 
 type Step3Data = {
-  field1: {
+  paymentObject: {
+    value: string;
+    readonly: boolean;
+  };
+  paymentOption: {
+    value: string;
+    readonly: boolean;
+  };
+  amount: {
+    value: string;
+    readonly: boolean;
+  };
+  dueDate: {
     value: string;
     readonly: boolean;
   };
@@ -168,7 +180,19 @@ const DebtPositionCreateWizard = () => {
       // }
     },
     step3: {
-      field1: {
+      paymentObject: {
+        value: '',
+        readonly: false
+      },
+      paymentOption: {
+        value: '',
+        readonly: false
+      },
+      amount: {
+        value: '',
+        readonly: false
+      },
+      dueDate: {
         value: '',
         readonly: false
       }
@@ -194,8 +218,8 @@ const DebtPositionCreateWizard = () => {
     {
       key: 'step3',
       Component: Step3 as React.ComponentType<Step3ComponentProps>,
-      title: t('debtPositionCreateWizard.step3.title'),
-      subtitle: t('debtPositionCreateWizard.step3.subtitle')
+      title: t('debtPositionCreateWizard.configurationAlert.title'),
+      subtitle: t('debtPositionCreateWizard.configurationAlert.subtitle')
     }
   ];
 

--- a/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizard.tsx
+++ b/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizard.tsx
@@ -72,7 +72,11 @@ type Step3Data = {
     readonly: boolean;
   };
   dueDate: {
-    value: string;
+    value: string | null;
+    readonly: boolean;
+  };
+  isMultibeneficiary: {
+    value: boolean;
     readonly: boolean;
   };
 };
@@ -194,6 +198,10 @@ const DebtPositionCreateWizard = () => {
       },
       dueDate: {
         value: '',
+        readonly: false
+      },
+      isMultibeneficiary: {
+        value: false,
         readonly: false
       }
     }

--- a/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizardCompleted.test.tsx
+++ b/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizardCompleted.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, useLocation, useNavigate } from 'react-router';
+import DebtPositionCreateWizardCompleted from './DebtPositionCreateWizardCompleted';
+import config from '../../utils/config';
+
+// Mock dei moduli
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return {
+    ...actual,
+    useLocation: vi.fn(),
+    useNavigate: vi.fn()
+  };
+});
+
+// Mock di react-i18next
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, string>) => {
+      // Implementazione semplice per le traduzioni utilizzate nei test
+      if (key === 'debtPositionCreateWizardCompleted.title') {
+        return `La posizione debitoria '${options?.paymentObject || ''}' è stata creata!`;
+      }
+      if (key === 'debtPositionCreateWizardCompleted.description') {
+        return "La trovi nella sezione Dovuti, dove puoi tenere traccia dell'andamento.";
+      }
+      if (key === 'debtPositionCreateWizardCompleted.backToStart') {
+        return "Torna all'inizio";
+      }
+      return key;
+    }
+  })
+}));
+
+describe('DebtPositionCreateWizardCompleted', () => {
+  const mockNavigate = vi.fn();
+  const originalDeployPath = config.deployPath;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useNavigate as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      mockNavigate
+    );
+
+    // Imposta la variabile d'ambiente per i test
+    vi.stubEnv('VITE_DEPLOY_PATH', '/test-path');
+
+    // Aggiorna direttamente il valore di config.deployPath
+    config.deployPath = '/test-path';
+  });
+
+  afterEach(() => {
+    // Ripristina le variabili d'ambiente originali dopo ogni test
+    vi.unstubAllEnvs();
+
+    // Ripristina il valore originale di config.deployPath
+    config.deployPath = originalDeployPath;
+  });
+
+  it('renderizza correttamente il componente con il titolo e la descrizione', () => {
+    // Configura il mock di useLocation per fornire un paymentObject
+    (useLocation as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      state: { paymentObject: 'Test Payment' }
+    });
+
+    render(
+      <MemoryRouter>
+        <DebtPositionCreateWizardCompleted />
+      </MemoryRouter>
+    );
+
+    // Verifica che il titolo contenga il paymentObject
+    expect(
+      screen.getByText(/La posizione debitoria 'Test Payment' è stata creata!/i)
+    ).toBeInTheDocument();
+
+    // Verifica che la descrizione sia presente
+    expect(
+      screen.getByText(
+        /La trovi nella sezione Dovuti, dove puoi tenere traccia dell'andamento./i
+      )
+    ).toBeInTheDocument();
+
+    // Verifica che il pulsante "Torna all'inizio" sia presente
+    expect(
+      screen.getByRole('button', { name: /Torna all'inizio/i })
+    ).toBeInTheDocument();
+  });
+
+  it('gestisce correttamente il caso in cui paymentObject non è fornito', () => {
+    // Configura il mock di useLocation senza paymentObject
+    (useLocation as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      state: {}
+    });
+
+    render(
+      <MemoryRouter>
+        <DebtPositionCreateWizardCompleted />
+      </MemoryRouter>
+    );
+
+    // Verifica che il titolo contenga un valore vuoto per paymentObject
+    expect(
+      screen.getByText(/La posizione debitoria '' è stata creata!/i)
+    ).toBeInTheDocument();
+  });
+
+  it('naviga correttamente quando si clicca sul pulsante "Torna all\'inizio"', () => {
+    // Configura il mock di useLocation
+    (useLocation as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      state: { paymentObject: 'Test Payment' }
+    });
+
+    render(
+      <MemoryRouter>
+        <DebtPositionCreateWizardCompleted />
+      </MemoryRouter>
+    );
+
+    // Trova e clicca sul pulsante
+    const backButton = screen.getByRole('button', {
+      name: /Torna all'inizio/i
+    });
+    fireEvent.click(backButton);
+
+    // Verifica che navigate sia stato chiamato con il percorso corretto
+    expect(mockNavigate).toHaveBeenCalledWith('/test-path/debt-positions/');
+  });
+});

--- a/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizardCompleted.tsx
+++ b/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizardCompleted.tsx
@@ -1,0 +1,85 @@
+import { Box, Typography, Button } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { useLocation, useNavigate } from 'react-router';
+import config from '../../utils/config';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import { theme } from '@pagopa/mui-italia';
+
+function DebtPositionCreateWizardCompleted() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const deployPath = config.deployPath;
+
+  // Recupera il titolo dinamico (tipo soggetto) passato come stato
+  const paymentObject = location.state?.paymentObject || '';
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '80vh',
+        textAlign: 'center',
+        padding: 3,
+        margin: '0 auto'
+      }}
+    >
+      <Box
+        sx={{
+          padding: 4,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 3,
+          width: '100%'
+        }}
+      >
+        <CheckCircleOutlineIcon
+          sx={{
+            fontSize: 64,
+            color: theme.palette.success.main,
+            borderRadius: '50%'
+          }}
+        />
+
+        <Typography
+          variant="h4"
+          component="h1"
+          fontSize={24}
+          sx={{
+            fontWeight: 700,
+            textAlign: 'center',
+            maxWidth: (theme) => theme.spacing(50)
+          }}
+        >
+          {t('debtPositionCreateWizardCompleted.title', {
+            paymentObject
+          })}
+        </Typography>
+
+        <Typography
+          fontSize={16}
+          sx={{
+            textAlign: 'center',
+            fontWeight: 400
+          }}
+        >
+          {t('debtPositionCreateWizardCompleted.description')}
+        </Typography>
+
+        <Button
+          role="button"
+          variant="contained"
+          onClick={() => navigate(`${deployPath}/debt-positions/`)}
+        >
+          {t('debtPositionCreateWizardCompleted.backToStart')}
+        </Button>
+      </Box>
+    </Box>
+  );
+}
+
+export default DebtPositionCreateWizardCompleted;

--- a/src/routes/DebtPositionCreateWizard/components/Step1GeneralConfiguration.test.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step1GeneralConfiguration.test.tsx
@@ -65,7 +65,8 @@ describe('Step1GeneralConfiguration', () => {
     data: {
       debtPositionType: {
         value: '',
-        readonly: false
+        readonly: false,
+        flagMandatoryDueDate: false
       },
       description: {
         value: '',
@@ -161,7 +162,8 @@ describe('Step1GeneralConfiguration', () => {
       data: {
         debtPositionType: {
           value: '1',
-          readonly: false
+          readonly: false,
+          flagMandatoryDueDate: false
         },
         description: {
           value: 'Test description',
@@ -189,7 +191,8 @@ describe('Step1GeneralConfiguration', () => {
       data: {
         debtPositionType: {
           value: '1',
-          readonly: true
+          readonly: true,
+          flagMandatoryDueDate: false
         },
         description: {
           value: 'Test description',
@@ -251,7 +254,8 @@ describe('Step1GeneralConfiguration', () => {
       data: {
         debtPositionType: {
           value: '',
-          readonly: true
+          readonly: true,
+          flagMandatoryDueDate: false
         },
         description: {
           value: '',
@@ -275,7 +279,8 @@ describe('Step1GeneralConfiguration', () => {
         mockSetData({
           debtPositionType: {
             value: '1',
-            readonly: false
+            readonly: false,
+            flagMandatoryDueDate: false
           },
           description: {
             value: 'Test descrizione',
@@ -308,7 +313,8 @@ describe('Step1GeneralConfiguration', () => {
     expect(mockSetData).toHaveBeenCalledWith({
       debtPositionType: {
         value: '1',
-        readonly: false
+        readonly: false,
+        flagMandatoryDueDate: false
       },
       description: {
         value: 'Test descrizione',
@@ -482,7 +488,8 @@ describe('Step1GeneralConfiguration', () => {
     expect(mockSetData).toHaveBeenCalledWith({
       debtPositionType: {
         value: '1',
-        readonly: false
+        readonly: false,
+        flagMandatoryDueDate: false
       },
       description: {
         value: 'Test descrizione con tre parole',

--- a/src/routes/DebtPositionCreateWizard/components/Step1GeneralConfiguration.test.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step1GeneralConfiguration.test.tsx
@@ -41,7 +41,12 @@ vi.mock('react-hook-form', () => ({
 
 // Mock di react-i18next
 vi.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key: string) => key })
+  useTranslation: () => ({
+    t: (key: string) => {
+      if (key === 'commons.continue') return 'Continua';
+      return key;
+    }
+  })
 }));
 
 // Tipi per i mocks

--- a/src/routes/DebtPositionCreateWizard/components/Step1GeneralConfiguration.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step1GeneralConfiguration.tsx
@@ -4,7 +4,9 @@ import { useTranslation } from 'react-i18next';
 import { Box, MenuItem, TextField } from '@mui/material';
 import { useDebtPositionsTypeOrg } from '../../../hooks/useDebtPositionsTypeOrg';
 import SectionBox from '../../../components/Wizard/SectionBox';
+import PaperContent from '../../../components/Wizard/PaperContent';
 import WizardStepButtons from '../../../components/Wizard/WizardStepButtons';
+import BookIcon from '@mui/icons-material/MenuBook';
 
 // Tipizzazione per lo stato dello step 1
 type Step1Data = {
@@ -73,76 +75,84 @@ const Step1GeneralConfiguration = ({
 
   return (
     <Box>
-      <SectionBox title={t('debtPositionCreateWizard.step1.title')}>
+      <SectionBox hideHeader>
         <form onSubmit={handleSubmit(onSubmit)}>
-          {/* Select - Tipo di dovuto */}
-          <Controller
-            name="debtPositionType"
-            control={control}
-            rules={{
-              required: t(
-                'debtPositionCreateWizard.step1.debtPositionType.required'
-              )
-            }}
-            render={({ field }) => (
-              <TextField
-                {...field}
-                label={t(
-                  'debtPositionCreateWizard.step1.debtPositionType.label'
-                )}
-                select
-                required
-                fullWidth
-                margin="normal"
-                disabled={data.debtPositionType.readonly}
-                error={!!errors.debtPositionType}
-                helperText={errors.debtPositionType?.message}
-              >
-                {debtPositionsTypes.map((option) => (
-                  <MenuItem key={option.value} value={option.value.toString()}>
-                    {option.label}
-                  </MenuItem>
-                ))}
-              </TextField>
-            )}
-          />
-          {/* Input - Descrizione posizione debitoria */}
-          <Controller
-            name="description"
-            control={control}
-            rules={{
-              required: t(
-                'debtPositionCreateWizard.step1.description.required'
-              ),
-              validate: (value) => {
-                const trimmed = value.trim();
-                // if (trimmed === '') return true;
-                const wordCount = trimmed.split(/\s+/).length;
-                return (
-                  wordCount >= 3 || t('debtPositionCreateWizard.step1.minWords')
-                );
-              }
-            }}
-            render={({ field }) => (
-              <TextField
-                {...field}
-                label={t('debtPositionCreateWizard.step1.description.label')}
-                fullWidth
-                margin="normal"
-                required
-                disabled={data.description.readonly}
-                error={!!errors.description}
-                helperText={errors.description?.message}
-              />
-            )}
-          />
-
-          <WizardStepButtons
-            onBack={onBack}
-            disableBack={true}
-            disableNext={false}
-            onNext={handleSubmit(onSubmit)}
-          />
+          <PaperContent
+            title={t('debtPositionCreateWizard.step1.title')}
+            icon={<BookIcon color="action" sx={{ mr: 1 }} />}
+          >
+            {/* Select - Tipo di dovuto */}
+            <Controller
+              name="debtPositionType"
+              control={control}
+              rules={{
+                required: t(
+                  'debtPositionCreateWizard.step1.debtPositionType.required'
+                )
+              }}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  label={t(
+                    'debtPositionCreateWizard.step1.debtPositionType.label'
+                  )}
+                  select
+                  required
+                  fullWidth
+                  margin="normal"
+                  disabled={data.debtPositionType.readonly}
+                  error={!!errors.debtPositionType}
+                  helperText={errors.debtPositionType?.message}
+                >
+                  {debtPositionsTypes.map((option) => (
+                    <MenuItem
+                      key={option.value}
+                      value={option.value.toString()}
+                    >
+                      {option.label}
+                    </MenuItem>
+                  ))}
+                </TextField>
+              )}
+            />
+            {/* Input - Descrizione posizione debitoria */}
+            <Controller
+              name="description"
+              control={control}
+              rules={{
+                required: t(
+                  'debtPositionCreateWizard.step1.description.required'
+                ),
+                validate: (value) => {
+                  const trimmed = value.trim();
+                  // if (trimmed === '') return true;
+                  const wordCount = trimmed.split(/\s+/).length;
+                  return (
+                    wordCount >= 3 ||
+                    t('debtPositionCreateWizard.step1.minWords')
+                  );
+                }
+              }}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  label={t('debtPositionCreateWizard.step1.description.label')}
+                  fullWidth
+                  margin="normal"
+                  required
+                  disabled={data.description.readonly}
+                  error={!!errors.description}
+                  helperText={errors.description?.message}
+                />
+              )}
+            />
+            <WizardStepButtons
+              onBack={onBack}
+              disableBack={true}
+              disableNext={false}
+              onNext={handleSubmit(onSubmit)}
+            />
+          </PaperContent>
         </form>
       </SectionBox>
     </Box>

--- a/src/routes/DebtPositionCreateWizard/components/Step1GeneralConfiguration.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step1GeneralConfiguration.tsx
@@ -12,6 +12,7 @@ import BookIcon from '@mui/icons-material/MenuBook';
 type Step1Data = {
   debtPositionType: {
     value: string;
+    flagMandatoryDueDate: boolean;
     readonly: boolean;
   };
   description: {
@@ -63,6 +64,7 @@ const Step1GeneralConfiguration = ({
     setData({
       debtPositionType: {
         value: values.debtPositionType,
+        flagMandatoryDueDate: data.debtPositionType.flagMandatoryDueDate,
         readonly: data.debtPositionType.readonly
       },
       description: {

--- a/src/routes/DebtPositionCreateWizard/components/Step2AddDebtor.test.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step2AddDebtor.test.tsx
@@ -29,7 +29,16 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('../../../utils/fieldValidation', () => ({
-  validateTaxCode: vi.fn()
+  validateTaxCode: vi.fn(),
+  createValidators: vi.fn().mockReturnValue({
+    getValidationRules: vi.fn().mockReturnValue({
+      taxCode: { validate: vi.fn() },
+      fullName: { validate: vi.fn() },
+      subjectType: {
+        required: 'debtPositionCreateWizard.step2.subjectType.required'
+      }
+    })
+  })
 }));
 
 // Mock dei componenti Material-UI

--- a/src/routes/DebtPositionCreateWizard/components/Step2AddDebtor.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step2AddDebtor.tsx
@@ -6,12 +6,9 @@ import PersonIcon from '@mui/icons-material/Person';
 import WizardStepButtons from '../../../components/Wizard/WizardStepButtons';
 import SectionBox from '../../../components/Wizard/SectionBox';
 import PaperContent from '../../../components/Wizard/PaperContent';
-import { validateTaxCode } from '../../../utils/fieldValidation';
-import { ValidationErrorCode } from '../../../store/types';
+import { createValidators } from '../../../utils/fieldValidation';
 
-/**
- * Tipo che definisce la struttura dati dello Step 2 del wizard.
- */
+// Tipo che definisce la struttura dati dello Step 2 del wizard.
 type Step2Data = {
   subjectType: { value: string; readonly: boolean }; // Tipo soggetto (fisica/giuridica)
   taxCode: { value: string; readonly: boolean }; // Codice fiscale o partita IVA
@@ -26,10 +23,8 @@ type Step2Data = {
 
 type Step2DataField = keyof Step2Data;
 
-/**
- * Tipo che rappresenta il percorso completo al valore di un campo.
- * Esempio: 'subjectType.value', 'taxCode.value'
- */
+//Tipo che rappresenta il percorso completo al valore di un campo.
+//Esempio: 'subjectType.value', 'taxCode.value'
 type NestedFieldName = `${Step2DataField}.value`;
 
 type Props = {
@@ -40,6 +35,7 @@ type Props = {
 };
 
 const Step2AddDebtor = ({ data, setData, onNext, onBack }: Props) => {
+  const { t } = useTranslation();
   const {
     handleSubmit, // Funzione per gestire la sottomissione del form
     watch, // Funzione per osservare i valori dei campi
@@ -53,19 +49,23 @@ const Step2AddDebtor = ({ data, setData, onNext, onBack }: Props) => {
     mode: 'onChange' // Modalità di validazione: alla modifica del campo
   });
 
-  const { t } = useTranslation();
-
   // Osservazione di campi specifici per reagire ai loro cambiamenti
   const subjectTypeValue = watch('subjectType.value') || '';
   // const countryValue = watch('country.value') || '';
   // const provinceValue = watch('province.value') || '';
 
-  // Effetto che rivalida il codice fiscale/partita IVA quando cambia il tipo di soggetto
+  // Effetto che rivalida il codice fiscale/partita IVA e fullName e ragione socialequando cambia il tipo di soggetto
   useEffect(() => {
     if (isSubmitted) {
       trigger('taxCode.value');
+      trigger('fullName.value');
     }
   }, [subjectTypeValue, trigger, isSubmitted]);
+
+  // Creazione delle utility di validazione e label
+  const { getValidationRules } = createValidators(t, subjectTypeValue);
+  // Ottiene le regole di validazione per tutti i campi
+  const validationRules = getValidationRules();
 
   // Funzione per validare il CAP.
   // Per l'Italia deve essere un numero di 5 cifre.
@@ -157,6 +157,17 @@ const Step2AddDebtor = ({ data, setData, onNext, onBack }: Props) => {
     }
   };
 
+  const getCompanyNameLabel = () => {
+    switch (subjectTypeValue) {
+      case 'fisica':
+        return t('debtPositionCreateWizard.step2.fullName.label');
+      case 'giuridica':
+        return t('debtPositionCreateWizard.step2.companyName.label');
+      default:
+        return t('debtPositionCreateWizard.step2.fullName.label');
+    }
+  };
+
   return (
     <Box>
       <SectionBox hideHeader>
@@ -173,11 +184,7 @@ const Step2AddDebtor = ({ data, setData, onNext, onBack }: Props) => {
             <Controller
               name="subjectType.value"
               control={control}
-              rules={{
-                required: t(
-                  'debtPositionCreateWizard.step2.subjectType.required'
-                )
-              }}
+              rules={validationRules.subjectType}
               render={({ field }) => (
                 <TextField
                   {...field}
@@ -216,43 +223,7 @@ const Step2AddDebtor = ({ data, setData, onNext, onBack }: Props) => {
             <Controller
               name="taxCode.value"
               control={control}
-              rules={{
-                validate: (value) => {
-                  // Se il campo è vuoto, restituisce il messaggio appropriato in base al tipo di soggetto
-                  if (!value) {
-                    // Se non è stato selezionato il tipo di soggetto, mostra il messaggio generico
-                    if (!subjectTypeValue) {
-                      return t(
-                        'debtPositionCreateWizard.step2.taxCodeOrVat.required'
-                      );
-                    }
-                    // Altrimenti mostrare il messaggio specifico in base al tipo di soggetto
-                    return subjectTypeValue !== 'giuridica'
-                      ? t('debtPositionCreateWizard.step2.taxCode.required')
-                      : t('debtPositionCreateWizard.step2.vat.required');
-                  }
-                  // Altrimenti, valida il formato
-                  const result = validateTaxCode(value, subjectTypeValue);
-
-                  if (result == 'commons.required') {
-                    // Se non è stato selezionato il tipo di soggetto, mostra il messaggio generico
-                    if (!subjectTypeValue) {
-                      return t(
-                        'debtPositionCreateWizard.step2.taxCodeOrVat.required'
-                      );
-                    }
-                    // Altrimenti mostra il messaggio specifico in base al tipo di soggetto
-                    return subjectTypeValue !== 'giuridica'
-                      ? t('debtPositionCreateWizard.step2.taxCode.required')
-                      : t('debtPositionCreateWizard.step2.vat.required');
-                  }
-
-                  // Restituisce il risultato della validazione
-                  return result === ValidationErrorCode.VALID
-                    ? true
-                    : t(result);
-                }
-              }}
+              rules={validationRules.taxCode}
               render={({ field }) => (
                 <TextField
                   {...field}
@@ -285,22 +256,11 @@ const Step2AddDebtor = ({ data, setData, onNext, onBack }: Props) => {
             <Controller
               name="fullName.value"
               control={control}
-              rules={{
-                required: t('debtPositionCreateWizard.step2.fullName.required'),
-                validate: (value) => {
-                  const trimmed = value.trim();
-                  if (trimmed.split(' ').length < 2) {
-                    return t(
-                      'debtPositionCreateWizard.step2.fullName.minTwoWords'
-                    );
-                  }
-                  return true;
-                }
-              }}
+              rules={validationRules.fullName}
               render={({ field }) => (
                 <TextField
                   {...field}
-                  label={t('debtPositionCreateWizard.step2.fullName.label')}
+                  label={getCompanyNameLabel()}
                   fullWidth
                   margin="normal"
                   required

--- a/src/routes/DebtPositionCreateWizard/components/Step2AddDebtor.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step2AddDebtor.tsx
@@ -1,10 +1,11 @@
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useForm, Controller } from 'react-hook-form';
-import { Box, MenuItem, TextField, Typography, Paper } from '@mui/material';
+import { Box, MenuItem, TextField, Typography } from '@mui/material';
 import PersonIcon from '@mui/icons-material/Person';
 import WizardStepButtons from '../../../components/Wizard/WizardStepButtons';
 import SectionBox from '../../../components/Wizard/SectionBox';
+import PaperContent from '../../../components/Wizard/PaperContent';
 import { validateTaxCode } from '../../../utils/fieldValidation';
 import { ValidationErrorCode } from '../../../store/types';
 
@@ -160,14 +161,10 @@ const Step2AddDebtor = ({ data, setData, onNext, onBack }: Props) => {
     <Box>
       <SectionBox hideHeader>
         <form onSubmit={handleSubmit(onSubmit)} noValidate>
-          <Paper variant="outlined" sx={{ p: 3, mt: 2 }}>
-            <Box display="flex" alignItems="center" mb={2}>
-              <PersonIcon sx={{ mr: 1 }} />
-              <Typography variant="h6">
-                {t('debtPositionCreateWizard.step2.title')}
-              </Typography>
-            </Box>
-
+          <PaperContent
+            title={t('debtPositionCreateWizard.step2.title')}
+            icon={<PersonIcon sx={{ mr: 1 }} />}
+          >
             <Typography variant="subtitle1" gutterBottom>
               {t('debtPositionCreateWizard.step2.fiscalData')}
             </Typography>
@@ -465,7 +462,7 @@ const Step2AddDebtor = ({ data, setData, onNext, onBack }: Props) => {
                 />
               </Grid>
             </Grid> */}
-          </Paper>
+          </PaperContent>
 
           {/* Pulsanti per navigare nel wizard */}
           <WizardStepButtons

--- a/src/routes/DebtPositionCreateWizard/components/Step3.test.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step3.test.tsx
@@ -1,0 +1,707 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Step3 from './Step3';
+import { useForm } from 'react-hook-form';
+import { formatDate } from '../../../utils/formatters';
+
+// Mock dei moduli
+vi.mock('react-hook-form', () => ({
+  useForm: vi.fn(),
+  Controller: vi.fn(({ render, name }) => {
+    // Cattura anche il nome per migliorare la copertura
+    return render({
+      field: {
+        onChange: vi.fn((e) => e?.target?.value || e),
+        onBlur: vi.fn(),
+        value: '',
+        name,
+        ref: vi.fn()
+      },
+      fieldState: {
+        error: null
+      }
+    });
+  })
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}));
+
+vi.mock('../../../utils/formatters', () => ({
+  formatDate: vi.fn((date) => date)
+}));
+
+// Mock dei componenti Material-UI
+vi.mock('@mui/material', () => ({
+  Box: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Grid: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  MenuItem: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  TextField: ({
+    label,
+    error,
+    helperText,
+    children,
+    onChange,
+    name,
+    type
+  }: {
+    label: string;
+    error?: boolean;
+    helperText?: string;
+    children?: React.ReactNode;
+    onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    name?: string;
+    type?: string;
+  }) => (
+    <div data-testid={`textfield-${name || label}`}>
+      <label>{label}</label>
+      {error && <span className="error">{helperText}</span>}
+      {onChange && (
+        <input
+          data-testid={`input-${name || label}`}
+          onChange={onChange}
+          type={type}
+        />
+      )}
+      {children}
+    </div>
+  ),
+  FormControlLabel: ({
+    control,
+    label
+  }: {
+    control: React.ReactNode;
+    label: string;
+  }) => (
+    <div>
+      <label>{label}</label>
+      {control}
+    </div>
+  ),
+  Switch: ({
+    checked,
+    onChange,
+    disabled
+  }: {
+    checked: boolean;
+    onChange: (e: { target: { checked: boolean } }) => void;
+    disabled?: boolean;
+  }) => (
+    <input
+      type="checkbox"
+      checked={checked}
+      onChange={(e) => {
+        // Simuliamo il comportamento del componente Switch
+        onChange({ target: { checked: e.target.checked } });
+      }}
+      disabled={disabled}
+      data-testid="switch-input"
+    />
+  ),
+  InputAdornment: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  )
+}));
+
+vi.mock('@mui/x-date-pickers/DatePicker', () => ({
+  DatePicker: ({
+    value,
+    onChange,
+    label,
+    disabled,
+    slotProps
+  }: {
+    value: Date | null;
+    onChange: (date: Date | null) => void;
+    label: string;
+    disabled?: boolean;
+    slotProps?: {
+      textField: {
+        fullWidth: boolean;
+        required: boolean;
+        error?: boolean;
+        helperText?: string;
+      };
+    };
+  }) => (
+    <div>
+      <label>{label}</label>
+      <input
+        type="date"
+        value={value ? value.toISOString().split('T')[0] : ''}
+        onChange={(e) => {
+          const date = e.target.value ? new Date(e.target.value) : null;
+          onChange(date);
+        }}
+        disabled={disabled}
+        data-testid="datepicker-input"
+      />
+      {slotProps?.textField.error && (
+        <span className="error">{slotProps.textField.helperText}</span>
+      )}
+    </div>
+  )
+}));
+
+vi.mock('../../../components/Wizard/WizardStepButtons', () => ({
+  default: ({
+    onBack,
+    onNext,
+    disableNext,
+    nextLabel
+  }: {
+    onBack: () => void;
+    onNext: () => void;
+    disableNext?: boolean;
+    nextLabel?: string;
+  }) => (
+    <div>
+      <button onClick={onBack}>commons.back</button>
+      <button onClick={onNext} disabled={disableNext}>
+        {nextLabel || 'Continua'}
+      </button>
+    </div>
+  )
+}));
+
+vi.mock('../../../components/Wizard/SectionBox', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  )
+}));
+
+vi.mock('../../../components/Wizard/PaperContent', () => ({
+  default: ({
+    title,
+    icon,
+    children
+  }: {
+    title: string;
+    icon: React.ReactNode;
+    children: React.ReactNode;
+  }) => (
+    <div>
+      <div>{icon}</div>
+      <h2>{title}</h2>
+      {children}
+    </div>
+  )
+}));
+
+vi.mock('@mui/icons-material/Article', () => ({
+  default: () => <div>ArticleIcon</div>
+}));
+
+// Tipo per i dati del form
+type Step3Data = {
+  paymentObject: { value: string; readonly: boolean };
+  paymentOption: { value: string; readonly: boolean };
+  amount: { value: string; readonly: boolean };
+  dueDate: { value: string | null; readonly: boolean };
+  isMultibeneficiary: { value: boolean; readonly: boolean };
+};
+
+// Tipo per i valori del form
+type FormValue = string | boolean | Date | null;
+
+describe('Step3', () => {
+  // Setup iniziale per i test
+  const mockSetData = vi.fn();
+  const mockOnNext = vi.fn();
+  const mockOnBack = vi.fn();
+
+  const defaultProps = {
+    data: {
+      paymentObject: { value: '', readonly: false },
+      paymentOption: { value: '', readonly: false },
+      amount: { value: '', readonly: false },
+      dueDate: { value: null, readonly: false },
+      isMultibeneficiary: { value: false, readonly: false }
+    },
+    setData: mockSetData,
+    onNext: mockOnNext,
+    onBack: mockOnBack
+  };
+
+  // Mock di base per useForm
+  const mockRegister = vi.fn((name: string, options = {}) => ({
+    name,
+    onChange: vi.fn((e) => e?.target?.value || e),
+    onBlur: vi.fn(),
+    ref: vi.fn(),
+    ...options
+  }));
+
+  const mockHandleSubmit = vi.fn(
+    (onSubmit: (data: Step3Data) => void) =>
+      (e?: { preventDefault?: () => void }) => {
+        e?.preventDefault?.();
+        onSubmit({
+          paymentObject: { value: 'Pagamento bolletta', readonly: false },
+          paymentOption: { value: 'SINGLE', readonly: false },
+          amount: { value: '100.00', readonly: false },
+          dueDate: {
+            value: new Date('2023-12-31').toISOString(),
+            readonly: false
+          },
+          isMultibeneficiary: { value: false, readonly: false }
+        });
+        return false;
+      }
+  );
+
+  const createFormValues = (
+    overrides: Record<string, FormValue> = {}
+  ): Record<string, FormValue> => {
+    const defaultValues: Record<string, FormValue> = {
+      'paymentObject.value': 'Pagamento bolletta',
+      'paymentOption.value': 'SINGLE',
+      'amount.value': '100.00',
+      'dueDate.value': new Date('2023-12-31').toISOString(),
+      'isMultibeneficiary.value': false
+    };
+
+    return { ...defaultValues, ...overrides };
+  };
+
+  const mockWatchFactory = (
+    values: Record<string, string | boolean | Date | null>
+  ) => {
+    return vi.fn((fieldName: string) => values[fieldName] || '');
+  };
+
+  const mockSetValue = vi.fn();
+  const mockTrigger = vi.fn().mockResolvedValue(true);
+  const mockClearErrors = vi.fn();
+  const mockGetValues = vi.fn().mockReturnValue('');
+
+  // Configurazione di base per useForm che può essere sovrascritta nei test
+  const createMockUseForm = (overrides = {}) => {
+    const defaultUseForm = {
+      register: mockRegister,
+      handleSubmit: mockHandleSubmit,
+      watch: mockWatchFactory(createFormValues()),
+      setValue: mockSetValue,
+      trigger: mockTrigger,
+      clearErrors: mockClearErrors,
+      getValues: mockGetValues,
+      control: {},
+      formState: { errors: {}, isSubmitted: false }
+    };
+
+    return { ...defaultUseForm, ...overrides };
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useForm as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      createMockUseForm()
+    );
+    (formatDate as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      '2023-12-31'
+    );
+  });
+
+  // Test base
+  it('renderizza correttamente il componente con tutti i campi richiesti', () => {
+    render(<Step3 {...defaultProps} />);
+    expect(
+      screen.getByText('debtPositionCreateWizard.step3.title')
+    ).toBeInTheDocument();
+  });
+
+  it('inizializza il form con i valori forniti', () => {
+    const testDate = new Date('2023-12-31');
+    const propsWithValues = {
+      ...defaultProps,
+      data: {
+        paymentObject: { value: 'Pagamento bolletta', readonly: false },
+        paymentOption: { value: 'SINGLE', readonly: false },
+        amount: { value: '100.00', readonly: false },
+        dueDate: { value: testDate.toISOString(), readonly: false },
+        isMultibeneficiary: { value: false, readonly: false }
+      }
+    };
+
+    render(<Step3 {...propsWithValues} />);
+    expect(useForm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultValues: {
+          ...propsWithValues.data,
+          dueDate: {
+            ...propsWithValues.data.dueDate,
+            value: testDate
+          }
+        }
+      })
+    );
+  });
+
+  // Test ottimizzato che copre più scenari in un unico test
+  it('copre vari scenari del form incluse validazioni e gestori di eventi', async () => {
+    // 1. Setup per testare handleFieldChange
+    const setValue = vi.fn();
+    const trigger = vi.fn().mockResolvedValue(true);
+    const clearErrors = vi.fn();
+
+    // Mock per simulare diversi stati del form
+    (useForm as unknown as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+      createMockUseForm({
+        setValue,
+        trigger,
+        clearErrors,
+        formState: { errors: {}, isSubmitted: true }
+      })
+    );
+
+    // 2. Renderizza il componente
+    render(<Step3 {...defaultProps} />);
+
+    // 3. Testa handleFieldChange per diversi campi
+    const testFields = [
+      { fieldName: 'paymentObject', value: 'Pagamento bolletta' },
+      { fieldName: 'paymentOption', value: 'SINGLE' },
+      { fieldName: 'amount', value: '100.00' },
+      { fieldName: 'dueDate', value: new Date('2023-12-31') },
+      { fieldName: 'isMultibeneficiary', value: true }
+    ];
+
+    for (const { fieldName, value } of testFields) {
+      setValue(`${fieldName}.value`, value);
+      // Chiamiamo direttamente trigger per simulare il comportamento del componente
+      await trigger(`${fieldName}.value`);
+      if (await trigger(`${fieldName}.value`)) {
+        clearErrors(`${fieldName}.value`);
+      }
+
+      expect(setValue).toHaveBeenCalledWith(`${fieldName}.value`, value);
+    }
+  });
+
+  // Test per i campi in sola lettura
+  it('gestisce correttamente i campi in sola lettura', () => {
+    const testDate = new Date('2023-12-31');
+    const propsWithReadonly = {
+      ...defaultProps,
+      data: {
+        paymentObject: { value: 'Pagamento bolletta', readonly: true },
+        paymentOption: { value: 'SINGLE', readonly: true },
+        amount: { value: '100.00', readonly: true },
+        dueDate: { value: testDate.toISOString(), readonly: true },
+        isMultibeneficiary: { value: false, readonly: true }
+      }
+    };
+
+    (useForm as unknown as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+      createMockUseForm({
+        defaultValues: {
+          ...propsWithReadonly.data,
+          dueDate: {
+            ...propsWithReadonly.data.dueDate,
+            value: testDate
+          }
+        }
+      })
+    );
+
+    render(<Step3 {...propsWithReadonly} />);
+    expect(useForm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultValues: {
+          ...propsWithReadonly.data,
+          dueDate: {
+            ...propsWithReadonly.data.dueDate,
+            value: testDate
+          }
+        }
+      })
+    );
+  });
+
+  // Test che copre il flusso completo del wizard con errori e successo
+  it('copre il flusso completo del wizard con errori e successo', async () => {
+    // Prima parte: testa con errori di validazione
+    const errorsState = {
+      paymentObject: { value: { message: 'Errore oggetto pagamento' } }
+    };
+
+    (useForm as unknown as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+      createMockUseForm({
+        formState: { errors: errorsState, isSubmitted: true }
+      })
+    );
+
+    const { rerender } = render(<Step3 {...defaultProps} />);
+
+    expect(screen.getByText('Errore oggetto pagamento')).toBeInTheDocument();
+
+    // Seconda parte: completa con successo
+    const handleSubmitSuccess = vi.fn((onSubmit) => {
+      return () => {
+        onSubmit({
+          paymentObject: { value: 'Pagamento bolletta', readonly: false },
+          paymentOption: { value: 'SINGLE', readonly: false },
+          amount: { value: '100.00', readonly: false },
+          dueDate: {
+            value: new Date('2023-12-31').toISOString(),
+            readonly: false
+          },
+          isMultibeneficiary: { value: false, readonly: false }
+        });
+        return false;
+      };
+    });
+
+    (useForm as unknown as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+      createMockUseForm({
+        handleSubmit: handleSubmitSuccess,
+        formState: { errors: {}, isSubmitted: false }
+      })
+    );
+
+    rerender(<Step3 {...defaultProps} />);
+
+    // Simula click sul pulsante Crea
+    fireEvent.click(screen.getByText('commons.create'));
+
+    expect(handleSubmitSuccess).toHaveBeenCalled();
+    expect(mockSetData).toHaveBeenCalled();
+    expect(mockOnNext).toHaveBeenCalled();
+
+    // Simula click sul pulsante Indietro
+    fireEvent.click(screen.getByText('commons.back'));
+    expect(mockOnBack).toHaveBeenCalled();
+  });
+
+  // Test specifico per la funzione handleFieldChange
+  it('gestisce correttamente il cambio di un campo del form', async () => {
+    const setValue = vi.fn();
+    const trigger = vi.fn().mockResolvedValue(true);
+    const clearErrors = vi.fn();
+
+    // Creiamo un mock più dettagliato per useForm
+    const mockUseForm = createMockUseForm({
+      setValue,
+      trigger,
+      clearErrors,
+      formState: {
+        isSubmitted: true,
+        errors: {
+          paymentObject: { value: { message: 'Errore oggetto pagamento' } }
+        }
+      }
+    });
+
+    // Assicuriamoci che il mock di useForm restituisca il nostro setValue
+    (useForm as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      mockUseForm
+    );
+
+    // Renderizziamo il componente
+    render(<Step3 {...defaultProps} />);
+
+    // Verifichiamo che setValue sia stato correttamente passato al componente
+    expect(mockUseForm.setValue).toBe(setValue);
+
+    // Troviamo l'input dell'oggetto pagamento
+    const paymentObjectInput = screen.getByTestId('input-paymentObject.value');
+
+    // Verifichiamo che l'input sia stato trovato
+    expect(paymentObjectInput).toBeInTheDocument();
+
+    // Simuliamo il cambio dell'oggetto pagamento
+    fireEvent.change(paymentObjectInput, {
+      target: { value: 'Pagamento bolletta' }
+    });
+
+    // Attendiamo che tutte le promesse vengano risolte
+    await vi.waitFor(() => {
+      // Verifichiamo che setValue sia stato chiamato
+      expect(setValue).toHaveBeenCalled();
+
+      // Verifichiamo i parametri passati a setValue
+      expect(setValue.mock.calls[0][0]).toBe('paymentObject.value');
+      expect(setValue.mock.calls[0][1]).toBe('Pagamento bolletta');
+
+      // Verifichiamo che trigger sia stato chiamato
+      expect(trigger).toHaveBeenCalledWith('paymentObject.value');
+
+      // Verifichiamo che clearErrors sia stato chiamato
+      expect(clearErrors).toHaveBeenCalledWith('paymentObject.value');
+    });
+  });
+
+  // Test specifico per la funzione onSubmit
+  it('gestisce correttamente la submission del form', () => {
+    const handleSubmit = vi.fn((onSubmit) => {
+      return () => {
+        onSubmit({
+          paymentObject: { value: 'Pagamento bolletta', readonly: false },
+          paymentOption: { value: 'SINGLE', readonly: false },
+          amount: { value: '100.00', readonly: false },
+          dueDate: {
+            value: new Date('2023-12-31').toISOString(),
+            readonly: false
+          },
+          isMultibeneficiary: { value: false, readonly: false }
+        });
+        return false;
+      };
+    });
+
+    (useForm as unknown as ReturnType<typeof vi.fn>).mockReturnValueOnce(
+      createMockUseForm({
+        handleSubmit
+      })
+    );
+
+    render(<Step3 {...defaultProps} />);
+
+    // Simula click sul pulsante Crea
+    fireEvent.click(screen.getByText('commons.create'));
+
+    // Verifica che handleSubmit sia stato chiamato
+    expect(handleSubmit).toHaveBeenCalled();
+
+    // Verifica che setData sia stato chiamato con i dati corretti
+    expect(mockSetData).toHaveBeenCalledWith({
+      paymentObject: { value: 'Pagamento bolletta', readonly: false },
+      paymentOption: { value: 'SINGLE', readonly: false },
+      amount: { value: '100.00', readonly: false },
+      dueDate: { value: '2023-12-31T00:00:00.000Z', readonly: false },
+      isMultibeneficiary: { value: false, readonly: false }
+    });
+
+    // Verifica che onNext sia stato chiamato
+    expect(mockOnNext).toHaveBeenCalled();
+  });
+
+  // Test per la validazione dell'importo
+  it("valida correttamente l'importo", async () => {
+    const setValue = vi.fn();
+    const trigger = vi.fn().mockResolvedValue(true);
+    const clearErrors = vi.fn();
+
+    // Creiamo un mock per useForm con errori di validazione per l'importo
+    const mockUseForm = createMockUseForm({
+      setValue,
+      trigger,
+      clearErrors,
+      formState: {
+        isSubmitted: true,
+        errors: {
+          amount: {
+            value: { message: 'debtPositionCreateWizard.step3.amount.positive' }
+          }
+        }
+      }
+    });
+
+    (useForm as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      mockUseForm
+    );
+
+    render(<Step3 {...defaultProps} />);
+
+    // Troviamo l'input dell'importo
+    const amountInput = screen.getByTestId('input-amount.value');
+
+    // Verifichiamo che l'input sia stato trovato
+    expect(amountInput).toBeInTheDocument();
+
+    // Verifichiamo che l'errore sia visualizzato
+    expect(
+      screen.getByText('debtPositionCreateWizard.step3.amount.positive')
+    ).toBeInTheDocument();
+
+    // Simuliamo il cambio dell'importo con un valore valido
+    fireEvent.change(amountInput, { target: { value: '100.00' } });
+
+    // Attendiamo che tutte le promesse vengano risolte
+    await vi.waitFor(() => {
+      // Verifichiamo che setValue sia stato chiamato con il nuovo valore
+      expect(setValue).toHaveBeenCalledWith('amount.value', '100.00');
+
+      // Verifichiamo che trigger sia stato chiamato
+      expect(trigger).toHaveBeenCalledWith('amount.value');
+
+      // Verifichiamo che clearErrors sia stato chiamato
+      expect(clearErrors).toHaveBeenCalledWith('amount.value');
+    });
+  });
+
+  // Test per il DatePicker
+  it('gestisce correttamente il DatePicker', () => {
+    const setValue = vi.fn();
+    const testDate = new Date('2023-12-31');
+
+    // Creiamo un mock per useForm
+    const mockUseForm = createMockUseForm({
+      setValue,
+      formState: {
+        isSubmitted: false,
+        errors: {}
+      }
+    });
+
+    (useForm as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      mockUseForm
+    );
+
+    render(<Step3 {...defaultProps} />);
+
+    // Troviamo l'input del DatePicker
+    const datePickerInput = screen.getByTestId('datepicker-input');
+
+    // Verifichiamo che l'input sia stato trovato
+    expect(datePickerInput).toBeInTheDocument();
+
+    // Simuliamo il cambio della data
+    fireEvent.change(datePickerInput, { target: { value: '2023-12-31' } });
+
+    // Verifichiamo che setValue sia stato chiamato con la nuova data
+    expect(setValue).toHaveBeenCalledWith('dueDate.value', testDate);
+  });
+
+  // Test per lo switch isMultibeneficiary
+  it('gestisce correttamente lo switch isMultibeneficiary', async () => {
+    const setValue = vi.fn();
+    const trigger = vi.fn().mockResolvedValue(true);
+    const clearErrors = vi.fn();
+
+    // Creiamo un mock per useForm
+    const mockUseForm = createMockUseForm({
+      setValue,
+      trigger,
+      clearErrors,
+      formState: {
+        isSubmitted: false,
+        errors: {}
+      }
+    });
+
+    (useForm as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      mockUseForm
+    );
+
+    render(<Step3 {...defaultProps} />);
+
+    // Troviamo l'input dello switch
+    const switchInput = screen.getByTestId('switch-input');
+
+    // Verifichiamo che l'input sia stato trovato
+    expect(switchInput).toBeInTheDocument();
+
+    // Simuliamo il click sullo switch invece del change
+    fireEvent.click(switchInput);
+
+    // Attendiamo che tutte le promesse vengano risolte
+    await vi.waitFor(() => {
+      // Verifichiamo che setValue sia stato chiamato con il nuovo valore
+      expect(setValue).toHaveBeenCalledWith('isMultibeneficiary.value', true);
+    });
+  });
+});

--- a/src/routes/DebtPositionCreateWizard/components/Step3.test.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step3.test.tsx
@@ -1,8 +1,25 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import Step3 from './Step3';
-import { useForm } from 'react-hook-form';
+import { useForm, Controller } from 'react-hook-form';
 import { formatDate } from '../../../utils/formatters';
+import { MemoryRouter, useNavigate } from 'react-router';
+
+// Definizione dei tipi
+type FormField<T> = {
+  value: T;
+  readonly: boolean;
+};
+
+type FormValues = {
+  paymentObject: FormField<string>;
+  paymentOption: FormField<string>;
+  amount: FormField<string>;
+  dueDate: FormField<Date | null>;
+  isMultibeneficiary: FormField<boolean>;
+};
+
+type FormFieldValue = string | boolean | Date | null;
 
 // Mock dei moduli
 vi.mock('react-hook-form', () => ({
@@ -23,6 +40,15 @@ vi.mock('react-hook-form', () => ({
     });
   })
 }));
+
+// Mock di react-router
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return {
+    ...actual,
+    useNavigate: vi.fn()
+  };
+});
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key })
@@ -195,23 +221,12 @@ vi.mock('@mui/icons-material/Article', () => ({
   default: () => <div>ArticleIcon</div>
 }));
 
-// Tipo per i dati del form
-type Step3Data = {
-  paymentObject: { value: string; readonly: boolean };
-  paymentOption: { value: string; readonly: boolean };
-  amount: { value: string; readonly: boolean };
-  dueDate: { value: string | null; readonly: boolean };
-  isMultibeneficiary: { value: boolean; readonly: boolean };
-};
-
-// Tipo per i valori del form
-type FormValue = string | boolean | Date | null;
-
 describe('Step3', () => {
   // Setup iniziale per i test
   const mockSetData = vi.fn();
   const mockOnNext = vi.fn();
   const mockOnBack = vi.fn();
+  const mockNavigate = vi.fn();
 
   const defaultProps = {
     data: {
@@ -219,7 +234,8 @@ describe('Step3', () => {
       paymentOption: { value: '', readonly: false },
       amount: { value: '', readonly: false },
       dueDate: { value: null, readonly: false },
-      isMultibeneficiary: { value: false, readonly: false }
+      isMultibeneficiary: { value: false, readonly: false },
+      flagMandatoryDueDate: false
     },
     setData: mockSetData,
     onNext: mockOnNext,
@@ -236,7 +252,7 @@ describe('Step3', () => {
   }));
 
   const mockHandleSubmit = vi.fn(
-    (onSubmit: (data: Step3Data) => void) =>
+    (onSubmit: (data: FormValues) => void) =>
       (e?: { preventDefault?: () => void }) => {
         e?.preventDefault?.();
         onSubmit({
@@ -244,7 +260,7 @@ describe('Step3', () => {
           paymentOption: { value: 'SINGLE', readonly: false },
           amount: { value: '100.00', readonly: false },
           dueDate: {
-            value: new Date('2023-12-31').toISOString(),
+            value: new Date('2023-12-31'),
             readonly: false
           },
           isMultibeneficiary: { value: false, readonly: false }
@@ -254,17 +270,20 @@ describe('Step3', () => {
   );
 
   const createFormValues = (
-    overrides: Record<string, FormValue> = {}
-  ): Record<string, FormValue> => {
-    const defaultValues: Record<string, FormValue> = {
+    overrides: Partial<Record<string, FormFieldValue>> = {}
+  ): Record<string, FormFieldValue> => {
+    const defaultValues: Record<string, FormFieldValue> = {
       'paymentObject.value': 'Pagamento bolletta',
       'paymentOption.value': 'SINGLE',
       'amount.value': '100.00',
-      'dueDate.value': new Date('2023-12-31').toISOString(),
+      'dueDate.value': new Date('2023-12-31'),
       'isMultibeneficiary.value': false
     };
 
-    return { ...defaultValues, ...overrides };
+    return Object.assign({}, defaultValues, overrides) as Record<
+      string,
+      FormFieldValue
+    >;
   };
 
   const mockWatchFactory = (
@@ -303,11 +322,18 @@ describe('Step3', () => {
     (formatDate as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
       '2023-12-31'
     );
+    (useNavigate as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      mockNavigate
+    );
   });
 
   // Test base
   it('renderizza correttamente il componente con tutti i campi richiesti', () => {
-    render(<Step3 {...defaultProps} />);
+    render(
+      <MemoryRouter>
+        <Step3 {...defaultProps} />
+      </MemoryRouter>
+    );
     expect(
       screen.getByText('debtPositionCreateWizard.step3.title')
     ).toBeInTheDocument();
@@ -322,11 +348,16 @@ describe('Step3', () => {
         paymentOption: { value: 'SINGLE', readonly: false },
         amount: { value: '100.00', readonly: false },
         dueDate: { value: testDate.toISOString(), readonly: false },
-        isMultibeneficiary: { value: false, readonly: false }
+        isMultibeneficiary: { value: false, readonly: false },
+        flagMandatoryDueDate: false
       }
     };
 
-    render(<Step3 {...propsWithValues} />);
+    render(
+      <MemoryRouter>
+        <Step3 {...propsWithValues} />
+      </MemoryRouter>
+    );
     expect(useForm).toHaveBeenCalledWith(
       expect.objectContaining({
         defaultValues: {
@@ -358,7 +389,11 @@ describe('Step3', () => {
     );
 
     // 2. Renderizza il componente
-    render(<Step3 {...defaultProps} />);
+    render(
+      <MemoryRouter>
+        <Step3 {...defaultProps} />
+      </MemoryRouter>
+    );
 
     // 3. Testa handleFieldChange per diversi campi
     const testFields = [
@@ -391,7 +426,8 @@ describe('Step3', () => {
         paymentOption: { value: 'SINGLE', readonly: true },
         amount: { value: '100.00', readonly: true },
         dueDate: { value: testDate.toISOString(), readonly: true },
-        isMultibeneficiary: { value: false, readonly: true }
+        isMultibeneficiary: { value: false, readonly: true },
+        flagMandatoryDueDate: false
       }
     };
 
@@ -407,7 +443,11 @@ describe('Step3', () => {
       })
     );
 
-    render(<Step3 {...propsWithReadonly} />);
+    render(
+      <MemoryRouter>
+        <Step3 {...propsWithReadonly} />
+      </MemoryRouter>
+    );
     expect(useForm).toHaveBeenCalledWith(
       expect.objectContaining({
         defaultValues: {
@@ -434,7 +474,11 @@ describe('Step3', () => {
       })
     );
 
-    const { rerender } = render(<Step3 {...defaultProps} />);
+    const { rerender } = render(
+      <MemoryRouter>
+        <Step3 {...defaultProps} />
+      </MemoryRouter>
+    );
 
     expect(screen.getByText('Errore oggetto pagamento')).toBeInTheDocument();
 
@@ -462,14 +506,18 @@ describe('Step3', () => {
       })
     );
 
-    rerender(<Step3 {...defaultProps} />);
+    rerender(
+      <MemoryRouter>
+        <Step3 {...defaultProps} />
+      </MemoryRouter>
+    );
 
     // Simula click sul pulsante Crea
     fireEvent.click(screen.getByText('commons.create'));
 
     expect(handleSubmitSuccess).toHaveBeenCalled();
     expect(mockSetData).toHaveBeenCalled();
-    expect(mockOnNext).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalled();
 
     // Simula click sul pulsante Indietro
     fireEvent.click(screen.getByText('commons.back'));
@@ -481,6 +529,7 @@ describe('Step3', () => {
     const setValue = vi.fn();
     const trigger = vi.fn().mockResolvedValue(true);
     const clearErrors = vi.fn();
+    const onChange = vi.fn();
 
     // Creiamo un mock più dettagliato per useForm
     const mockUseForm = createMockUseForm({
@@ -495,16 +544,35 @@ describe('Step3', () => {
       }
     });
 
+    // Modifichiamo il mock di Controller per catturare l'onChange
+    (Controller as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      ({ render, name }) => {
+        return render({
+          field: {
+            onChange,
+            onBlur: vi.fn(),
+            value: '',
+            name,
+            ref: vi.fn()
+          },
+          fieldState: {
+            error: null
+          }
+        });
+      }
+    );
+
     // Assicuriamoci che il mock di useForm restituisca il nostro setValue
     (useForm as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
       mockUseForm
     );
 
     // Renderizziamo il componente
-    render(<Step3 {...defaultProps} />);
-
-    // Verifichiamo che setValue sia stato correttamente passato al componente
-    expect(mockUseForm.setValue).toBe(setValue);
+    render(
+      <MemoryRouter>
+        <Step3 {...defaultProps} />
+      </MemoryRouter>
+    );
 
     // Troviamo l'input dell'oggetto pagamento
     const paymentObjectInput = screen.getByTestId('input-paymentObject.value');
@@ -517,21 +585,8 @@ describe('Step3', () => {
       target: { value: 'Pagamento bolletta' }
     });
 
-    // Attendiamo che tutte le promesse vengano risolte
-    await vi.waitFor(() => {
-      // Verifichiamo che setValue sia stato chiamato
-      expect(setValue).toHaveBeenCalled();
-
-      // Verifichiamo i parametri passati a setValue
-      expect(setValue.mock.calls[0][0]).toBe('paymentObject.value');
-      expect(setValue.mock.calls[0][1]).toBe('Pagamento bolletta');
-
-      // Verifichiamo che trigger sia stato chiamato
-      expect(trigger).toHaveBeenCalledWith('paymentObject.value');
-
-      // Verifichiamo che clearErrors sia stato chiamato
-      expect(clearErrors).toHaveBeenCalledWith('paymentObject.value');
-    });
+    // Verifichiamo che onChange sia stato chiamato con il nuovo valore
+    expect(onChange).toHaveBeenCalledWith('Pagamento bolletta');
   });
 
   // Test specifico per la funzione onSubmit
@@ -558,7 +613,11 @@ describe('Step3', () => {
       })
     );
 
-    render(<Step3 {...defaultProps} />);
+    render(
+      <MemoryRouter>
+        <Step3 {...defaultProps} />
+      </MemoryRouter>
+    );
 
     // Simula click sul pulsante Crea
     fireEvent.click(screen.getByText('commons.create'));
@@ -572,11 +631,12 @@ describe('Step3', () => {
       paymentOption: { value: 'SINGLE', readonly: false },
       amount: { value: '100.00', readonly: false },
       dueDate: { value: '2023-12-31T00:00:00.000Z', readonly: false },
-      isMultibeneficiary: { value: false, readonly: false }
+      isMultibeneficiary: { value: false, readonly: false },
+      flagMandatoryDueDate: false
     });
 
-    // Verifica che onNext sia stato chiamato
-    expect(mockOnNext).toHaveBeenCalled();
+    // Verifica che navigate sia stato chiamato invece di onNext
+    expect(mockNavigate).toHaveBeenCalled();
   });
 
   // Test per la validazione dell'importo
@@ -584,6 +644,7 @@ describe('Step3', () => {
     const setValue = vi.fn();
     const trigger = vi.fn().mockResolvedValue(true);
     const clearErrors = vi.fn();
+    const onChange = vi.fn();
 
     // Creiamo un mock per useForm con errori di validazione per l'importo
     const mockUseForm = createMockUseForm({
@@ -600,11 +661,33 @@ describe('Step3', () => {
       }
     });
 
+    // Modifichiamo il mock di Controller per catturare l'onChange
+    (Controller as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      ({ render, name }) => {
+        return render({
+          field: {
+            onChange,
+            onBlur: vi.fn(),
+            value: '',
+            name,
+            ref: vi.fn()
+          },
+          fieldState: {
+            error: null
+          }
+        });
+      }
+    );
+
     (useForm as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
       mockUseForm
     );
 
-    render(<Step3 {...defaultProps} />);
+    render(
+      <MemoryRouter>
+        <Step3 {...defaultProps} />
+      </MemoryRouter>
+    );
 
     // Troviamo l'input dell'importo
     const amountInput = screen.getByTestId('input-amount.value');
@@ -620,23 +703,15 @@ describe('Step3', () => {
     // Simuliamo il cambio dell'importo con un valore valido
     fireEvent.change(amountInput, { target: { value: '100.00' } });
 
-    // Attendiamo che tutte le promesse vengano risolte
-    await vi.waitFor(() => {
-      // Verifichiamo che setValue sia stato chiamato con il nuovo valore
-      expect(setValue).toHaveBeenCalledWith('amount.value', '100.00');
-
-      // Verifichiamo che trigger sia stato chiamato
-      expect(trigger).toHaveBeenCalledWith('amount.value');
-
-      // Verifichiamo che clearErrors sia stato chiamato
-      expect(clearErrors).toHaveBeenCalledWith('amount.value');
-    });
+    // Verifichiamo che onChange sia stato chiamato con il nuovo valore
+    expect(onChange).toHaveBeenCalledWith('100.00');
   });
 
   // Test per il DatePicker
   it('gestisce correttamente il DatePicker', () => {
     const setValue = vi.fn();
     const testDate = new Date('2023-12-31');
+    const onChange = vi.fn();
 
     // Creiamo un mock per useForm
     const mockUseForm = createMockUseForm({
@@ -647,11 +722,33 @@ describe('Step3', () => {
       }
     });
 
+    // Modifichiamo il mock di Controller per catturare l'onChange
+    (Controller as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      ({ render, name }) => {
+        return render({
+          field: {
+            onChange,
+            onBlur: vi.fn(),
+            value: null,
+            name,
+            ref: vi.fn()
+          },
+          fieldState: {
+            error: null
+          }
+        });
+      }
+    );
+
     (useForm as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
       mockUseForm
     );
 
-    render(<Step3 {...defaultProps} />);
+    render(
+      <MemoryRouter>
+        <Step3 {...defaultProps} />
+      </MemoryRouter>
+    );
 
     // Troviamo l'input del DatePicker
     const datePickerInput = screen.getByTestId('datepicker-input');
@@ -662,8 +759,8 @@ describe('Step3', () => {
     // Simuliamo il cambio della data
     fireEvent.change(datePickerInput, { target: { value: '2023-12-31' } });
 
-    // Verifichiamo che setValue sia stato chiamato con la nuova data
-    expect(setValue).toHaveBeenCalledWith('dueDate.value', testDate);
+    // Verifichiamo che onChange sia stato chiamato con la nuova data
+    expect(onChange).toHaveBeenCalledWith(testDate);
   });
 
   // Test per lo switch isMultibeneficiary
@@ -671,6 +768,7 @@ describe('Step3', () => {
     const setValue = vi.fn();
     const trigger = vi.fn().mockResolvedValue(true);
     const clearErrors = vi.fn();
+    const onChange = vi.fn();
 
     // Creiamo un mock per useForm
     const mockUseForm = createMockUseForm({
@@ -683,11 +781,33 @@ describe('Step3', () => {
       }
     });
 
+    // Modifichiamo il mock di Controller per catturare l'onChange
+    (Controller as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      ({ render }) => {
+        return render({
+          field: {
+            onChange,
+            onBlur: vi.fn(),
+            value: false,
+            name: 'isMultibeneficiary.value',
+            ref: vi.fn()
+          },
+          fieldState: {
+            error: null
+          }
+        });
+      }
+    );
+
     (useForm as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
       mockUseForm
     );
 
-    render(<Step3 {...defaultProps} />);
+    render(
+      <MemoryRouter>
+        <Step3 {...defaultProps} />
+      </MemoryRouter>
+    );
 
     // Troviamo l'input dello switch
     const switchInput = screen.getByTestId('switch-input');
@@ -698,10 +818,7 @@ describe('Step3', () => {
     // Simuliamo il click sullo switch invece del change
     fireEvent.click(switchInput);
 
-    // Attendiamo che tutte le promesse vengano risolte
-    await vi.waitFor(() => {
-      // Verifichiamo che setValue sia stato chiamato con il nuovo valore
-      expect(setValue).toHaveBeenCalledWith('isMultibeneficiary.value', true);
-    });
+    // Verifichiamo che onChange sia stato chiamato con il nuovo valore
+    expect(onChange).toHaveBeenCalledWith(true);
   });
 });

--- a/src/routes/DebtPositionCreateWizard/components/Step3.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step3.tsx
@@ -1,5 +1,199 @@
-const Step3 = () => {
-  return <div>Step3</div>;
+import {
+  Box,
+  Grid,
+  TextField,
+  MenuItem,
+  InputAdornment,
+  Switch,
+  FormControlLabel
+} from '@mui/material';
+import { Controller, useForm } from 'react-hook-form';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import WizardStepButtons from '../../../components/Wizard/WizardStepButtons';
+import SectionBox from '../../../components/Wizard/SectionBox';
+import PaperContent from '../../../components/Wizard/PaperContent';
+import ArticleIcon from '@mui/icons-material/Article';
+import { useTranslation } from 'react-i18next';
+
+type FormValues = {
+  paymentObject: string;
+  paymentOption: string;
+  amount: string;
+  dueDate: Date | null;
+  isMultibeneficiary: boolean;
+};
+
+type Step3Data = {
+  paymentObject: { value: string; readonly: boolean };
+  paymentOption: { value: string; readonly: boolean };
+  amount: { value: string; readonly: boolean };
+  dueDate: { value: string; readonly: boolean };
+  // isMultibeneficiary: { value: boolean; readonly: boolean };
+};
+
+type Props = {
+  data: Step3Data; // Dati attuali dello step
+  setData: (data: Step3Data) => void; // Funzione per aggiornare i dati
+  onNext: () => void; // Funzione per passare allo step successivo
+  onBack: () => void; // Funzione per tornare allo step precedente
+};
+
+const Step3 = ({ data, setData, onNext, onBack }: Props) => {
+  const { t } = useTranslation();
+  const { handleSubmit, control } = useForm<FormValues>({
+    defaultValues: {
+      paymentObject: data.paymentObject?.value || '',
+      paymentOption: data.paymentOption?.value || 'SINGLE',
+      amount: data.amount?.value || '',
+      dueDate: data.dueDate?.value ? new Date(data.dueDate.value) : null,
+      isMultibeneficiary: false
+    }
+  });
+
+  const onSubmit = (formValues: FormValues) => {
+    setData({
+      paymentObject: {
+        value: formValues.paymentObject,
+        readonly: data.paymentObject?.readonly ?? false
+      },
+      paymentOption: {
+        value: formValues.paymentOption,
+        readonly: data.paymentOption?.readonly ?? false
+      },
+      amount: {
+        value: formValues.amount,
+        readonly: data.amount?.readonly ?? false
+      },
+      dueDate: {
+        value: formValues.dueDate?.toISOString() ?? '',
+        readonly: data.dueDate?.readonly ?? false
+      }
+      // isMultibeneficiary: {
+      //   value: formValues.isMultibeneficiary,
+      //   readonly: data.isMultibeneficiary?.readonly ?? false
+      // }
+    });
+    onNext();
+  };
+
+  return (
+    <Box>
+      <SectionBox hideHeader>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <PaperContent
+            title={t('debtPositionCreateWizard.step3.title')}
+            icon={<ArticleIcon sx={{ mr: 1 }} />}
+          >
+            <Grid container spacing={2}>
+              <Grid item xs={12}>
+                <Controller
+                  name="paymentObject"
+                  control={control}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      fullWidth
+                      label="Oggetto del pagamento"
+                      required
+                      disabled={data.paymentObject?.readonly}
+                    />
+                  )}
+                />
+              </Grid>
+
+              <Grid item xs={12}>
+                <Controller
+                  name="paymentOption"
+                  control={control}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      select
+                      fullWidth
+                      label="Opzione di pagamento"
+                      required
+                      disabled={data.paymentOption?.readonly}
+                    >
+                      <MenuItem value="SINGLE">Soluzione unica</MenuItem>
+                      <MenuItem value="INSTALLMENTS">
+                        Soluzione rateale
+                      </MenuItem>
+                    </TextField>
+                  )}
+                />
+              </Grid>
+
+              <Grid item xs={12}>
+                <Controller
+                  name="amount"
+                  control={control}
+                  render={({ field }) => (
+                    <TextField
+                      {...field}
+                      fullWidth
+                      label="Importo"
+                      required
+                      type="number"
+                      disabled={data.amount?.readonly}
+                      InputProps={{
+                        startAdornment: (
+                          <InputAdornment position="start">€</InputAdornment>
+                        )
+                      }}
+                    />
+                  )}
+                />
+              </Grid>
+
+              <Grid item xs={12}>
+                <Controller
+                  name="dueDate"
+                  control={control}
+                  render={({ field }) => (
+                    <DatePicker
+                      {...field}
+                      label="Data scadenza"
+                      disabled={data.dueDate?.readonly}
+                      slotProps={{
+                        textField: {
+                          fullWidth: true
+                        }
+                      }}
+                    />
+                  )}
+                />
+              </Grid>
+
+              <Grid item xs={12}>
+                <Controller
+                  name="isMultibeneficiary"
+                  control={control}
+                  render={({ field }) => (
+                    <FormControlLabel
+                      control={
+                        <Switch
+                          {...field}
+                          checked={field.value}
+                          // disabled={data.isMultibeneficiary?.readonly}
+                        />
+                      }
+                      label="Multibeneficiari"
+                    />
+                  )}
+                />
+              </Grid>
+            </Grid>
+          </PaperContent>
+
+          <WizardStepButtons
+            onBack={onBack}
+            onNext={handleSubmit(onSubmit)}
+            disableNext={false}
+          />
+        </form>
+      </SectionBox>
+    </Box>
+  );
 };
 
 export default Step3;

--- a/src/routes/DebtPositionCreateWizard/components/Step3.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step3.tsx
@@ -15,12 +15,15 @@ import PaperContent from '../../../components/Wizard/PaperContent';
 import ArticleIcon from '@mui/icons-material/Article';
 import { useTranslation } from 'react-i18next';
 import { formatDate } from '../../../utils/formatters';
+import { useNavigate } from 'react-router';
+import config from '../../../utils/config';
 
 type Step3Data = {
   paymentObject: { value: string; readonly: boolean };
   paymentOption: { value: string; readonly: boolean };
   amount: { value: string; readonly: boolean };
   dueDate: { value: string | null; readonly: boolean };
+  flagMandatoryDueDate: boolean;
   isMultibeneficiary: { value: boolean; readonly: boolean };
 };
 
@@ -39,8 +42,10 @@ type FormValues = {
   isMultibeneficiary: { value: boolean; readonly: boolean };
 };
 
-const Step3 = ({ data, setData, onNext, onBack }: Props) => {
+const Step3 = ({ data, setData, onBack }: Props) => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const deployPath = config.deployPath;
 
   // Converti il valore stringa della data in oggetto Date per il DatePicker
   const initialData: FormValues = {
@@ -54,10 +59,7 @@ const Step3 = ({ data, setData, onNext, onBack }: Props) => {
   const {
     handleSubmit,
     control,
-    formState: { errors, isSubmitted },
-    trigger,
-    clearErrors,
-    setValue
+    formState: { errors, isSubmitted }
   } = useForm<FormValues>({
     defaultValues: initialData,
     mode: 'onChange'
@@ -73,36 +75,39 @@ const Step3 = ({ data, setData, onNext, onBack }: Props) => {
           values.dueDate.value instanceof Date
             ? formatDate(values.dueDate.value.toISOString())
             : values.dueDate.value
-      }
+      },
+      flagMandatoryDueDate: data.flagMandatoryDueDate
     };
     setData(formattedValues);
-    onNext();
+    // va alla pagina finale, passando il valore aggiornato
+    navigate(`${deployPath}/debt-types/create-wizard/completed`, {
+      state: {
+        paymentObject: formattedValues.paymentObject.value
+      },
+      replace: true // sovrascrive la rotta step3 nello stack del browser si ritorna a ${deployPath}/debt-positions/
+    });
   };
 
-  // Funzione per gestire il cambiamento di un qualsiasi campo del form
-  const handleFieldChange = async (
-    fieldName: keyof FormValues,
-    value: string | boolean | Date | null
-  ) => {
-    // Se il campo è dueDate e il valore è una stringa, convertilo in Date
-    if (fieldName === 'dueDate' && typeof value === 'string') {
-      value = new Date(value);
-    }
-
-    // Imposta il nuovo valore nel form
-    if (fieldName === 'dueDate') {
-      setValue(`${fieldName}.value`, value as Date | null);
-    } else if (fieldName === 'isMultibeneficiary') {
-      setValue(`${fieldName}.value`, value as boolean);
-    } else {
-      setValue(`${fieldName}.value`, value as string);
-    }
-
-    // Se il form è già stato inviato, verifica il campo e pulisce eventuali errori
-    if (isSubmitted) {
-      const isFieldValid = await trigger(`${fieldName}.value`);
-      if (isFieldValid) {
-        clearErrors(`${fieldName}.value`);
+  // Validazione importo - estratta per leggibilità
+  const validateAmount = {
+    required: {
+      value: true,
+      message: t('debtPositionCreateWizard.step3.amount.required')
+    },
+    validate: {
+      positive: (value: string) => {
+        if (!value) return true;
+        const numValue = parseFloat(value);
+        return (
+          numValue > 0 || t('debtPositionCreateWizard.step3.amount.positive')
+        );
+      },
+      validNumber: (value: string) => {
+        if (!value) return true;
+        return (
+          !isNaN(parseFloat(value)) ||
+          t('debtPositionCreateWizard.step3.amount.validNumber')
+        );
       }
     }
   };
@@ -141,7 +146,7 @@ const Step3 = ({ data, setData, onNext, onBack }: Props) => {
                       onChange={(e) => {
                         const value = e.target.value;
                         field.onChange(value);
-                        handleFieldChange('paymentObject', value);
+                        // handleFieldChange('paymentObject', value);
                       }}
                     />
                   )}
@@ -174,7 +179,7 @@ const Step3 = ({ data, setData, onNext, onBack }: Props) => {
                       onChange={(e) => {
                         const value = e.target.value;
                         field.onChange(value);
-                        handleFieldChange('paymentOption', value);
+                        // handleFieldChange('paymentOption', value);
                       }}
                     >
                       <MenuItem value="SINGLE">
@@ -196,31 +201,7 @@ const Step3 = ({ data, setData, onNext, onBack }: Props) => {
                 <Controller
                   name="amount.value"
                   control={control}
-                  rules={{
-                    required: {
-                      value: true,
-                      message: t(
-                        'debtPositionCreateWizard.step3.amount.required'
-                      )
-                    },
-                    validate: {
-                      positive: (value) => {
-                        if (!value) return true; // La validazione required gestisce il caso vuoto
-                        const numValue = parseFloat(value);
-                        return (
-                          numValue > 0 ||
-                          t('debtPositionCreateWizard.step3.amount.positive')
-                        );
-                      },
-                      validNumber: (value) => {
-                        if (!value) return true; // La validazione required gestisce il caso vuoto
-                        return (
-                          !isNaN(parseFloat(value)) ||
-                          t('debtPositionCreateWizard.step3.amount.validNumber')
-                        );
-                      }
-                    }
-                  }}
+                  rules={validateAmount}
                   render={({ field }) => (
                     <TextField
                       {...field}
@@ -243,7 +224,7 @@ const Step3 = ({ data, setData, onNext, onBack }: Props) => {
                       onChange={(e) => {
                         const value = e.target.value;
                         field.onChange(value);
-                        handleFieldChange('amount', value);
+                        // handleFieldChange('amount', value);
                       }}
                     />
                   )}
@@ -255,9 +236,9 @@ const Step3 = ({ data, setData, onNext, onBack }: Props) => {
                   name="dueDate.value"
                   control={control}
                   rules={{
-                    required: t(
-                      'debtPositionCreateWizard.step3.dueDate.required'
-                    )
+                    required: data.flagMandatoryDueDate
+                      ? t('debtPositionCreateWizard.step3.dueDate.required')
+                      : false
                   }}
                   render={({ field: { onChange, value, ...field } }) => (
                     <DatePicker
@@ -265,11 +246,12 @@ const Step3 = ({ data, setData, onNext, onBack }: Props) => {
                       value={value}
                       label={t('debtPositionCreateWizard.step3.dueDate.label')}
                       disabled={data.dueDate?.readonly}
+                      minDate={new Date()}
                       format="dd/MM/yyyy"
                       slotProps={{
                         textField: {
                           fullWidth: true,
-                          required: true,
+                          required: data.flagMandatoryDueDate,
                           error: isSubmitted && !!errors.dueDate?.value,
                           helperText:
                             isSubmitted && errors.dueDate?.value?.message
@@ -277,8 +259,6 @@ const Step3 = ({ data, setData, onNext, onBack }: Props) => {
                       }}
                       onChange={(date) => {
                         onChange(date);
-                        // Non convertire la data in stringa qui, mantieni l'oggetto Date
-                        handleFieldChange('dueDate', date);
                       }}
                     />
                   )}
@@ -299,7 +279,7 @@ const Step3 = ({ data, setData, onNext, onBack }: Props) => {
                           onChange={(e) => {
                             const value = e.target.checked;
                             field.onChange(value);
-                            handleFieldChange('isMultibeneficiary', value);
+                            // handleFieldChange('isMultibeneficiary', value);
                           }}
                         />
                       }

--- a/src/routes/DebtPositionCreateWizard/components/Step3.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step3.tsx
@@ -14,66 +14,97 @@ import SectionBox from '../../../components/Wizard/SectionBox';
 import PaperContent from '../../../components/Wizard/PaperContent';
 import ArticleIcon from '@mui/icons-material/Article';
 import { useTranslation } from 'react-i18next';
-
-type FormValues = {
-  paymentObject: string;
-  paymentOption: string;
-  amount: string;
-  dueDate: Date | null;
-  isMultibeneficiary: boolean;
-};
+import { formatDate } from '../../../utils/formatters';
 
 type Step3Data = {
   paymentObject: { value: string; readonly: boolean };
   paymentOption: { value: string; readonly: boolean };
   amount: { value: string; readonly: boolean };
-  dueDate: { value: string; readonly: boolean };
-  // isMultibeneficiary: { value: boolean; readonly: boolean };
+  dueDate: { value: string | null; readonly: boolean };
+  isMultibeneficiary: { value: boolean; readonly: boolean };
 };
 
 type Props = {
-  data: Step3Data; // Dati attuali dello step
-  setData: (data: Step3Data) => void; // Funzione per aggiornare i dati
-  onNext: () => void; // Funzione per passare allo step successivo
-  onBack: () => void; // Funzione per tornare allo step precedente
+  data: Step3Data;
+  setData: (data: Step3Data) => void;
+  onNext: () => void;
+  onBack: () => void;
+};
+
+type FormValues = {
+  paymentObject: { value: string; readonly: boolean };
+  paymentOption: { value: string; readonly: boolean };
+  amount: { value: string; readonly: boolean };
+  dueDate: { value: Date | null; readonly: boolean };
+  isMultibeneficiary: { value: boolean; readonly: boolean };
 };
 
 const Step3 = ({ data, setData, onNext, onBack }: Props) => {
   const { t } = useTranslation();
-  const { handleSubmit, control } = useForm<FormValues>({
-    defaultValues: {
-      paymentObject: data.paymentObject?.value || '',
-      paymentOption: data.paymentOption?.value || 'SINGLE',
-      amount: data.amount?.value || '',
-      dueDate: data.dueDate?.value ? new Date(data.dueDate.value) : null,
-      isMultibeneficiary: false
+
+  // Converti il valore stringa della data in oggetto Date per il DatePicker
+  const initialData: FormValues = {
+    ...data,
+    dueDate: {
+      ...data.dueDate,
+      value: data.dueDate?.value ? new Date(data.dueDate.value) : null
     }
+  };
+
+  const {
+    handleSubmit,
+    control,
+    formState: { errors, isSubmitted },
+    trigger,
+    clearErrors,
+    setValue
+  } = useForm<FormValues>({
+    defaultValues: initialData,
+    mode: 'onChange'
   });
 
-  const onSubmit = (formValues: FormValues) => {
-    setData({
-      paymentObject: {
-        value: formValues.paymentObject,
-        readonly: data.paymentObject?.readonly ?? false
-      },
-      paymentOption: {
-        value: formValues.paymentOption,
-        readonly: data.paymentOption?.readonly ?? false
-      },
-      amount: {
-        value: formValues.amount,
-        readonly: data.amount?.readonly ?? false
-      },
+  const onSubmit = async (values: FormValues) => {
+    // Converti la data in stringa prima di salvare
+    const formattedValues: Step3Data = {
+      ...values,
       dueDate: {
-        value: formValues.dueDate?.toISOString() ?? '',
-        readonly: data.dueDate?.readonly ?? false
+        ...values.dueDate,
+        value:
+          values.dueDate.value instanceof Date
+            ? formatDate(values.dueDate.value.toISOString())
+            : values.dueDate.value
       }
-      // isMultibeneficiary: {
-      //   value: formValues.isMultibeneficiary,
-      //   readonly: data.isMultibeneficiary?.readonly ?? false
-      // }
-    });
+    };
+    setData(formattedValues);
     onNext();
+  };
+
+  // Funzione per gestire il cambiamento di un qualsiasi campo del form
+  const handleFieldChange = async (
+    fieldName: keyof FormValues,
+    value: string | boolean | Date | null
+  ) => {
+    // Se il campo è dueDate e il valore è una stringa, convertilo in Date
+    if (fieldName === 'dueDate' && typeof value === 'string') {
+      value = new Date(value);
+    }
+
+    // Imposta il nuovo valore nel form
+    if (fieldName === 'dueDate') {
+      setValue(`${fieldName}.value`, value as Date | null);
+    } else if (fieldName === 'isMultibeneficiary') {
+      setValue(`${fieldName}.value`, value as boolean);
+    } else {
+      setValue(`${fieldName}.value`, value as string);
+    }
+
+    // Se il form è già stato inviato, verifica il campo e pulisce eventuali errori
+    if (isSubmitted) {
+      const isFieldValid = await trigger(`${fieldName}.value`);
+      if (isFieldValid) {
+        clearErrors(`${fieldName}.value`);
+      }
+    }
   };
 
   return (
@@ -87,15 +118,31 @@ const Step3 = ({ data, setData, onNext, onBack }: Props) => {
             <Grid container spacing={2}>
               <Grid item xs={12}>
                 <Controller
-                  name="paymentObject"
+                  name="paymentObject.value"
                   control={control}
+                  rules={{
+                    required: t(
+                      'debtPositionCreateWizard.step3.paymentObject.required'
+                    )
+                  }}
                   render={({ field }) => (
                     <TextField
                       {...field}
                       fullWidth
-                      label="Oggetto del pagamento"
+                      label={t(
+                        'debtPositionCreateWizard.step3.paymentObject.label'
+                      )}
                       required
                       disabled={data.paymentObject?.readonly}
+                      error={isSubmitted && !!errors.paymentObject?.value}
+                      helperText={
+                        isSubmitted && errors.paymentObject?.value?.message
+                      }
+                      onChange={(e) => {
+                        const value = e.target.value;
+                        field.onChange(value);
+                        handleFieldChange('paymentObject', value);
+                      }}
                     />
                   )}
                 />
@@ -103,20 +150,42 @@ const Step3 = ({ data, setData, onNext, onBack }: Props) => {
 
               <Grid item xs={12}>
                 <Controller
-                  name="paymentOption"
+                  name="paymentOption.value"
                   control={control}
+                  rules={{
+                    required: t(
+                      'debtPositionCreateWizard.step3.paymentOption.required'
+                    )
+                  }}
                   render={({ field }) => (
                     <TextField
                       {...field}
                       select
                       fullWidth
-                      label="Opzione di pagamento"
+                      label={t(
+                        'debtPositionCreateWizard.step3.paymentOption.label'
+                      )}
                       required
                       disabled={data.paymentOption?.readonly}
+                      error={isSubmitted && !!errors.paymentOption?.value}
+                      helperText={
+                        isSubmitted && errors.paymentOption?.value?.message
+                      }
+                      onChange={(e) => {
+                        const value = e.target.value;
+                        field.onChange(value);
+                        handleFieldChange('paymentOption', value);
+                      }}
                     >
-                      <MenuItem value="SINGLE">Soluzione unica</MenuItem>
+                      <MenuItem value="SINGLE">
+                        {t(
+                          'debtPositionCreateWizard.step3.paymentOption.single'
+                        )}
+                      </MenuItem>
                       <MenuItem value="INSTALLMENTS">
-                        Soluzione rateale
+                        {t(
+                          'debtPositionCreateWizard.step3.paymentOption.installments'
+                        )}
                       </MenuItem>
                     </TextField>
                   )}
@@ -125,40 +194,57 @@ const Step3 = ({ data, setData, onNext, onBack }: Props) => {
 
               <Grid item xs={12}>
                 <Controller
-                  name="amount"
+                  name="amount.value"
                   control={control}
+                  rules={{
+                    required: {
+                      value: true,
+                      message: t(
+                        'debtPositionCreateWizard.step3.amount.required'
+                      )
+                    },
+                    validate: {
+                      positive: (value) => {
+                        if (!value) return true; // La validazione required gestisce il caso vuoto
+                        const numValue = parseFloat(value);
+                        return (
+                          numValue > 0 ||
+                          t('debtPositionCreateWizard.step3.amount.positive')
+                        );
+                      },
+                      validNumber: (value) => {
+                        if (!value) return true; // La validazione required gestisce il caso vuoto
+                        return (
+                          !isNaN(parseFloat(value)) ||
+                          t('debtPositionCreateWizard.step3.amount.validNumber')
+                        );
+                      }
+                    }
+                  }}
                   render={({ field }) => (
                     <TextField
                       {...field}
                       fullWidth
-                      label="Importo"
+                      label={t('debtPositionCreateWizard.step3.amount.label')}
                       required
                       type="number"
                       disabled={data.amount?.readonly}
                       InputProps={{
                         startAdornment: (
                           <InputAdornment position="start">€</InputAdornment>
-                        )
-                      }}
-                    />
-                  )}
-                />
-              </Grid>
-
-              <Grid item xs={12}>
-                <Controller
-                  name="dueDate"
-                  control={control}
-                  render={({ field }) => (
-                    <DatePicker
-                      {...field}
-                      label="Data scadenza"
-                      disabled={data.dueDate?.readonly}
-                      slotProps={{
-                        textField: {
-                          fullWidth: true
+                        ),
+                        inputProps: {
+                          min: 0.01,
+                          step: 0.01
                         }
                       }}
+                      error={isSubmitted && !!errors.amount?.value}
+                      helperText={isSubmitted && errors.amount?.value?.message}
+                      onChange={(e) => {
+                        const value = e.target.value;
+                        field.onChange(value);
+                        handleFieldChange('amount', value);
+                      }}
                     />
                   )}
                 />
@@ -166,7 +252,42 @@ const Step3 = ({ data, setData, onNext, onBack }: Props) => {
 
               <Grid item xs={12}>
                 <Controller
-                  name="isMultibeneficiary"
+                  name="dueDate.value"
+                  control={control}
+                  rules={{
+                    required: t(
+                      'debtPositionCreateWizard.step3.dueDate.required'
+                    )
+                  }}
+                  render={({ field: { onChange, value, ...field } }) => (
+                    <DatePicker
+                      {...field}
+                      value={value}
+                      label={t('debtPositionCreateWizard.step3.dueDate.label')}
+                      disabled={data.dueDate?.readonly}
+                      format="dd/MM/yyyy"
+                      slotProps={{
+                        textField: {
+                          fullWidth: true,
+                          required: true,
+                          error: isSubmitted && !!errors.dueDate?.value,
+                          helperText:
+                            isSubmitted && errors.dueDate?.value?.message
+                        }
+                      }}
+                      onChange={(date) => {
+                        onChange(date);
+                        // Non convertire la data in stringa qui, mantieni l'oggetto Date
+                        handleFieldChange('dueDate', date);
+                      }}
+                    />
+                  )}
+                />
+              </Grid>
+
+              <Grid item xs={12}>
+                <Controller
+                  name="isMultibeneficiary.value"
                   control={control}
                   render={({ field }) => (
                     <FormControlLabel
@@ -174,10 +295,17 @@ const Step3 = ({ data, setData, onNext, onBack }: Props) => {
                         <Switch
                           {...field}
                           checked={field.value}
-                          // disabled={data.isMultibeneficiary?.readonly}
+                          disabled={data.isMultibeneficiary?.readonly}
+                          onChange={(e) => {
+                            const value = e.target.checked;
+                            field.onChange(value);
+                            handleFieldChange('isMultibeneficiary', value);
+                          }}
                         />
                       }
-                      label="Multibeneficiari"
+                      label={t(
+                        'debtPositionCreateWizard.step3.isMultibeneficiary.label'
+                      )}
                     />
                   )}
                 />
@@ -189,6 +317,7 @@ const Step3 = ({ data, setData, onNext, onBack }: Props) => {
             onBack={onBack}
             onNext={handleSubmit(onSubmit)}
             disableNext={false}
+            nextLabel="commons.create"
           />
         </form>
       </SectionBox>

--- a/src/routes/debtTypes.tsx
+++ b/src/routes/debtTypes.tsx
@@ -4,6 +4,7 @@ import config from '../utils/config';
 import DebtTypes from './DebtTypes/DebtTypes';
 import DebtTypeDetailView from './DebtTypeCatalogDetailView/DebtTypeCatalogDetailView';
 import DebtPositionCreateWizard from './DebtPositionCreateWizard/DebtPositionCreateWizard';
+import DebtPositionCreateWizardCompleted from './DebtPositionCreateWizard/DebtPositionCreateWizardCompleted';
 
 const deployPath = config.deployPath;
 
@@ -41,6 +42,18 @@ export const debtTypesRoutes = [
         handle: {
           backButton: true,
           backButtonText: 'commons.exit',
+          hideBreadcrumbs: true,
+          sidebar: {
+            visible: false
+          }
+        } as RouteHandleObject
+      },
+      {
+        id: 'DEBT_POSITION_CREATE_WIZARD_COMPLETED',
+        path: 'create-wizard/completed',
+        element: <DebtPositionCreateWizardCompleted />,
+        handle: {
+          backButton: false,
           hideBreadcrumbs: true,
           sidebar: {
             visible: false

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -376,7 +376,11 @@
       "fullName": {
         "label": "Nome e cognome",
         "required": "Il campo nome e cognome è obbligatorio",
-        "minTwoWords": "Inserire almeno 2 parole nel nome e cognome"
+        "minTwoWords": "Inserire almeno 2 parole"
+      },
+      "companyName": {
+        "label": "Ragione sociale",
+        "required": "Il campo ragione sociale è obbligatorio"
       },
       "address": {
         "label": "Indirizzo",
@@ -433,6 +437,11 @@
       "step2": "Aggiungi debitore",
       "step3": "Configurazione avviso"
     }
+  },
+  "debtPositionCreateWizardCompleted": {
+    "title": "La posizione debitoria ‘{{paymentObject}}’ è stata creata!",
+    "description": "La trovi nella sezione Dovuti, dove puoi tenere traccia dell'andamento.",
+    "backToStart": "Torna al'inizio"
   },
   "FileUploaderFlowImport": {
     "telematic-receipt": {

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -324,6 +324,10 @@
       "title": "Aggiungi debitore",
       "subtitle": "Aggiungi i dati del destinatario principale della posizione debitoria."
     },
+    "configurationAlert": {
+      "title": "Configurazione avviso",
+      "subtitle": "Indica la opzione di pagamento a disposizione del cittadino e aggiunge l'importo dovuto."
+    },
 
     "step1": {
       "title": "Descrizione",
@@ -395,6 +399,9 @@
       "city": {
         "label": "Località"
       }
+    },
+    "step3": {
+      "title": "Avviso"
     },
     "wizardStepper": {
       "step1": "Configurazione Generale",

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -415,8 +415,8 @@
       "paymentOption": {
         "label": "Opzione pagamento",
         "required": "Il campo opzione pagamento è obbligatorio",
-        "single": "Pagamento unico",
-        "installments": "Pagamento rateale"
+        "single": "Soluzione unica",
+        "installments": "Soluzione rateale"
       },
       "amount": {
         "label": "Importo",

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -22,6 +22,8 @@
     "close": "Chiudi",
     "collectionReason": "Motivo Riscossione",
     "copied": "Copiato!",
+    "continue": "Continua",
+    "create": "Crea",
     "debtor": "Debitore",
     "debtTypeCode": "Codice Tipo dovuto",
     "debtTypeName": "Nome del Tipo dovuto",
@@ -401,7 +403,30 @@
       }
     },
     "step3": {
-      "title": "Avviso"
+      "title": "Avviso",
+      "paymentObject": {
+        "label": "Oggetto pagamento",
+        "required": "Il campo oggetto pagamento è obbligatorio"
+      },
+      "paymentOption": {
+        "label": "Opzione pagamento",
+        "required": "Il campo opzione pagamento è obbligatorio",
+        "single": "Pagamento unico",
+        "installments": "Pagamento rateale"
+      },
+      "amount": {
+        "label": "Importo",
+        "required": "Il campo importo è obbligatorio",
+        "positive": "Il campo importo deve essere maggiore di 0",
+        "validNumber": "Il campo importo deve essere un numero valido"
+      },
+      "dueDate": {
+        "label": "Data scadenza",
+        "required": "Il campo data scadenza è obbligatorio"
+      },
+      "isMultibeneficiary": {
+        "label": "Multibeneficiario"
+      }
     },
     "wizardStepper": {
       "step1": "Configurazione Generale",

--- a/src/utils/__tests__/fieldValidation.test.tsx
+++ b/src/utils/__tests__/fieldValidation.test.tsx
@@ -1,8 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   isValidCodiceFiscale,
   isValidPartitaIVA,
-  validateTaxCode
+  validateTaxCode,
+  createValidators
 } from '../fieldValidation';
 import { ValidationErrorCode } from '../../store/types';
 
@@ -119,6 +120,112 @@ describe('validateTaxCode', () => {
     it('rejects partita IVA with wrong length for persona giuridica', () => {
       expect(validateTaxCode('123456789', 'giuridica')).toBe(
         'debtPositionCreateWizard.step2.taxCode.invalidVAT'
+      );
+    });
+  });
+});
+
+describe('createValidators', () => {
+  // Mock della funzione di traduzione
+  const mockT = vi.fn((key: string) => key);
+
+  describe('validateTaxCodeField', () => {
+    it('restituisce il messaggio generico quando il campo è vuoto e non è selezionato il tipo di soggetto', () => {
+      const { validateTaxCodeField } = createValidators(mockT, '');
+      expect(validateTaxCodeField('')).toBe(
+        'debtPositionCreateWizard.step2.taxCodeOrVat.required'
+      );
+    });
+
+    it('restituisce il messaggio specifico per persona fisica quando il campo è vuoto', () => {
+      const { validateTaxCodeField } = createValidators(mockT, 'fisica');
+      expect(validateTaxCodeField('')).toBe(
+        'debtPositionCreateWizard.step2.taxCode.required'
+      );
+    });
+
+    it('restituisce il messaggio specifico per persona giuridica quando il campo è vuoto', () => {
+      const { validateTaxCodeField } = createValidators(mockT, 'giuridica');
+      expect(validateTaxCodeField('')).toBe(
+        'debtPositionCreateWizard.step2.vat.required'
+      );
+    });
+
+    it('restituisce true quando il codice fiscale è valido per persona fisica', () => {
+      const { validateTaxCodeField } = createValidators(mockT, 'fisica');
+      expect(validateTaxCodeField('RSSMRA80A01H501U')).toBe(true);
+    });
+
+    it('restituisce true quando la partita IVA è valida per persona giuridica', () => {
+      const { validateTaxCodeField } = createValidators(mockT, 'giuridica');
+      expect(validateTaxCodeField('12345678901')).toBe(true);
+    });
+
+    it('restituisce il messaggio di errore quando il codice fiscale non è valido per persona fisica', () => {
+      const { validateTaxCodeField } = createValidators(mockT, 'fisica');
+      expect(validateTaxCodeField('12345678901')).toBe(
+        'debtPositionCreateWizard.step2.taxCode.invalid'
+      );
+    });
+
+    it('restituisce il messaggio di errore quando la partita IVA non è valida per persona giuridica', () => {
+      const { validateTaxCodeField } = createValidators(mockT, 'giuridica');
+      expect(validateTaxCodeField('RSSMRA80A01H501U')).toBe(
+        'debtPositionCreateWizard.step2.taxCode.invalidVAT'
+      );
+    });
+  });
+
+  describe('validateFullNameField', () => {
+    it('restituisce il messaggio generico quando il campo è vuoto e non è selezionato il tipo di soggetto', () => {
+      const { validateFullNameField } = createValidators(mockT, '');
+      expect(validateFullNameField('')).toBe(
+        'debtPositionCreateWizard.step2.fullName.required'
+      );
+    });
+
+    it('restituisce il messaggio specifico per persona fisica quando il campo è vuoto', () => {
+      const { validateFullNameField } = createValidators(mockT, 'fisica');
+      expect(validateFullNameField('')).toBe(
+        'debtPositionCreateWizard.step2.fullName.required'
+      );
+    });
+
+    it('restituisce il messaggio specifico per persona giuridica quando il campo è vuoto', () => {
+      const { validateFullNameField } = createValidators(mockT, 'giuridica');
+      expect(validateFullNameField('')).toBe(
+        'debtPositionCreateWizard.step2.companyName.required'
+      );
+    });
+
+    it('restituisce true quando il nome completo è valido (almeno due parole)', () => {
+      const { validateFullNameField } = createValidators(mockT, 'fisica');
+      expect(validateFullNameField('Mario Rossi')).toBe(true);
+    });
+
+    it('restituisce il messaggio di errore quando il nome completo ha meno di due parole', () => {
+      const { validateFullNameField } = createValidators(mockT, 'fisica');
+      expect(validateFullNameField('Mario')).toBe(
+        'debtPositionCreateWizard.step2.fullName.minTwoWords'
+      );
+    });
+  });
+
+  describe('getValidationRules', () => {
+    it('restituisce le regole di validazione corrette', () => {
+      const { getValidationRules } = createValidators(mockT, 'fisica');
+      const rules = getValidationRules();
+
+      expect(rules).toHaveProperty('taxCode');
+      expect(rules).toHaveProperty('fullName');
+      expect(rules).toHaveProperty('subjectType');
+
+      expect(rules.taxCode).toHaveProperty('validate');
+      expect(rules.fullName).toHaveProperty('validate');
+      expect(rules.subjectType).toHaveProperty('required');
+
+      expect(rules.subjectType.required).toBe(
+        'debtPositionCreateWizard.step2.subjectType.required'
       );
     });
   });

--- a/src/utils/__tests__/fieldValidation.test.tsx
+++ b/src/utils/__tests__/fieldValidation.test.tsx
@@ -153,12 +153,12 @@ describe('createValidators', () => {
 
     it('restituisce true quando il codice fiscale è valido per persona fisica', () => {
       const { validateTaxCodeField } = createValidators(mockT, 'fisica');
-      expect(validateTaxCodeField('RSSMRA80A01H501U')).toBe(true);
+      expect(validateTaxCodeField('RSSMRA80A01H501U')).toBe('true');
     });
 
     it('restituisce true quando la partita IVA è valida per persona giuridica', () => {
       const { validateTaxCodeField } = createValidators(mockT, 'giuridica');
-      expect(validateTaxCodeField('12345678901')).toBe(true);
+      expect(validateTaxCodeField('12345678901')).toBe('true');
     });
 
     it('restituisce il messaggio di errore quando il codice fiscale non è valido per persona fisica', () => {
@@ -200,7 +200,7 @@ describe('createValidators', () => {
 
     it('restituisce true quando il nome completo è valido (almeno due parole)', () => {
       const { validateFullNameField } = createValidators(mockT, 'fisica');
-      expect(validateFullNameField('Mario Rossi')).toBe(true);
+      expect(validateFullNameField('Mario Rossi')).toBe('true');
     });
 
     it('restituisce il messaggio di errore quando il nome completo ha meno di due parole', () => {

--- a/src/utils/__tests__/fieldValidation.test.tsx
+++ b/src/utils/__tests__/fieldValidation.test.tsx
@@ -151,14 +151,14 @@ describe('createValidators', () => {
       );
     });
 
-    it('restituisce true quando il codice fiscale è valido per persona fisica', () => {
+    it('restituisce undefined quando il codice fiscale è valido per persona fisica', () => {
       const { validateTaxCodeField } = createValidators(mockT, 'fisica');
-      expect(validateTaxCodeField('RSSMRA80A01H501U')).toBe('true');
+      expect(validateTaxCodeField('RSSMRA80A01H501U')).toBeUndefined();
     });
 
-    it('restituisce true quando la partita IVA è valida per persona giuridica', () => {
+    it('restituisce undefined quando la partita IVA è valida per persona giuridica', () => {
       const { validateTaxCodeField } = createValidators(mockT, 'giuridica');
-      expect(validateTaxCodeField('12345678901')).toBe('true');
+      expect(validateTaxCodeField('12345678901')).toBeUndefined();
     });
 
     it('restituisce il messaggio di errore quando il codice fiscale non è valido per persona fisica', () => {
@@ -198,9 +198,9 @@ describe('createValidators', () => {
       );
     });
 
-    it('restituisce true quando il nome completo è valido (almeno due parole)', () => {
+    it('restituisce undefined quando il nome completo è valido (almeno due parole)', () => {
       const { validateFullNameField } = createValidators(mockT, 'fisica');
-      expect(validateFullNameField('Mario Rossi')).toBe('true');
+      expect(validateFullNameField('Mario Rossi')).toBeUndefined();
     });
 
     it('restituisce il messaggio di errore quando il nome completo ha meno di due parole', () => {

--- a/src/utils/fieldValidation.tsx
+++ b/src/utils/fieldValidation.tsx
@@ -2,6 +2,12 @@
 
 import { ValidationErrorCode } from '../store/types';
 
+// enum per il tipo di soggetto
+export enum SubjectType {
+  INDIVIDUAL = 'fisica',
+  BUSINESS = 'giuridica'
+}
+
 /**
  * Verifica se un codice fiscale italiano è valido
  * @param cf - Codice fiscale da validare
@@ -60,12 +66,12 @@ export const validateTaxCode = (
   const normalizedValue = value.replace(/\s/g, '').toUpperCase();
 
   switch (subjectType) {
-    case 'fisica':
+    case SubjectType.INDIVIDUAL:
       if (!isValidCodiceFiscale(normalizedValue)) {
         return ValidationErrorCode.INVALID_CF;
       }
       break;
-    case 'giuridica':
+    case SubjectType.BUSINESS:
       if (!isValidPartitaIVA(normalizedValue)) {
         return ValidationErrorCode.INVALID_VAT;
       }
@@ -91,7 +97,7 @@ export const createValidators = (
         return t('debtPositionCreateWizard.step2.taxCodeOrVat.required');
       }
       // Altrimenti mostrare il messaggio specifico in base al tipo di soggetto
-      return subjectTypeValue !== 'giuridica'
+      return subjectTypeValue !== SubjectType.BUSINESS
         ? t('debtPositionCreateWizard.step2.taxCode.required')
         : t('debtPositionCreateWizard.step2.vat.required');
     }
@@ -104,7 +110,7 @@ export const createValidators = (
         return t('debtPositionCreateWizard.step2.taxCodeOrVat.required');
       }
       // Altrimenti mostra il messaggio specifico in base al tipo di soggetto
-      return subjectTypeValue !== 'giuridica'
+      return subjectTypeValue !== SubjectType.BUSINESS
         ? t('debtPositionCreateWizard.step2.taxCode.required')
         : t('debtPositionCreateWizard.step2.vat.required');
     }
@@ -122,7 +128,7 @@ export const createValidators = (
         return t('debtPositionCreateWizard.step2.fullName.required');
       }
       // Altrimenti mostrare il messaggio specifico in base al tipo di soggetto
-      return subjectTypeValue !== 'giuridica'
+      return subjectTypeValue !== SubjectType.BUSINESS
         ? t('debtPositionCreateWizard.step2.fullName.required')
         : t('debtPositionCreateWizard.step2.companyName.required');
     }

--- a/src/utils/fieldValidation.tsx
+++ b/src/utils/fieldValidation.tsx
@@ -83,7 +83,7 @@ export const createValidators = (
   subjectTypeValue: string
 ) => {
   // Funzione di validazione per il codice fiscale / partita IVA
-  const validateTaxCodeField = (value: string): string | boolean => {
+  const validateTaxCodeField = (value: string): string => {
     // Se il campo è vuoto, restituisce il messaggio appropriato in base al tipo di soggetto
     if (!value) {
       // Se non è stato selezionato il tipo di soggetto, mostra il messaggio generico
@@ -110,11 +110,11 @@ export const createValidators = (
     }
 
     // Restituisce il risultato della validazione
-    return result === ValidationErrorCode.VALID ? true : t(result);
+    return result === ValidationErrorCode.VALID ? 'true' : t(result);
   };
 
   //Funzione di validazione per il nome completo / ragione sociale
-  const validateFullNameField = (value: string): string | boolean => {
+  const validateFullNameField = (value: string): string => {
     // Se il campo è vuoto, restituisce il messaggio appropriato in base al tipo di soggetto
     if (!value) {
       // Se non è stato selezionato il tipo di soggetto, mostra il messaggio generico
@@ -133,7 +133,7 @@ export const createValidators = (
       return t('debtPositionCreateWizard.step2.fullName.minTwoWords');
     }
 
-    return true;
+    return 'true';
   };
 
   // Factory per le regole di validazione per React Hook Form

--- a/src/utils/fieldValidation.tsx
+++ b/src/utils/fieldValidation.tsx
@@ -76,3 +76,82 @@ export const validateTaxCode = (
 
   return ValidationErrorCode.VALID;
 };
+
+// functions per la validazione dei campi
+export const createValidators = (
+  t: (key: string) => string,
+  subjectTypeValue: string
+) => {
+  // Funzione di validazione per il codice fiscale / partita IVA
+  const validateTaxCodeField = (value: string): string | boolean => {
+    // Se il campo è vuoto, restituisce il messaggio appropriato in base al tipo di soggetto
+    if (!value) {
+      // Se non è stato selezionato il tipo di soggetto, mostra il messaggio generico
+      if (!subjectTypeValue) {
+        return t('debtPositionCreateWizard.step2.taxCodeOrVat.required');
+      }
+      // Altrimenti mostrare il messaggio specifico in base al tipo di soggetto
+      return subjectTypeValue !== 'giuridica'
+        ? t('debtPositionCreateWizard.step2.taxCode.required')
+        : t('debtPositionCreateWizard.step2.vat.required');
+    }
+    // Altrimenti, valida il formato
+    const result = validateTaxCode(value, subjectTypeValue);
+
+    if (result == 'commons.required') {
+      // Se non è stato selezionato il tipo di soggetto, mostra il messaggio generico
+      if (!subjectTypeValue) {
+        return t('debtPositionCreateWizard.step2.taxCodeOrVat.required');
+      }
+      // Altrimenti mostra il messaggio specifico in base al tipo di soggetto
+      return subjectTypeValue !== 'giuridica'
+        ? t('debtPositionCreateWizard.step2.taxCode.required')
+        : t('debtPositionCreateWizard.step2.vat.required');
+    }
+
+    // Restituisce il risultato della validazione
+    return result === ValidationErrorCode.VALID ? true : t(result);
+  };
+
+  //Funzione di validazione per il nome completo / ragione sociale
+  const validateFullNameField = (value: string): string | boolean => {
+    // Se il campo è vuoto, restituisce il messaggio appropriato in base al tipo di soggetto
+    if (!value) {
+      // Se non è stato selezionato il tipo di soggetto, mostra il messaggio generico
+      if (!subjectTypeValue) {
+        return t('debtPositionCreateWizard.step2.fullName.required');
+      }
+      // Altrimenti mostrare il messaggio specifico in base al tipo di soggetto
+      return subjectTypeValue !== 'giuridica'
+        ? t('debtPositionCreateWizard.step2.fullName.required')
+        : t('debtPositionCreateWizard.step2.companyName.required');
+    }
+
+    // Validazione per il formato del nome (almeno due parole)
+    const trimmed = value.trim();
+    if (trimmed.split(' ').length < 2) {
+      return t('debtPositionCreateWizard.step2.fullName.minTwoWords');
+    }
+
+    return true;
+  };
+
+  // Factory per le regole di validazione per React Hook Form
+  const getValidationRules = () => ({
+    taxCode: {
+      validate: validateTaxCodeField
+    },
+    fullName: {
+      validate: validateFullNameField
+    },
+    subjectType: {
+      required: t('debtPositionCreateWizard.step2.subjectType.required')
+    }
+  });
+
+  return {
+    validateTaxCodeField,
+    validateFullNameField,
+    getValidationRules
+  };
+};

--- a/src/utils/fieldValidation.tsx
+++ b/src/utils/fieldValidation.tsx
@@ -83,7 +83,7 @@ export const createValidators = (
   subjectTypeValue: string
 ) => {
   // Funzione di validazione per il codice fiscale / partita IVA
-  const validateTaxCodeField = (value: string): string => {
+  const validateTaxCodeField = (value: string): string | undefined => {
     // Se il campo è vuoto, restituisce il messaggio appropriato in base al tipo di soggetto
     if (!value) {
       // Se non è stato selezionato il tipo di soggetto, mostra il messaggio generico
@@ -110,11 +110,11 @@ export const createValidators = (
     }
 
     // Restituisce il risultato della validazione
-    return result === ValidationErrorCode.VALID ? 'true' : t(result);
+    return result === ValidationErrorCode.VALID ? undefined : t(result);
   };
 
   //Funzione di validazione per il nome completo / ragione sociale
-  const validateFullNameField = (value: string): string => {
+  const validateFullNameField = (value: string): string | undefined => {
     // Se il campo è vuoto, restituisce il messaggio appropriato in base al tipo di soggetto
     if (!value) {
       // Se non è stato selezionato il tipo di soggetto, mostra il messaggio generico
@@ -133,7 +133,7 @@ export const createValidators = (
       return t('debtPositionCreateWizard.step2.fullName.minTwoWords');
     }
 
-    return 'true';
+    return undefined;
   };
 
   // Factory per le regole di validazione per React Hook Form


### PR DESCRIPTION
This PR introduces the third step of the wizard for creating a new debt position. The step includes fields for the payment object, payment option, amount, due date, and multibeneficiary flag, all managed through react-hook-form. Proper frontend validations have been implemented for each field to ensure data consistency. Additionally, a final confirmation page has been created to conclude the wizard. It dynamically displays a summary message using the payment object value entered in the previous step. Navigation to the final page uses replace: true to prevent users from returning to step 3 via the browser back button. A fallback redirect to the debt positions list has also been added in case the page is accessed directly without context.

#### List of Changes

- Created step 3 of the wizard for debt position creation
- Implemented the final confirmation page of the wizard
- Refactored validation functions in step 2 for better readability and maintainability


#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

- visual testing
- unit tests


#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
