### PR TITLE
fix: [P4ADEV-2369] simplify the management of the selected state in the SidebarMenuItem

### DIFF
--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -37,8 +37,6 @@ export const Sidebar: React.FC = () => {
   const { collapsed, changeMenuState, setCollapsed, setOverlay, overlay } =
     useCollapseMenu(!lg);
 
-  const [selectedTarget, setSelectedTarget] = useState('');
-
   useEffect(() => {
     setOverlay(!(lg || collapsed));
   }, [lg, collapsed]);
@@ -199,11 +197,7 @@ export const Sidebar: React.FC = () => {
           >
             {menuItems.map((item, index) => (
               <SidebarMenuItem
-                onClick={() =>
-                  !lg && setCollapsed(true) && setSelectedTarget('')
-                }
-                selectedTarget={selectedTarget}
-                setSelectedTarget={setSelectedTarget}
+                onClick={() => !lg && setCollapsed(true)}
                 collapsed={collapsed}
                 item={item}
                 key={index}
@@ -223,11 +217,7 @@ export const Sidebar: React.FC = () => {
           >
             {additionalItems.map((item, index) => (
               <SidebarMenuItem
-                onClick={() =>
-                  !lg && setCollapsed(true) && setSelectedTarget('')
-                }
-                selectedTarget={selectedTarget}
-                setSelectedTarget={setSelectedTarget}
+                onClick={() => !lg && setCollapsed(true)}
                 collapsed={collapsed}
                 item={item}
                 key={index}

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import {
   Box,
   Divider,

--- a/src/components/Sidebar/SidebarMenuItem.tsx
+++ b/src/components/Sidebar/SidebarMenuItem.tsx
@@ -8,7 +8,8 @@ import {
   useMediaQuery,
   type Theme,
   useTheme,
-  Box
+  Box,
+  SxProps
 } from '@mui/material';
 import { NavLink, useNavigate } from 'react-router-dom';
 import { alpha } from '@mui/material';
@@ -21,22 +22,56 @@ type Props = {
   collapsed: boolean;
   item: ISidebarMenuItem;
   onClick: React.MouseEventHandler<HTMLAnchorElement> | undefined;
-  selectedTarget: string;
-  setSelectedTarget: React.Dispatch<React.SetStateAction<string>>;
 };
 
 function renderIcon(Icon: React.ElementType) {
   return <Icon />;
 }
 
-export const SidebarMenuItem = ({
-  collapsed,
-  item,
-  onClick,
-  selectedTarget,
-  setSelectedTarget
-}: Props) => {
+type listItemProps = {
+  component: React.ElementType;
+  to?: string;
+  onClick?: (() => void) | React.MouseEventHandler<HTMLAnchorElement>;
+  item: ISidebarMenuItem;
+  children?: React.ReactNode;
+  sx?: SxProps<Theme>;
+};
+
+const ListItem = (props: listItemProps) => {
+  const { component, to = '', onClick, item, children, sx } = props;
   const theme = useTheme();
+  return (
+    <ListItemButton
+      component={component}
+      to={to}
+      onClick={onClick}
+      sx={{
+        px: 3,
+        '&.hover': {
+          backgroundColor: 'none'
+        },
+        '&.active': {
+          fontWeight: item.route && !item.items ? 'bold' : 'normal',
+          backgroundColor: alpha(theme.palette.primary.main, 0.08),
+          borderRight: '2px solid',
+          borderColor: theme.palette.primary.dark,
+          '.MuiTypography-root': {
+            fontWeight: 600,
+            color: theme.palette.primary.dark
+          },
+          '.MuiListItemIcon-root': {
+            color: theme.palette.primary.dark
+          }
+        },
+        ...sx
+      }}
+    >
+      {children}
+    </ListItemButton>
+  );
+};
+
+export const SidebarMenuItem = ({ collapsed, item, onClick }: Props) => {
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
   const lg = useMediaQuery((theme: Theme) => theme.breakpoints.up('lg'));
@@ -55,9 +90,7 @@ export const SidebarMenuItem = ({
     setOpen(!open);
   };
 
-  const handleListItemClick = (target: string, route?: string) => {
-    setSelectedTarget(target);
-
+  const handleListItemClick = (route?: string) => {
     if (route) {
       navigate(route);
       if (!lg) {
@@ -68,29 +101,11 @@ export const SidebarMenuItem = ({
 
   return (
     <Box sx={{ flexDirection: 'column', alignItems: 'stretch', width: '100%' }}>
-      <ListItemButton
+      <ListItem
+        item={item}
+        to={item.route}
         component={item.route && !item.items ? NavLink : 'div'}
-        to={item.route ?? ''}
         onClick={item.items ? handleCollapseClick : onClick}
-        sx={{
-          px: 3,
-          '&.hover': {
-            backgroundColor: 'none'
-          },
-          '&.active': {
-            fontWeight: item.route && !item.items ? 'bold' : 'normal',
-            backgroundColor: alpha(theme.palette.primary.main, 0.08),
-            borderRight: '2px solid',
-            borderColor: theme.palette.primary.dark,
-            '.MuiTypography-root': {
-              fontWeight: 600,
-              color: theme.palette.primary.dark
-            },
-            '.MuiListItemIcon-root': {
-              color: theme.palette.primary.dark
-            }
-          }
-        }}
       >
         {item.icon && (
           <ListItemIcon aria-hidden="true">
@@ -111,23 +126,23 @@ export const SidebarMenuItem = ({
           ) : (
             <ExpandMoreRoundedIcon color="action" />
           ))}
-      </ListItemButton>
+      </ListItem>
 
       {item.items && (
         <Collapse in={open && !collapsed} timeout="auto" unmountOnExit>
           <Box sx={{ pl: 1 }}>
             <List component="div" disablePadding>
-              {item.items.map((subitem, subindex) => (
-                <ListItemButton
+              {item.items.map((subitem) => (
+                <ListItem
+                  key={subitem.route}
+                  component={NavLink}
+                  to={subitem.route}
+                  item={subitem}
                   sx={{ pl: 8 }}
-                  selected={selectedTarget === `subitem-${subindex}`}
-                  onClick={() =>
-                    handleListItemClick(`subitem-${subindex}`, subitem.route)
-                  }
-                  key={subindex}
+                  onClick={() => handleListItemClick(subitem.route)}
                 >
-                  <ListItemText primary={subitem.label} key={subindex} />
-                </ListItemButton>
+                  <ListItemText primary={subitem.label} />
+                </ListItem>
               ))}
             </List>
           </Box>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Removed the unnecessary and error prone selectedTarget state in Sidebar component
- Give selected feedback through active state of NavLink component exported from react-router-dom

<!--- Describe your changes in detail -->

#### Motivation and Context

Bug reported with the following ticket [P4ADEV-2369](https://pagopa.atlassian.net/browse/P4ADEV-2369)
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

Tested manually and visually using the local FE instance

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


[P4ADEV-2369]: https://pagopa.atlassian.net/browse/P4ADEV-2369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ