### PR TITLE
feat: [P4ADEV-2712] Auto-select first available organization when stored ID is invalid

### DIFF
--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -94,4 +94,45 @@ describe('Header component', () => {
 
     mockStorage.mockRestore();
   });
+
+  it('should not render anything when organizations.isSuccess is false', () => {
+    // @ts-expect-error mock not success
+    mockUseOrganizations.mockReturnValue({
+      data: null,
+      isSuccess: false
+    });
+
+    const { container } = render(<Header />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('should not render HeaderProduct when organizations data is empty', () => {
+    // @ts-expect-error mock empty data
+    mockUseOrganizations.mockReturnValue({
+      data: [],
+      isSuccess: true
+    });
+
+    const { container } = render(<Header />);
+
+    expect(container.innerHTML).not.toBe('');
+    expect(screen.queryByText('Piattaforma Unitaria')).not.toBeInTheDocument();
+  });
+
+  it('should call onDocumentationClick when documentation button is clicked', () => {
+    const onDocumentationClick = vi.fn();
+    render(<Header onDocumentationClick={onDocumentationClick} />);
+
+    fireEvent.click(screen.getByText('Manuale operativo'));
+    expect(onDocumentationClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should navigate to home page when clicking on user data menu item', () => {
+    render(<Header />);
+
+    fireEvent.click(screen.getByText('Marco Polo'));
+    fireEvent.click(screen.getByText('I tuoi dati'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/');
+  });
 });

--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -42,7 +42,7 @@ describe('Header component', () => {
           orgFiscalCode: 'XXXXXXX',
           flagNotifyIo: false,
           flagNotifyOutcomePush: false,
-          flagPaymentNotification: false,
+          flagPaymentNotification: false
         }
       ],
       isSuccess: true

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import {
   HeaderAccount,
   HeaderProduct,
@@ -28,12 +29,42 @@ export const Header = (props: HeaderProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { state } = useStore();
-
   const organizations = useOrganizations();
   const userInfo = useUserInfo();
+  const [isInitialized, setIsInitialized] = useState(false);
 
   const { onAssistanceClick = () => null } = props;
   const { onDocumentationClick = () => null } = props;
+
+  // this useEffect initializes the selected organization based on saved state when data is loaded
+  useEffect(() => {
+    if (organizations.isSuccess && organizations.data && !isInitialized) {
+      const savedOrgId = state?.organizationId;
+
+      if (savedOrgId) {
+        const orgExists = organizations.data.some(
+          (org) => org.organizationId === savedOrgId
+        );
+
+        if (orgExists) {
+          setOrganizationId(savedOrgId);
+          const matchedOrg = organizations.data.find(
+            (org) => org.organizationId === savedOrgId
+          );
+          if (matchedOrg) {
+            setOperatorRole(matchedOrg.operatorRole);
+          }
+        }
+      }
+
+      setIsInitialized(true);
+    }
+  }, [
+    organizations.isSuccess,
+    organizations.data,
+    isInitialized,
+    state?.organizationId
+  ]);
 
   const jwtUser: JwtUser | undefined = userInfo
     ? {
@@ -50,6 +81,20 @@ export const Header = (props: HeaderProps) => {
       name: item.orgName || t('commons.unknownOrganization'),
       productRole: item.operatorRole
     })) || [];
+
+  const currentOrgExists =
+    state?.organizationId &&
+    organizationsToMenuItems.some(
+      (item) => Number(item.id) === state.organizationId
+    );
+
+  let partyIdToUse: string | undefined;
+
+  if (currentOrgExists && state?.organizationId) {
+    partyIdToUse = state.organizationId.toString();
+  } else if (organizationsToMenuItems.length > 0) {
+    partyIdToUse = organizationsToMenuItems[0].id;
+  }
 
   async function logoutUser() {
     try {
@@ -93,7 +138,7 @@ export const Header = (props: HeaderProps) => {
     navigate(0);
   };
 
-  return organizations.isSuccess ? (
+  return organizations.isSuccess && isInitialized ? (
     <>
       <HeaderAccount
         rootLink={utils.config.pagopaLink}
@@ -103,16 +148,14 @@ export const Header = (props: HeaderProps) => {
         loggedUser={jwtUser}
         userActions={userActions}
       />
-      {state?.organizationId ? (
+      {partyIdToUse && organizationsToMenuItems.length > 0 ? (
         <HeaderProduct
           onSelectedParty={onSelectedParty}
-          partyId={state?.organizationId?.toString()}
+          partyId={partyIdToUse}
           partyList={organizationsToMenuItems}
           productsList={[product]}
         />
-      ) : (
-        ''
-      )}
+      ) : null}
     </>
   ) : null;
 };

--- a/src/hooks/useOrganizations.test.ts
+++ b/src/hooks/useOrganizations.test.ts
@@ -85,7 +85,54 @@ describe('useOrganizations', () => {
     expect(mockSetOpRole).toHaveBeenCalledWith('ROLE_ADMIN');
   });
 
-  it('should use the first organization if no match is found', () => {
+  it('should handle empty organizations data', () => {
+    (utils.loaders.getOrganizations as Mock).mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+      isSuccess: true
+    });
+
+    mockSetOrgId.mockClear();
+    mockSetOpRole.mockClear();
+
+    renderHook(() => useOrganizations());
+
+    expect(mockSetOrgId).not.toHaveBeenCalled();
+    expect(mockSetOpRole).not.toHaveBeenCalled();
+  });
+
+  it('should handle loading state', () => {
+    (utils.loaders.getOrganizations as Mock).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      isSuccess: false
+    });
+
+    mockSetOrgId.mockClear();
+    mockSetOpRole.mockClear();
+
+    renderHook(() => useOrganizations());
+
+    expect(mockSetOrgId).not.toHaveBeenCalled();
+    expect(mockSetOpRole).not.toHaveBeenCalled();
+  });
+
+  it('should handle case when idToken has no organization info', () => {
+    vi.mock('../store/GlobalStore', async () => {
+      const actual = await vi.importActual('../store/GlobalStore');
+      return {
+        ...actual,
+        useStore: () => ({
+          state: {
+            organizationId: undefined,
+            idToken: null
+          }
+        })
+      };
+    });
+
     const mockData = [
       {
         orgFiscalCode: '99999999999',
@@ -102,9 +149,10 @@ describe('useOrganizations', () => {
       isSuccess: true
     });
 
-    renderHook(() => useOrganizations(), {
-      wrapper: StoreProvider
-    });
+    mockSetOrgId.mockClear();
+    mockSetOpRole.mockClear();
+
+    renderHook(() => useOrganizations());
 
     expect(mockSetOrgId).toHaveBeenCalledWith(3);
     expect(mockSetOpRole).toHaveBeenCalledWith('ROLE_OPER');

--- a/src/hooks/useOrganizations.ts
+++ b/src/hooks/useOrganizations.ts
@@ -40,7 +40,7 @@ export const useOrganizations = () => {
       }
 
       if (query.isError) {
-        console.error('Failed to fetch organizations', query.error);
+        console.error('Failed to fetch fe config', query.error);
       }
     }
   }, [

--- a/src/hooks/useOrganizations.ts
+++ b/src/hooks/useOrganizations.ts
@@ -12,22 +12,35 @@ export const useOrganizations = () => {
   const { data, ...query } = utils.loaders.getOrganizations();
 
   useEffect(() => {
-    if (!organizationId && data) {
-      const initOrganization = data.find(
-        (org) =>
-          org.orgFiscalCode === idToken?.organization.fiscal_code &&
-          org.ipaCode === idToken.organization.ipaCode
-      );
+    if (data && data.length > 0) {
+      const currentOrgExists =
+        organizationId &&
+        data.some((org) => org.organizationId === organizationId);
 
-      const firstOrganization = initOrganization || data[0];
-      if (firstOrganization) {
-        setOrganizationId(firstOrganization.organizationId);
-        setOperatorRole(firstOrganization.operatorRole);
+      if (!currentOrgExists) {
+        const savedOrg = organizationId
+          ? data.find((org) => org.organizationId === organizationId)
+          : null;
+
+        const idTokenMatchedOrg =
+          !savedOrg && idToken
+            ? data.find(
+                (org) =>
+                  org.orgFiscalCode === idToken.organization.fiscal_code &&
+                  org.ipaCode === idToken.organization.ipaCode
+              )
+            : null;
+
+        const orgToSelect = savedOrg || idTokenMatchedOrg || data[0];
+
+        if (orgToSelect) {
+          setOrganizationId(orgToSelect.organizationId);
+          setOperatorRole(orgToSelect.operatorRole);
+        }
       }
 
       if (query.isError) {
-        // TODO: Handle error (e.g., show a toast)
-        console.error('Failed to fetch fe config', query.error);
+        console.error('Failed to fetch organizations', query.error);
       }
     }
   }, [

--- a/src/utils/__tests__/loaders.test.tsx
+++ b/src/utils/__tests__/loaders.test.tsx
@@ -43,7 +43,7 @@ describe('loaders', () => {
           orgFiscalCode: '123456789',
           flagNotifyIo: false,
           flagNotifyOutcomePush: false,
-          flagPaymentNotification: false,
+          flagPaymentNotification: false
         }
       ];
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

This PR handles the case where an organizationId stored in the browser doesn't match any organization returned by getOrganization API. This situation occurs when a user returns to selfcare and switches accounts without logging out first. The fix implements automatic selection of the first available organization when this mismatch is detected.

#### List of Changes

<!--- Describe your changes in detail -->

- Fix invalid organizationId handling
- Auto-select first available organization

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- visual testing
- unit tests

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
