### PR TITLE
fix: [P4ADEV-2529] Update sidebar styles to fix a bug with its height and transparency

### DIFF
--- a/src/components/Sidebar/sidebar.styles.ts
+++ b/src/components/Sidebar/sidebar.styles.ts
@@ -7,7 +7,6 @@ export const sidebarStyles = (
   container: {
     zIndex: 5,
     top: 0,
-    minHeight: '100vh',
     transition: 'width 0.3s ease, height 0.3s ease', // Add transition for smooth resizing
     [theme.breakpoints.down('lg')]: {
       height: collapsed ? 'fit-content' : '100%',

--- a/src/components/Sidebar/sidebar.styles.ts
+++ b/src/components/Sidebar/sidebar.styles.ts
@@ -7,7 +7,7 @@ export const sidebarStyles = (
   container: {
     zIndex: 5,
     top: 0,
-    height: '100vh',
+    minHeight: '100vh',
     transition: 'width 0.3s ease, height 0.3s ease', // Add transition for smooth resizing
     [theme.breakpoints.down('lg')]: {
       height: collapsed ? 'fit-content' : '100%',
@@ -46,6 +46,7 @@ export const sidebarStyles = (
     }
   },
   hamburgerBox: {
+    backgroundColor: 'background.paper',
     marginTop: 'auto',
     position: 'sticky',
     bottom: '0',


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Update sidebar styles to fix a bug with its height and transparency
<!--- Describe your changes in detail -->

#### Motivation and Context
Bug reported with the following ticket [P4ADEV-2529](https://pagopa.atlassian.net/browse/P4ADEV-2529)
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested manually and visually using the local FE instance

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/7d279996-e3dc-4fee-8810-30c2cc2976bd)

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


[P4ADEV-2529]: https://pagopa.atlassian.net/browse/P4ADEV-2529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ