### PR TITLE
feat: [P4ADEV-2614] debt position create api

### DIFF
--- a/src/api/debtPositionsTypes.ts
+++ b/src/api/debtPositionsTypes.ts
@@ -1,7 +1,11 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import utils from '../utils';
 import { parseAndLog } from '../utils/loaders';
-import { pagedDebtPositionTypeWithCountSchema } from '../../generated/zod-schema';
+import {
+  debtPositionTypeSchema,
+  pagedDebtPositionTypeWithCountSchema
+} from '../../generated/zod-schema';
+import { DebtPositionTypeRequestBody } from '../../generated/data-contracts';
 
 export const getDebtPositionsTypes = ({
   organizationId
@@ -56,5 +60,15 @@ export const getDebtPositionTypeWithCount = (
       }
 
       return response;
+    }
+  });
+
+export const postDebtPositionType = () =>
+  useMutation({
+    mutationKey: ['postDebtPositionType'],
+    mutationFn: async (query: DebtPositionTypeRequestBody) => {
+      const response = await utils.apiClient.bff.createDebtPositionType(query);
+      parseAndLog(debtPositionTypeSchema, response.data);
+      return response.data;
     }
   });

--- a/src/components/FormComponent/_TextField.tsx
+++ b/src/components/FormComponent/_TextField.tsx
@@ -5,9 +5,15 @@ import SearchRoundedIcon from '@mui/icons-material/SearchRounded';
 export type _TextFieldProps = Omit<TextFieldProps, 'type'> & {
   adornment?: React.ReactNode;
   forwardRef?: React.Ref<HTMLInputElement>;
+  noAdornment?: boolean;
 };
 
-export const _TextField = (props: _TextFieldProps) => (
+export const _TextField = ({
+  forwardRef,
+  noAdornment,
+  adornment,
+  ...props
+}: _TextFieldProps) => (
   <TextField
     data-testid={props.id}
     fullWidth
@@ -17,14 +23,14 @@ export const _TextField = (props: _TextFieldProps) => (
       }
     }}
     InputProps={{
-      endAdornment: (
+      endAdornment: noAdornment ? undefined : (
         <InputAdornment position="end">
-          {props?.adornment ?? <SearchRoundedIcon />}
+          {adornment ?? <SearchRoundedIcon />}
         </InputAdornment>
       )
     }}
     size="small"
     {...props}
-    ref={props.forwardRef}
+    ref={forwardRef}
   />
 );

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -126,7 +126,7 @@ export const Sidebar: React.FC = () => {
 
     debtypes.push({
       label: t('commons.routes.DEBT_TYPES_CREATED'),
-      route: PageRoutes.DEBT_TYPES_CATALOG,
+      route: PageRoutes.DEBT_TYPES_CREATED,
       end: true
     });
 
@@ -200,7 +200,7 @@ export const Sidebar: React.FC = () => {
                 onClick={() => !lg && setCollapsed(true)}
                 collapsed={collapsed}
                 item={item}
-                key={index}
+                key={`${item.label}-${index}`}
               />
             ))}
           </List>
@@ -220,7 +220,7 @@ export const Sidebar: React.FC = () => {
                 onClick={() => !lg && setCollapsed(true)}
                 collapsed={collapsed}
                 item={item}
-                key={index}
+                key={`${item.label}-${index}`}
               />
             ))}
           </List>

--- a/src/routes/DebtTypeCreate/DebtTypeCreate.test.tsx
+++ b/src/routes/DebtTypeCreate/DebtTypeCreate.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '../../__tests__/renderers';
 import { vi } from 'vitest';
 import { DebtTypeCreate } from '../DebtTypeCreate';
 import { Step1Props } from './components/Step1Configuration';
 import { Step2Props } from './components/Step2Settings';
 import { StepperContainerProps } from '../../components/Stepper';
+import { DebtPositionTypeRequestBody } from '../../../generated/apiClient';
 
 vi.mock('./components/Step1Configuration', () => ({
   Step1Configuration: ({ setData, onNext }: Step1Props) => (
@@ -11,12 +12,12 @@ vi.mock('./components/Step1Configuration', () => ({
       <button
         onClick={() => {
           setData({
-            debtPositionType: 'Test Debt Type',
-            debtPositionTypeCode: 'CODE1',
-            organizationType: 'ORG1',
-            macroAreaCode: 'MACRO1',
-            serviceTypeCode: 'SERVICE1',
-            collectionReason: 'REASON1',
+            description: 'Test Debt Type',
+            code: 'CODE1',
+            orgType: 'ORG1',
+            macroArea: 'MACRO1',
+            serviceType: 'SERVICE1',
+            collectingReason: 'REASON1',
             taxonomyCode: 'TAX1'
           });
           onNext();
@@ -35,12 +36,11 @@ vi.mock('./components/Step2Settings', () => ({
       <button
         onClick={() => {
           setData({
-            option1: true,
-            option2: false,
-            option3: true,
-            checkbox2: true,
-            textField: 'Test Subject',
-            textArea: 'Test Message'
+            flagMandatoryDueDate: true,
+            flagAnonymousFiscalCode: false,
+            flagNotifyIo: true,
+            ioTemplateSubject: 'Test Subject',
+            ioTemplateMessage: 'Test Message'
           });
           onNext();
         }}
@@ -60,10 +60,38 @@ vi.mock('../../components/Stepper', () => ({
   )
 }));
 
-const mockNavigate = vi.fn();
-vi.mock('react-router', () => ({
-  useNavigate: () => mockNavigate
+vi.mock('../../api/debtPositionsTypes', () => ({
+  postDebtPositionType: vi.fn(() => ({
+    mutate: (
+      _formData: DebtPositionTypeRequestBody,
+      { onSuccess }: { onSuccess: (data: DebtPositionTypeRequestBody) => void }
+    ) => {
+      onSuccess({
+        description: 'Test Debt Type',
+        code: 'CODE1',
+        orgType: 'ORG1',
+        macroArea: 'MACRO1',
+        serviceType: 'SERVICE1',
+        collectingReason: 'REASON1',
+        taxonomyCode: 'TAX1',
+        flagMandatoryDueDate: true,
+        flagAnonymousFiscalCode: false,
+        flagNotifyIo: true,
+        ioTemplateSubject: 'Test Subject',
+        ioTemplateMessage: 'Test Message'
+      });
+    }
+  }))
 }));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate
+  };
+});
 
 vi.mock('../../App', () => ({
   PageRoutes: {
@@ -136,24 +164,19 @@ describe('DebtTypeCreate', () => {
         replace: true,
         state: {
           formData: {
-            step1: {
-              debtPositionType: 'Test Debt Type',
-              debtPositionTypeCode: 'CODE1',
-              organizationType: 'ORG1',
-              macroAreaCode: 'MACRO1',
-              serviceTypeCode: 'SERVICE1',
-              collectionReason: 'REASON1',
-              taxonomyCode: 'TAX1'
-            },
-            step2: {
-              option1: true,
-              option2: false,
-              option3: true,
-              checkbox2: true,
-              textField: 'Test Subject',
-              textArea: 'Test Message'
-            }
-          }
+            description: 'Test Debt Type',
+            code: 'CODE1',
+            orgType: 'ORG1',
+            macroArea: 'MACRO1',
+            serviceType: 'SERVICE1',
+            collectingReason: 'REASON1',
+            taxonomyCode: 'TAX1',
+            flagMandatoryDueDate: true,
+            flagAnonymousFiscalCode: false,
+            flagNotifyIo: true,
+            ioTemplateSubject: 'Test Subject',
+            ioTemplateMessage: 'Test Message'
+          } as DebtPositionTypeRequestBody
         }
       });
     });

--- a/src/routes/DebtTypeCreate/DebtTypeCreateSuccess.test.tsx
+++ b/src/routes/DebtTypeCreate/DebtTypeCreateSuccess.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import { DebtTypeCreateSuccess } from './DebtTypeCreateSuccess';
 
@@ -20,9 +20,7 @@ vi.mock('react-router', () => ({
   useLocation: () => ({
     state: {
       formData: {
-        step1: {
-          debtPositionType: 'Test Debt Type'
-        }
+        description: 'Test Debt Type'
       }
     }
   })
@@ -50,16 +48,18 @@ describe('DebtTypeCreateSuccess', () => {
     vi.clearAllMocks();
   });
 
-  it('renders success message with correct debt type name', () => {
+  it('renders success message with correct debt type name', async () => {
     render(<DebtTypeCreateSuccess />);
 
     // Verify the success icon is displayed
     expect(screen.getByTestId('CheckCircleOutlineIcon')).toBeInTheDocument();
 
     // Verify the title includes the debt type name from location state
-    expect(
-      screen.getByText('debtTypeCreateSuccess.title Test Debt Type')
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByText('debtTypeCreateSuccess.title Test Debt Type')
+      ).toBeInTheDocument();
+    });
 
     // Verify the description is displayed
     expect(

--- a/src/routes/DebtTypeCreate/DebtTypeCreateSuccess.tsx
+++ b/src/routes/DebtTypeCreate/DebtTypeCreateSuccess.tsx
@@ -4,6 +4,7 @@ import { useLocation, useNavigate } from 'react-router';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { theme } from '@pagopa/mui-italia';
 import { PageRoutes } from '../../App';
+import { DebtPositionType } from '../../../generated/data-contracts';
 
 export const DebtTypeCreateSuccess = () => {
   const { t } = useTranslation();
@@ -11,7 +12,7 @@ export const DebtTypeCreateSuccess = () => {
   const location = useLocation();
 
   // TODO: error if no formData is provided
-  const formData = location.state?.formData || '';
+  const formData = location.state?.formData as DebtPositionType;
 
   return (
     <Box
@@ -44,20 +45,22 @@ export const DebtTypeCreateSuccess = () => {
           }}
         />
 
-        <Typography
-          variant="h4"
-          component="h1"
-          fontSize={24}
-          sx={{
-            fontWeight: 700,
-            textAlign: 'center',
-            maxWidth: (theme) => theme.spacing(50)
-          }}
-        >
-          {t('debtTypeCreateSuccess.title', {
-            paymentObject: formData.step1.debtPositionType
-          })}
-        </Typography>
+        {formData?.description && (
+          <Typography
+            variant="h4"
+            component="h1"
+            fontSize={24}
+            sx={{
+              fontWeight: 700,
+              textAlign: 'center',
+              maxWidth: (theme) => theme.spacing(50)
+            }}
+          >
+            {t('debtTypeCreateSuccess.title', {
+              paymentObject: formData.description
+            })}
+          </Typography>
+        )}
 
         <Typography
           fontSize={16}

--- a/src/routes/DebtTypeCreate/components/Step1Configuration.test.tsx
+++ b/src/routes/DebtTypeCreate/components/Step1Configuration.test.tsx
@@ -145,12 +145,12 @@ describe('Step1Configuration', () => {
 
     await waitFor(() => {
       expect(mockSetData).toHaveBeenCalledWith({
-        debtPositionTypeCode: 'DPT001',
-        debtPositionType: 'Debt Position Title',
-        organizationType: 'org1',
-        macroAreaCode: 'macro1',
-        serviceTypeCode: 'service1',
-        collectionReason: 'reason1',
+        code: 'DPT001',
+        collectingReason: 'reason1',
+        description: 'Debt Position Title',
+        macroArea: 'macro1',
+        orgType: 'org1',
+        serviceType: 'service1',
         taxonomyCode: 'tax1'
       });
       expect(mockOnNext).toHaveBeenCalled();

--- a/src/routes/DebtTypeCreate/components/Step1Configuration.tsx
+++ b/src/routes/DebtTypeCreate/components/Step1Configuration.tsx
@@ -20,16 +20,19 @@ import {
   getTaxonomyCode
 } from '../../../api/taxonomy';
 import { useFormDependencies } from '../../../hooks/useFormDependecies';
+import { DebtPositionTypeRequestBody } from '../../../../generated/data-contracts';
 
-export type Step1Data = {
-  debtPositionType: string;
-  debtPositionTypeCode: string;
-  organizationType: string;
-  macroAreaCode: string;
-  serviceTypeCode: string;
-  collectionReason: string;
-  taxonomyCode: string;
-};
+export type Step1Data = Partial<DebtPositionTypeRequestBody> &
+  Pick<
+    DebtPositionTypeRequestBody,
+    | 'description'
+    | 'code'
+    | 'orgType'
+    | 'macroArea'
+    | 'serviceType'
+    | 'collectingReason'
+    | 'taxonomyCode'
+  >;
 
 export type Step1Props = {
   setData: (data: Step1Data) => void;
@@ -39,25 +42,25 @@ export type Step1Props = {
 
 const validationSchema = (t: TFunction) =>
   z.object({
-    debtPositionType: z
+    code: z
+      .string()
+      .nonempty(t('debtTypeCreate.configuration.debtTypeCode.required')),
+    description: z
       .string()
       .nonempty(t('debtTypeCreate.configuration.debtType.required'))
       .max(100, t('debtTypeCreate.configuration.debtType.maxCharacters')),
-    debtPositionTypeCode: z
-      .string()
-      .nonempty(t('debtTypeCreate.configuration.debtTypeCode.required')),
-    organizationType: z.string({
+    orgType: z.string({
       required_error: t(
         'debtTypeCreate.configuration.organizationType.required'
       )
     }),
-    macroAreaCode: z.string({
+    macroArea: z.string({
       required_error: t('debtTypeCreate.configuration.macroArea.required')
     }),
-    serviceTypeCode: z.string({
+    serviceType: z.string({
       required_error: t('debtTypeCreate.configuration.serviceType.required')
     }),
-    collectionReason: z.string({
+    collectingReason: z.string({
       required_error: t(
         'debtTypeCreate.configuration.collectionReason.required'
       )
@@ -84,19 +87,19 @@ export const Step1Configuration = ({ setData, onNext, onBack }: Step1Props) => {
   } = form;
 
   const fieldOrder: Array<keyof Step1Data> = [
-    'organizationType',
-    'macroAreaCode',
-    'serviceTypeCode',
-    'collectionReason',
+    'orgType',
+    'macroArea',
+    'serviceType',
+    'collectingReason',
     'taxonomyCode'
   ];
 
   const { keys } = useFormDependencies({ form, fieldOrder });
 
-  const organizationType = watch('organizationType');
-  const macroAreaCode = watch('macroAreaCode');
-  const serviceTypeCode = watch('serviceTypeCode');
-  const collectionReason = watch('collectionReason');
+  const organizationType = watch('orgType');
+  const macroAreaCode = watch('macroArea');
+  const serviceTypeCode = watch('serviceType');
+  const collectionReason = watch('collectingReason');
 
   const isVisible = !!organizationType;
 
@@ -118,7 +121,7 @@ export const Step1Configuration = ({ setData, onNext, onBack }: Step1Props) => {
         >
           <Stack direction="row" spacing={3}>
             <Controller
-              name="debtPositionTypeCode"
+              name="code"
               control={control}
               defaultValue=""
               render={({ field }) => (
@@ -128,16 +131,16 @@ export const Step1Configuration = ({ setData, onNext, onBack }: Step1Props) => {
                   ref={null}
                   required
                   label={t('debtTypeCreate.configuration.debtTypeCode.label')}
-                  id="debtPositionTypeCode"
-                  error={!!errors.debtPositionTypeCode}
-                  helperText={errors.debtPositionTypeCode?.message}
-                  adornment={''}
+                  id="code"
+                  error={!!errors.code}
+                  helperText={errors.code?.message}
+                  noAdornment
                 />
               )}
             />
             <Stack flex={3}>
               <Controller
-                name="debtPositionType"
+                name="description"
                 control={control}
                 defaultValue=""
                 render={({ field }) => (
@@ -146,12 +149,12 @@ export const Step1Configuration = ({ setData, onNext, onBack }: Step1Props) => {
                     ref={null}
                     required
                     label={t('debtTypeCreate.configuration.debtType.label')}
-                    id="debtPositionType"
+                    id="description"
                     placeholder={t(
                       'debtTypeCreate.configuration.debtType.placeholder'
                     )}
-                    error={!!errors.debtPositionType}
-                    helperText={errors.debtPositionType?.message}
+                    error={!!errors.description}
+                    helperText={errors.description?.message}
                     adornment={`${field.value?.length}/100`}
                   />
                 )}
@@ -170,9 +173,9 @@ export const Step1Configuration = ({ setData, onNext, onBack }: Step1Props) => {
           <FormComponent.ControlledSelect
             control={control}
             label={t('debtTypeCreate.configuration.organizationType.label')}
-            name="organizationType"
+            name="orgType"
             fetchFn={getOrganizationsTypes}
-            key={keys.organizationType}
+            key={keys.orgType}
           />
 
           <Stack
@@ -183,9 +186,9 @@ export const Step1Configuration = ({ setData, onNext, onBack }: Step1Props) => {
             <FormComponent.ControlledSelect
               control={control}
               label={t('debtTypeCreate.configuration.macroArea.label')}
-              name="macroAreaCode"
+              name="macroArea"
               fetchFn={() => getMacroAreas({ organizationType })}
-              key={keys.macroAreaCode}
+              key={keys.macroArea}
               disabled={!organizationType}
             />
 
@@ -193,18 +196,18 @@ export const Step1Configuration = ({ setData, onNext, onBack }: Step1Props) => {
               <FormComponent.ControlledSelect
                 control={control}
                 label={t('debtTypeCreate.configuration.serviceType.label')}
-                name="serviceTypeCode"
+                name="serviceType"
                 fetchFn={() =>
                   getServiceTypes({ organizationType, macroAreaCode })
                 }
-                key={keys.serviceTypeCode}
+                key={keys.serviceType}
                 disabled={!macroAreaCode || !organizationType}
               />
 
               <FormComponent.ControlledSelect
                 control={control}
                 label={t('debtTypeCreate.configuration.collectionReason.label')}
-                name="collectionReason"
+                name="collectingReason"
                 fetchFn={() =>
                   getCollectionReasons({
                     organizationType,
@@ -212,7 +215,7 @@ export const Step1Configuration = ({ setData, onNext, onBack }: Step1Props) => {
                     macroAreaCode
                   })
                 }
-                key={keys.collectionReason}
+                key={keys.collectingReason}
                 disabled={
                   !serviceTypeCode || !macroAreaCode || !organizationType
                 }

--- a/src/routes/DebtTypeCreate/components/Step2Settings.test.tsx
+++ b/src/routes/DebtTypeCreate/components/Step2Settings.test.tsx
@@ -12,7 +12,7 @@ describe('Step2Settings', () => {
     vi.clearAllMocks();
   });
 
-  it('renders the form with all sections', () => {
+  it('renders the form with the correct sections', () => {
     render(
       <Step2Settings
         setData={mockSetData}
@@ -47,12 +47,6 @@ describe('Step2Settings', () => {
     // Check if form controls are rendered
     expect(
       screen.getByText('debtTypeCreate.settings.template.checkbox')
-    ).toBeInTheDocument();
-    expect(
-      screen.getByLabelText('debtTypeCreate.settings.subject.label')
-    ).toBeInTheDocument();
-    expect(
-      screen.getByLabelText('debtTypeCreate.settings.message.label')
     ).toBeInTheDocument();
   });
 
@@ -217,7 +211,7 @@ describe('Step2Settings', () => {
     expect(mockOnNext).not.toHaveBeenCalled();
   });
 
-  it('displays preview link', () => {
+  it('displays template elements when template checkbox is checked', async () => {
     render(
       <Step2Settings
         setData={mockSetData}
@@ -226,8 +220,22 @@ describe('Step2Settings', () => {
       />
     );
 
-    expect(
-      screen.getByText('debtTypeCreate.settings.preview')
-    ).toBeInTheDocument();
+    const checkbox2 = screen.getByText(
+      'debtTypeCreate.settings.template.checkbox'
+    );
+    fireEvent.click(checkbox2);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('debtTypeCreate.settings.subject.label')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('debtTypeCreate.settings.message.label')
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByText('debtTypeCreate.settings.preview')
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/src/routes/DebtTypeCreate/components/Step2Settings.test.tsx
+++ b/src/routes/DebtTypeCreate/components/Step2Settings.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import { Step2Settings } from './Step2Settings';
+import { DebtPositionTypeRequestBody } from '../../../../generated/data-contracts';
 
 describe('Step2Settings', () => {
   const mockSetData = vi.fn();
@@ -33,13 +34,14 @@ describe('Step2Settings', () => {
 
     // Check if options are rendered
     expect(
-      screen.getByText('debtTypeCreate.settings.option1.description')
+      screen.getByText(
+        'debtTypeCreate.settings.flagMandatoryDueDate.description'
+      )
     ).toBeInTheDocument();
     expect(
-      screen.getByText('debtTypeCreate.settings.option2.description')
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText('debtTypeCreate.settings.option3.description')
+      screen.getByText(
+        'debtTypeCreate.settings.flagAnonymousFiscalCode.description'
+      )
     ).toBeInTheDocument();
 
     // Check if form controls are rendered
@@ -68,13 +70,12 @@ describe('Step2Settings', () => {
 
     await waitFor(() => {
       expect(mockSetData).toHaveBeenCalledWith({
-        option1: false,
-        option2: false,
-        option3: false,
-        checkbox2: undefined,
-        textField: '',
-        textArea: ''
-      });
+        flagMandatoryDueDate: false,
+        flagAnonymousFiscalCode: false,
+        flagNotifyIo: undefined,
+        ioTemplateSubject: '',
+        ioTemplateMessage: ''
+      } as DebtPositionTypeRequestBody);
       expect(mockOnNext).toHaveBeenCalled();
     });
   });
@@ -120,18 +121,14 @@ describe('Step2Settings', () => {
     );
 
     // Check all options
-    const option1 = screen.getByText(
-      'debtTypeCreate.settings.option1.description'
+    const flagMandatoryDueDate = screen.getByText(
+      'debtTypeCreate.settings.flagMandatoryDueDate.description'
     );
-    const option2 = screen.getByText(
-      'debtTypeCreate.settings.option2.description'
+    const flagAnonymousFiscalCode = screen.getByText(
+      'debtTypeCreate.settings.flagAnonymousFiscalCode.description'
     );
-    const option3 = screen.getByText(
-      'debtTypeCreate.settings.option3.description'
-    );
-    fireEvent.click(option1);
-    fireEvent.click(option2);
-    fireEvent.click(option3);
+    fireEvent.click(flagMandatoryDueDate);
+    fireEvent.click(flagAnonymousFiscalCode);
 
     // Check checkbox2 and fill text fields
     const checkbox2 = screen.getByText(
@@ -154,13 +151,12 @@ describe('Step2Settings', () => {
 
     await waitFor(() => {
       expect(mockSetData).toHaveBeenCalledWith({
-        option1: true,
-        option2: true,
-        option3: true,
-        checkbox2: true,
-        textField: 'Subject text',
-        textArea: 'Message content'
-      });
+        flagMandatoryDueDate: true,
+        flagAnonymousFiscalCode: true,
+        flagNotifyIo: true,
+        ioTemplateSubject: 'Subject text',
+        ioTemplateMessage: 'Message content'
+      } as DebtPositionTypeRequestBody);
       expect(mockOnNext).toHaveBeenCalled();
     });
   });
@@ -185,13 +181,12 @@ describe('Step2Settings', () => {
 
     await waitFor(() => {
       expect(mockSetData).toHaveBeenCalledWith({
-        option1: false,
-        option2: false,
-        option3: false,
-        checkbox2: undefined,
-        textField: '',
-        textArea: ''
-      });
+        flagMandatoryDueDate: false,
+        flagAnonymousFiscalCode: false,
+        flagNotifyIo: undefined,
+        ioTemplateSubject: '',
+        ioTemplateMessage: ''
+      } as DebtPositionTypeRequestBody);
       expect(mockOnNext).toHaveBeenCalled();
     });
 

--- a/src/routes/DebtTypeCreate/components/Step2Settings.tsx
+++ b/src/routes/DebtTypeCreate/components/Step2Settings.tsx
@@ -135,104 +135,111 @@ export const Step2Settings = ({ onBack, setData, onNext }: Step2Props) => {
                 )}
               />
 
-              <Controller
-                name="ioTemplateSubject"
-                control={control}
-                defaultValue=""
-                render={({ field }) => (
-                  <FormComponent.TextField
-                    {...field}
-                    ref={null}
-                    required={flagNotifyIo}
-                    label={t('debtTypeCreate.settings.subject.label')}
-                    placeholder={t(
-                      'debtTypeCreate.settings.subject.placeholder'
-                    )}
-                    error={flagNotifyIo && !!errors.ioTemplateSubject}
-                    helperText={
-                      flagNotifyIo && errors.ioTemplateSubject?.message
-                    }
-                    fullWidth
-                    sx={{ my: 2 }}
-                  />
-                )}
-              />
-              <Typography
-                variant="body2"
-                color="textSecondary"
-                component="span"
-              >
-                <Trans
-                  i18nKey="debtTypeCreate.settings.subject.guide"
-                  components={[
-                    <Link
-                      key="link"
-                      href="#"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      underline="none"
-                    />
-                  ]}
-                />
-              </Typography>
-
-              <Controller
-                name="ioTemplateMessage"
-                control={control}
-                render={({ field }) => (
-                  <TextField
-                    required={flagNotifyIo}
-                    label={t('debtTypeCreate.settings.message.label')}
-                    InputLabelProps={{ shrink: true }}
-                    error={flagNotifyIo && !!errors.ioTemplateMessage}
-                    helperText={
-                      flagNotifyIo && errors.ioTemplateMessage?.message
-                    }
+              {flagNotifyIo && (
+                <Stack>
+                  <Controller
+                    name="ioTemplateSubject"
+                    control={control}
                     defaultValue=""
-                    fullWidth
-                    multiline
-                    rows={7}
-                    sx={{ my: 2 }}
-                    {...field}
+                    render={({ field }) => (
+                      <FormComponent.TextField
+                        {...field}
+                        ref={null}
+                        noAdornment
+                        required={flagNotifyIo}
+                        label={t('debtTypeCreate.settings.subject.label')}
+                        placeholder={t(
+                          'debtTypeCreate.settings.subject.placeholder'
+                        )}
+                        error={flagNotifyIo && !!errors.ioTemplateSubject}
+                        helperText={
+                          flagNotifyIo && errors.ioTemplateSubject?.message
+                        }
+                        fullWidth
+                        sx={{ my: 2 }}
+                      />
+                    )}
                   />
-                )}
-              />
-
-              <Typography
-                variant="body2"
-                color="textSecondary"
-                component="span"
-              >
-                <Trans
-                  i18nKey="debtTypeCreate.settings.message.guide"
-                  components={[
-                    <Link
-                      key="link"
-                      href="#"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      underline="none"
-                    />,
-                    <Link
-                      key="link"
-                      href="#"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      underline="none"
+                  <Typography
+                    variant="body2"
+                    color="textSecondary"
+                    component="span"
+                  >
+                    <Trans
+                      i18nKey="debtTypeCreate.settings.subject.guide"
+                      components={[
+                        <Link
+                          key="link"
+                          href="#"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          underline="none"
+                        />
+                      ]}
                     />
-                  ]}
-                />
-              </Typography>
+                  </Typography>
+
+                  <Controller
+                    name="ioTemplateMessage"
+                    control={control}
+                    render={({ field }) => (
+                      <TextField
+                        required={flagNotifyIo}
+                        label={t('debtTypeCreate.settings.message.label')}
+                        InputLabelProps={{ shrink: true }}
+                        error={flagNotifyIo && !!errors.ioTemplateMessage}
+                        helperText={
+                          flagNotifyIo && errors.ioTemplateMessage?.message
+                        }
+                        defaultValue=""
+                        fullWidth
+                        multiline
+                        rows={7}
+                        sx={{ my: 2 }}
+                        {...field}
+                      />
+                    )}
+                  />
+
+                  <Typography
+                    variant="body2"
+                    color="textSecondary"
+                    component="span"
+                  >
+                    <Trans
+                      i18nKey="debtTypeCreate.settings.message.guide"
+                      components={[
+                        <Link
+                          key="link"
+                          href="#"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          underline="none"
+                        />,
+                        <Link
+                          key="link"
+                          href="#"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          underline="none"
+                        />
+                      ]}
+                    />
+                  </Typography>
+                </Stack>
+              )}
             </Stack>
-            <Stack
-              sx={{ whiteSpace: 'nowrap' }}
-              direction="row"
-              gap={1}
-              color="primary.main"
-            >
-              <PreviewIcon />
-              <Link>{t('debtTypeCreate.settings.preview')}</Link>
-            </Stack>
+            {flagNotifyIo && (
+              <Stack
+                sx={{ whiteSpace: 'nowrap' }}
+                direction="row"
+                gap={1}
+                color="primary.main"
+              >
+                <PreviewIcon />
+                <Link>{t('debtTypeCreate.settings.preview')}</Link>
+              </Stack>
+            )}
           </Stack>
         </SectionBox>
       </WizardStepWrapper>

--- a/src/routes/DebtTypeCreate/components/Step2Settings.tsx
+++ b/src/routes/DebtTypeCreate/components/Step2Settings.tsx
@@ -19,15 +19,17 @@ import WizardStepWrapper from '../../../components/Wizard/WizardStepWrapper';
 import SectionBox from '../../../components/Wizard/SectionBox';
 import WizardStepButtons from '../../../components/Wizard/WizardStepButtons';
 import { FormComponent } from '../../../components/FormComponent';
+import { DebtPositionTypeRequestBody } from '../../../../generated/data-contracts';
 
-export type Step2Data = {
-  option1?: boolean;
-  option2?: boolean;
-  option3?: boolean;
-  checkbox2?: boolean;
-  textField?: string;
-  textArea?: string;
-};
+export type Step2Data = Partial<DebtPositionTypeRequestBody> &
+  Pick<
+    DebtPositionTypeRequestBody,
+    | 'flagMandatoryDueDate'
+    | 'flagAnonymousFiscalCode'
+    | 'flagNotifyIo'
+    | 'ioTemplateSubject'
+    | 'ioTemplateMessage'
+  >;
 
 export type Step2Props = {
   setData: (data: Step2Data) => void;
@@ -40,20 +42,19 @@ export const Step2Settings = ({ onBack, setData, onNext }: Step2Props) => {
 
   const schema = z
     .object({
-      option1: z.boolean().optional(),
-      option2: z.boolean().optional(),
-      option3: z.boolean().optional(),
-      checkbox2: z.boolean().optional(),
-      textField: z.string().optional().default(''),
-      textArea: z.string().optional().default('')
+      flagMandatoryDueDate: z.boolean().optional(),
+      flagAnonymousFiscalCode: z.boolean().optional(),
+      flagNotifyIo: z.boolean().optional(),
+      ioTemplateSubject: z.string().optional().default(''),
+      ioTemplateMessage: z.string().optional().default('')
     })
-    .refine((data) => !data.checkbox2 || data.textField, {
+    .refine((data) => !data.flagNotifyIo || data.ioTemplateSubject, {
       message: t('debtTypeCreate.settings.subject.required'),
-      path: ['textField'] // Targets the textField property
+      path: ['ioTemplateSubject'] // Targets the ioTemplateSubject property
     })
-    .refine((data) => !data.checkbox2 || data.textArea, {
+    .refine((data) => !data.flagNotifyIo || data.ioTemplateMessage, {
       message: t('debtTypeCreate.settings.message.required'),
-      path: ['textArea']
+      path: ['ioTemplateMessage']
     });
 
   const {
@@ -71,8 +72,11 @@ export const Step2Settings = ({ onBack, setData, onNext }: Step2Props) => {
     onNext();
   };
 
-  const options: Array<keyof Step2Data> = ['option1', 'option2', 'option3'];
-  const checkbox2 = watch('checkbox2');
+  const options: Array<keyof Step2Data> = [
+    'flagMandatoryDueDate',
+    'flagAnonymousFiscalCode'
+  ];
+  const flagNotifyIo = watch('flagNotifyIo');
 
   return (
     <form>
@@ -121,7 +125,7 @@ export const Step2Settings = ({ onBack, setData, onNext }: Step2Props) => {
           <Stack direction="row" gap={2} alignItems="center" width="100%">
             <Stack>
               <Controller
-                name="checkbox2"
+                name="flagNotifyIo"
                 control={control}
                 render={({ field }) => (
                   <FormControlLabel
@@ -132,20 +136,22 @@ export const Step2Settings = ({ onBack, setData, onNext }: Step2Props) => {
               />
 
               <Controller
-                name="textField"
+                name="ioTemplateSubject"
                 control={control}
                 defaultValue=""
                 render={({ field }) => (
                   <FormComponent.TextField
                     {...field}
                     ref={null}
-                    required={checkbox2}
+                    required={flagNotifyIo}
                     label={t('debtTypeCreate.settings.subject.label')}
                     placeholder={t(
                       'debtTypeCreate.settings.subject.placeholder'
                     )}
-                    error={checkbox2 && !!errors.textField}
-                    helperText={checkbox2 && errors.textField?.message}
+                    error={flagNotifyIo && !!errors.ioTemplateSubject}
+                    helperText={
+                      flagNotifyIo && errors.ioTemplateSubject?.message
+                    }
                     fullWidth
                     sx={{ my: 2 }}
                   />
@@ -171,15 +177,17 @@ export const Step2Settings = ({ onBack, setData, onNext }: Step2Props) => {
               </Typography>
 
               <Controller
-                name="textArea"
+                name="ioTemplateMessage"
                 control={control}
                 render={({ field }) => (
                   <TextField
-                    required={checkbox2}
+                    required={flagNotifyIo}
                     label={t('debtTypeCreate.settings.message.label')}
                     InputLabelProps={{ shrink: true }}
-                    error={checkbox2 && !!errors.textArea}
-                    helperText={checkbox2 && errors.textArea?.message}
+                    error={flagNotifyIo && !!errors.ioTemplateMessage}
+                    helperText={
+                      flagNotifyIo && errors.ioTemplateMessage?.message
+                    }
                     defaultValue=""
                     fullWidth
                     multiline

--- a/src/routes/DebtTypeCreate/index.tsx
+++ b/src/routes/DebtTypeCreate/index.tsx
@@ -7,30 +7,22 @@ import { Step2Data, Step2Settings } from './components/Step2Settings';
 import { useNavigate } from 'react-router';
 import { PageRoutes } from '../../App';
 import { useSignal } from '@preact/signals-react';
+import { postDebtPositionType } from '../../api/debtPositionsTypes';
+import { DebtPositionTypeRequestBody } from '../../../generated/data-contracts';
 
-type FormData = {
-  step1: Step1Data;
-  step2: Step2Data;
-};
-
-const initialData: FormData = {
-  step1: {
-    debtPositionType: '',
-    debtPositionTypeCode: '',
-    organizationType: '',
-    macroAreaCode: '',
-    serviceTypeCode: '',
-    collectionReason: '',
-    taxonomyCode: ''
-  },
-  step2: {
-    option1: false,
-    option2: false,
-    option3: false,
-    checkbox2: false,
-    textField: '',
-    textArea: ''
-  }
+const initialData: DebtPositionTypeRequestBody = {
+  code: '',
+  description: '',
+  orgType: '',
+  macroArea: '',
+  serviceType: '',
+  collectingReason: '',
+  taxonomyCode: '',
+  flagMandatoryDueDate: false,
+  flagAnonymousFiscalCode: false,
+  flagNotifyIo: false,
+  ioTemplateSubject: '',
+  ioTemplateMessage: ''
 };
 
 export const DebtTypeCreate = () => {
@@ -38,14 +30,20 @@ export const DebtTypeCreate = () => {
   const navigate = useNavigate();
 
   const [step, setStep] = useState(0);
-  const formData = useSignal<FormData>(initialData);
+  const formData = useSignal<DebtPositionTypeRequestBody>(initialData);
+  const debtTypeCreate = postDebtPositionType();
 
   const submit = () => {
-    navigate(PageRoutes.DEBT_TYPE_CREATE_SUCCESS, {
-      replace: true,
-      state: {
-        formData: formData.value
-      }
+    debtTypeCreate.mutate(formData.value, {
+      onSuccess: (formData) => {
+        navigate(PageRoutes.DEBT_TYPE_CREATE_SUCCESS, {
+          replace: true,
+          state: {
+            formData
+          }
+        });
+      },
+      onError: console.error
     });
   };
 
@@ -56,7 +54,7 @@ export const DebtTypeCreate = () => {
         <Step1Configuration
           key="step1"
           setData={(data: Step1Data) => {
-            formData.value = { ...formData.value, step1: data };
+            formData.value = { ...formData.value, ...data };
           }}
           onNext={() => setStep(1)}
           onBack={() => navigate(PageRoutes.DEBT_TYPES_CATALOG)}
@@ -70,7 +68,7 @@ export const DebtTypeCreate = () => {
         <Step2Settings
           key="step2"
           setData={(data: Step2Data) => {
-            formData.value = { ...formData.value, step2: data };
+            formData.value = { ...formData.value, ...data };
           }}
           onBack={() => setStep(0)}
           onNext={submit}

--- a/src/routes/debtTypes.tsx
+++ b/src/routes/debtTypes.tsx
@@ -24,6 +24,15 @@ export const debtTypesRoutes = [
         } as RouteHandleObject
       },
       {
+        id: 'DEBT_TYPES_CREATED',
+        path: 'catalog-created',
+        element: <DebtTypes />,
+        handle: {
+          backButton: false,
+          hideBreadcrumbs: true
+        } as RouteHandleObject
+      },
+      {
         id: 'DEBT_TYPE_CATALOG_DETAIL',
         path: 'catalog/detail/:debtPositionTypeId',
         element: <DebtTypeDetailView />,

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -545,6 +545,7 @@
         "required": "Il Motivo Riscossione é obbligatorio"
       },
       "debtType": {
+        "label": "Nome del Tipo dovuto",
         "helper": "Inserisce il nome attribuito al servizio di incasso",
         "maxCharacters": "Il nome del Tipo dovuto deve avere al massimo 100 caratteri",
         "placeholder": "Inserisce il nome attribuito al servizio di incasso",
@@ -583,17 +584,13 @@
         "label": "Messaggio",
         "required": "il messaggio é obbligatorio"
       },
-      "option1": {
+      "flagMandatoryDueDate": {
         "description": "Data di Scadenza Obbligatoria",
         "subtitle": "Imposta la Data di Scadenza un campo obbligatorio nella creazione."
       },
-      "option2": {
+      "flagAnonymousFiscalCode": {
         "description": "Codice Fiscale Anonimo",
         "subtitle": "Permette di creare dovuti senza segnalare un Codice Fiscale nel caso di assenza."
-      },
-      "option3": {
-        "description": "Pagamento Spontaneo",
-        "subtitle": "Il tipo dovuto può essere utilizzato per pagamenti spontanei"
       },
       "preview": "Vedi anteprima",
       "subject": {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- debt position type create api
- fixes debt type routing
- add noAdornment prop to FormComponent.TextField
- adds test utils to check for mui select values

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Enables creation of debt position types.

N.B. There is a known bug when selecting organizationType 13 during step1, 
the resulting 2 macroArea have the same code, so both get selectet when
selecting one of the two.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- unit tests
- visual testing
#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
