### PR TITLE
feat: [P4ADEV-2691] IO message preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "react-markdown": "^9.0.3",
     "react-router": "^7.0.0",
     "react-router-dom": "^7.0.0",
+    "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
+    "remark-breaks": "^4.0.0",
     "whatwg-fetch": "^3.6.20"
   },
   "devDependencies": {

--- a/src/components/GenericDialog/GenericDialog.tsx
+++ b/src/components/GenericDialog/GenericDialog.tsx
@@ -6,13 +6,16 @@ import {
   DialogActions,
   Button
 } from '@mui/material';
+import { ReactNode } from 'react';
 
 type GenericDialogProps = {
   open: boolean;
   title: string;
-  message: string;
+  message?: string;
   confirmLabel?: string;
   cancelLabel?: string;
+  children?: ReactNode;
+  fullWidth?: boolean;
   onConfirm?: () => void;
   onClose?: () => void;
 };
@@ -23,14 +26,17 @@ const GenericDialog = ({
   message,
   confirmLabel,
   cancelLabel,
+  children,
+  fullWidth = false,
   onConfirm,
   onClose
 }: GenericDialogProps) => {
   return (
-    <Dialog open={open} onClose={onClose}>
+    <Dialog open={open} onClose={onClose} fullWidth={fullWidth}>
       <DialogTitle sx={{ px: 4, pt: 4 }}>{title}</DialogTitle>
       <DialogContent sx={{ px: 4 }}>
-        <DialogContentText>{message}</DialogContentText>
+        {message && <DialogContentText>{message}</DialogContentText>}
+        {children}
       </DialogContent>
       <DialogActions sx={{ px: 4, pb: 3 }}>
         {cancelLabel && (

--- a/src/routes/DebtTypeCreate/components/MarkdownPreview.test.tsx
+++ b/src/routes/DebtTypeCreate/components/MarkdownPreview.test.tsx
@@ -1,0 +1,21 @@
+import { render } from '../../../__tests__/renderers';
+import { screen } from '@testing-library/react';
+import { describe, it, vi, expect } from 'vitest';
+import { MarkdownPreview } from './MarkdownPreview';
+
+const defaultProps = {
+  title: 'Test Title',
+  message: 'Test message for %debitore_nomeCompleto%',
+  open: true,
+  onConfirm: vi.fn(),
+  onClose: vi.fn()
+};
+
+describe('MarkdownPreview', () => {
+  it('renders title and message, using a placeholder ', () => {
+    render(<MarkdownPreview {...defaultProps} />);
+
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
+    expect(screen.getByText('Mario Rossi')).toBeInTheDocument();
+  });
+});

--- a/src/routes/DebtTypeCreate/components/MarkdownPreview.tsx
+++ b/src/routes/DebtTypeCreate/components/MarkdownPreview.tsx
@@ -1,0 +1,102 @@
+import { useTranslation } from 'react-i18next';
+import GenericDialog from '../../../components/GenericDialog/GenericDialog';
+import { useTheme } from '@mui/material';
+import ReactMarkdown from 'react-markdown';
+import remarkBreaks from 'remark-breaks';
+import rehypeRaw from 'rehype-raw';
+import './markdownpreview.css';
+
+type MarkdownPreviewProps = {
+  title?: string;
+  message?: string;
+  open: boolean;
+  onClose: () => void;
+};
+
+const placeholders: Record<string, string> = {
+  '%posizioneDebitoria_descrizione%': 'Pagamento TARI',
+  '%debitore_nomeCompleto%': 'Mario Rossi',
+  '%debitore_codiceFiscale%': 'RSSMRA80R11A123H',
+  '%importoTotale%': '120 €',
+  '%IUV%': '82000000000',
+  '%NAV%': '0000 0000 0000 0000 00',
+  '%causale%': 'Causale del pagamento',
+  '%dataScadenza%': '12/04/2099'
+};
+
+/**
+ * `MarkdownPreview` shows a content in a modal window with the content rendered by markdown.
+ *
+ * This component allows you to use predefined placeholders to convert them into dynamic data.
+ *
+ * This componente uses:
+ * - `ReactMarkdown` for parsing & rendering markdown.
+ * - `rehype-raw` to enable HTML inline in the markdown.
+ * - `remark-breaks` to support breakline as `\n`.
+ * - `GenericDialog` to wrap all in a modal window.
+ *
+ * @component
+ *
+ * @param {Object} props - Component props
+ * @param {string} [props.title] - Dialog title (usually the subject)
+ * @param {string} [props.message] - Dialog message (usually the message)
+ * @param {boolean} props.open - Flag to show/hide dialog message
+ * @param {Function} props.onClose - Callback to use when the dialog windows closes.
+ *
+ * @returns {JSX.Element} Component `MarkdownPreview` rendered
+ */
+export const MarkdownPreview = ({
+  title,
+  message,
+  open,
+  onClose
+}: MarkdownPreviewProps) => {
+  const theme = useTheme();
+  const secondaryColor = theme.palette.text.secondary;
+  const { t } = useTranslation();
+
+  /**
+   * Replaces all placeholders defined in the `placeholders` dictionary with their respective values in the provided text, highlighting them with a specific style.
+   *
+   * Each placeholder (e.g. `%debtor_fullname%`) is replaced with `<span>` containing the replacement text
+   * and an inline style that applies a secondary color.
+   *
+   * @param {string} inputText - The original text which may contain placeholders
+   * @returns {string} The modified text with placeholders replaced by highlighted HTML
+   */
+  const renderTextWithPlaceholders = (inputText: string) => {
+    let modifiedText = inputText;
+    Object.keys(placeholders).forEach((placeholder: string) => {
+      const regex = new RegExp(placeholder, 'g');
+      modifiedText = modifiedText.replace(
+        regex,
+        `<span class="highlighted" style="color: ${secondaryColor} ">${placeholders[placeholder]}</span>`
+      );
+    });
+
+    return modifiedText;
+  };
+
+  return (
+    <GenericDialog
+      data-testid="confirm-dialog"
+      open={open}
+      title={title || ''}
+      cancelLabel={t('commons.close')}
+      onClose={onClose}
+      fullWidth={true}
+    >
+      <ReactMarkdown
+        rehypePlugins={[rehypeRaw]}
+        remarkPlugins={[remarkBreaks]}
+        components={{
+          span: ({ ...props }) => {
+            return <span {...props} />;
+          }
+        }}
+      >
+        {renderTextWithPlaceholders(message || '')}
+      </ReactMarkdown>
+    </GenericDialog>
+  );
+};

--- a/src/routes/DebtTypeCreate/components/Step2Settings.tsx
+++ b/src/routes/DebtTypeCreate/components/Step2Settings.tsx
@@ -5,14 +5,14 @@ import { z } from 'zod';
 import { Trans, useTranslation } from 'react-i18next';
 import {
   Box,
+  Button,
   Checkbox,
   FormControlLabel,
   FormGroup,
   Link,
   Stack,
   TextField,
-  Typography,
-  useTheme
+  Typography
 } from '@mui/material';
 import TuneIcon from '@mui/icons-material/Tune';
 import MessageIcon from '@mui/icons-material/Message';
@@ -20,11 +20,9 @@ import WizardStepWrapper from '../../../components/Wizard/WizardStepWrapper';
 import SectionBox from '../../../components/Wizard/SectionBox';
 import WizardStepButtons from '../../../components/Wizard/WizardStepButtons';
 import { FormComponent } from '../../../components/FormComponent';
-import ReactMarkdown from 'react-markdown';
-import remarkBreaks from 'remark-breaks';
-import rehypeRaw from 'rehype-raw';
-import './markdownpreview.css';
 import { DebtPositionTypeRequestBody } from '../../../../generated/data-contracts';
+import { useState } from 'react';
+import { MarkdownPreview } from './MarkdownPreview';
 
 export type Step2Data = Partial<DebtPositionTypeRequestBody> &
   Pick<
@@ -42,11 +40,9 @@ export type Step2Props = {
   onBack?: () => void;
 };
 
-
 export const Step2Settings = ({ onBack, setData, onNext }: Step2Props) => {
   const { t } = useTranslation();
-  const theme = useTheme();
-  const secondaryColor = theme.palette.text.secondary;
+  const [open, setOpen] = useState(false);
 
   const schema = z
     .object({
@@ -80,39 +76,13 @@ export const Step2Settings = ({ onBack, setData, onNext }: Step2Props) => {
     onNext();
   };
 
-  const ioTemplateMessage = watch("ioTemplateMessage");
-
-  const placeholders: Record<string, string> = {
-    '%posizioneDebitoria_descrizione%': 'Pagamento TARI',
-    '%debitore_nomeCompleto%': 'Mario Rossi',
-    '%debitore_codiceFiscale%': 'RSSMRA80R11A123H',
-    '%importoTotale%': '120 €',
-    '%IUV%': '82000000000',
-    '%NAV%': '0000 0000 0000 0000 00',
-    '%causale%': 'Causale del pagamento',
-    '%dataScadenza%': '12/04/2099'
-
-  }
-
-  const renderTextWithPlaceholders = (inputText: string) => {
-    let modifiedText = inputText;
-    Object.keys(placeholders).forEach((placeholder: string) => {
-      const regex = new RegExp(placeholder, 'g');
-      modifiedText = modifiedText.replace(
-        regex,
-        `<span class="highlighted" style="color: ${secondaryColor} ">${placeholders[placeholder]}</span>`
-      );
-    });
-
-    return modifiedText;
-  };
-
   const options: Array<keyof Step2Data> = [
     'flagMandatoryDueDate',
     'flagAnonymousFiscalCode'
   ];
   const flagNotifyIo = watch('flagNotifyIo');
-  const ioTemplateMessage = watch("ioTemplateMessage");
+  const ioTemplateMessage = watch('ioTemplateMessage');
+  const ioTemplateSubject = watch('ioTemplateSubject');
 
   return (
     <form>
@@ -236,15 +206,11 @@ export const Step2Settings = ({ onBack, setData, onNext }: Step2Props) => {
                       />
                     )}
                   />
-                  <ReactMarkdown
-                    children={renderTextWithPlaceholders(ioTemplateMessage || "")}
-                    rehypePlugins={[rehypeRaw]}
-                    remarkPlugins={[remarkBreaks]}
-                    components={{
-                      span: ({ node, ...props }) => {
-                        return <span {...props} />;
-                      },
-                    }}
+                  <MarkdownPreview
+                    title={ioTemplateSubject || ''}
+                    message={ioTemplateMessage || ''}
+                    open={open}
+                    onClose={() => setOpen(false)}
                   />
 
                   <Typography
@@ -279,11 +245,17 @@ export const Step2Settings = ({ onBack, setData, onNext }: Step2Props) => {
               <Stack
                 sx={{ whiteSpace: 'nowrap' }}
                 direction="row"
-                gap={1}
                 color="primary.main"
               >
-                <PreviewIcon />
-                <Link>{t('debtTypeCreate.settings.preview')}</Link>
+                <Button
+                  variant="text"
+                  onClick={() => setOpen(true)}
+                  sx={{ px: 0 }}
+                  disabled={!(ioTemplateMessage && ioTemplateSubject)}
+                >
+                  <PreviewIcon sx={{ mr: 1 }} />
+                  {t('debtTypeCreate.settings.preview')}
+                </Button>
               </Stack>
             )}
           </Stack>

--- a/src/routes/DebtTypeCreate/components/Step2Settings.tsx
+++ b/src/routes/DebtTypeCreate/components/Step2Settings.tsx
@@ -11,7 +11,8 @@ import {
   Link,
   Stack,
   TextField,
-  Typography
+  Typography,
+  useTheme
 } from '@mui/material';
 import TuneIcon from '@mui/icons-material/Tune';
 import MessageIcon from '@mui/icons-material/Message';
@@ -19,6 +20,10 @@ import WizardStepWrapper from '../../../components/Wizard/WizardStepWrapper';
 import SectionBox from '../../../components/Wizard/SectionBox';
 import WizardStepButtons from '../../../components/Wizard/WizardStepButtons';
 import { FormComponent } from '../../../components/FormComponent';
+import ReactMarkdown from 'react-markdown';
+import remarkBreaks from 'remark-breaks';
+import rehypeRaw from 'rehype-raw';
+import './markdownpreview.css';
 
 export type Step2Data = {
   option1?: boolean;
@@ -35,8 +40,11 @@ export type Step2Props = {
   onBack?: () => void;
 };
 
+
 export const Step2Settings = ({ onBack, setData, onNext }: Step2Props) => {
   const { t } = useTranslation();
+  const theme = useTheme();
+  const secondaryColor = theme.palette.text.secondary;
 
   const schema = z
     .object({
@@ -73,6 +81,33 @@ export const Step2Settings = ({ onBack, setData, onNext }: Step2Props) => {
 
   const options: Array<keyof Step2Data> = ['option1', 'option2', 'option3'];
   const checkbox2 = watch('checkbox2');
+  const textAreaValue = watch("textArea");
+
+  const placeholders: Record<string, string> = {
+    '%posizioneDebitoria_descrizione%': 'Pagamento TARI',
+    '%debitore_nomeCompleto%': 'Mario Rossi',
+    '%debitore_codiceFiscale%': 'RSSMRA80R11A123H',
+    '%importoTotale%': '120 €',
+    '%IUV%': '82000000000',
+    '%NAV%': '0000 0000 0000 0000 00',
+    '%causale%': 'Causale del pagamento',
+    '%dataScadenza%': '12/04/2099'
+
+  }
+
+  const renderTextWithPlaceholders = (inputText: string) => {
+    let modifiedText = inputText;
+    Object.keys(placeholders).forEach((placeholder: string) => {
+      const regex = new RegExp(placeholder, 'g');
+      modifiedText = modifiedText.replace(
+        regex,
+        `<span class="highlighted" style="color: ${secondaryColor} ">${placeholders[placeholder]}</span>`
+      );
+    });
+
+    return modifiedText;
+  };
+
 
   return (
     <form>
@@ -118,7 +153,7 @@ export const Step2Settings = ({ onBack, setData, onNext }: Step2Props) => {
           subtitle={t('debtTypeCreate.settings.template.helper')}
           adornment={<MessageIcon />}
         >
-          <Stack direction="row" gap={2} alignItems="center" width="100%">
+          <Stack direction="column" gap={2} alignItems="left" width="100%">
             <Stack>
               <Controller
                 name="checkbox2"
@@ -130,100 +165,107 @@ export const Step2Settings = ({ onBack, setData, onNext }: Step2Props) => {
                   />
                 )}
               />
-
-              <Controller
-                name="textField"
-                control={control}
-                defaultValue=""
-                render={({ field }) => (
-                  <FormComponent.TextField
-                    {...field}
-                    ref={null}
-                    required={checkbox2}
-                    label={t('debtTypeCreate.settings.subject.label')}
-                    placeholder={t(
-                      'debtTypeCreate.settings.subject.placeholder'
-                    )}
-                    error={checkbox2 && !!errors.textField}
-                    helperText={checkbox2 && errors.textField?.message}
-                    fullWidth
-                    sx={{ my: 2 }}
-                  />
-                )}
-              />
-              <Typography
-                variant="body2"
-                color="textSecondary"
-                component="span"
-              >
-                <Trans
-                  i18nKey="debtTypeCreate.settings.subject.guide"
-                  components={[
-                    <Link
-                      key="link"
-                      href="#"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      underline="none"
+              <Box display={checkbox2 ? 'block' : 'none'}>
+                <Controller
+                  name="textField"
+                  control={control}
+                  defaultValue=""
+                  render={({ field }) => (
+                    <FormComponent.TextField
+                      {...field}
+                      ref={null}
+                      required={checkbox2}
+                      label={t('debtTypeCreate.settings.subject.label')}
+                      placeholder={t(
+                        'debtTypeCreate.settings.subject.placeholder'
+                      )}
+                      error={checkbox2 && !!errors.textField}
+                      helperText={checkbox2 && errors.textField?.message}
+                      fullWidth
+                      sx={{ my: 2 }}
                     />
-                  ]}
+                  )}
                 />
-              </Typography>
 
-              <Controller
-                name="textArea"
-                control={control}
-                render={({ field }) => (
-                  <TextField
-                    required={checkbox2}
-                    label={t('debtTypeCreate.settings.message.label')}
-                    InputLabelProps={{ shrink: true }}
-                    error={checkbox2 && !!errors.textArea}
-                    helperText={checkbox2 && errors.textArea?.message}
-                    defaultValue=""
-                    fullWidth
-                    multiline
-                    rows={7}
-                    sx={{ my: 2 }}
-                    {...field}
+                <Typography
+                  variant="body2"
+                  color="textSecondary"
+                  component="span"
+                >
+                  <Trans
+                    i18nKey="debtTypeCreate.settings.subject.guide"
+                    components={[
+                      <Link
+                        key="link"
+                        href="#"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        underline="none"
+                      />
+                    ]}
                   />
-                )}
-              />
-
-              <Typography
-                variant="body2"
-                color="textSecondary"
-                component="span"
-              >
-                <Trans
-                  i18nKey="debtTypeCreate.settings.message.guide"
-                  components={[
-                    <Link
-                      key="link"
-                      href="#"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      underline="none"
-                    />,
-                    <Link
-                      key="link"
-                      href="#"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      underline="none"
+                </Typography>
+                <Controller
+                  name="textArea"
+                  control={control}
+                  render={({ field }) => (
+                    <TextField
+                      required={checkbox2}
+                      label={t('debtTypeCreate.settings.message.label')}
+                      InputLabelProps={{ shrink: true }}
+                      error={checkbox2 && !!errors.textArea}
+                      helperText={checkbox2 && errors.textArea?.message}
+                      defaultValue=""
+                      fullWidth
+                      multiline
+                      rows={7}
+                      sx={{ my: 2 }}
+                      {...field}
                     />
-                  ]}
+                  )}
                 />
-              </Typography>
-            </Stack>
-            <Stack
-              sx={{ whiteSpace: 'nowrap' }}
-              direction="row"
-              gap={1}
-              color="primary.main"
-            >
-              <PreviewIcon />
-              <Link>{t('debtTypeCreate.settings.preview')}</Link>
+                <Box component={'div'}>
+                  <ReactMarkdown
+                    children={renderTextWithPlaceholders(textAreaValue || "")}
+                    rehypePlugins={[rehypeRaw]}
+                    remarkPlugins={[remarkBreaks]}
+                    components={{
+                      span: ({ node, ...props }) => {
+                        return <span {...props} />;
+                      },
+                    }}
+                  />
+                </Box>
+
+                <Typography
+                  variant="body2"
+                  color="textSecondary"
+                  component="span"
+                >
+                  <Trans
+                    i18nKey="debtTypeCreate.settings.message.guide"
+                    components={[
+                      <Link
+                        key="link"
+                        href="#"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        underline="none"
+                      />,
+                      <Link
+                        key="link"
+                        href="#"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        underline="none"
+                      />
+                    ]}
+                  />
+                </Typography>
+                <Stack alignItems={'center'} direction={'row'} my={2} gap={1}><PreviewIcon color={'primary'} />
+                  <Link>{t('debtTypeCreate.settings.preview')}</Link></Stack>
+
+              </Box>
             </Stack>
           </Stack>
         </SectionBox>

--- a/src/routes/DebtTypeCreate/components/markdownpreview.css
+++ b/src/routes/DebtTypeCreate/components/markdownpreview.css
@@ -1,0 +1,3 @@
+.highlighted {
+    color: var(--primary-color);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2394,6 +2394,11 @@ entities@^4.5.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
+entities@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-6.0.0.tgz#09c9e29cb79b0a6459a9b9db9efb418ac5bb8e51"
+  integrity sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==
+
 env-paths@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
@@ -2617,6 +2622,11 @@ escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
+
+escape-string-regexp@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
+  integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
 
 eslint-config-prettier@^9.1.0:
   version "9.1.0"
@@ -3200,6 +3210,46 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+hast-util-from-parse5@^8.0.0:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz#830a35022fff28c3fea3697a98c2f4cc6b835a2e"
+  integrity sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    devlop "^1.0.0"
+    hastscript "^9.0.0"
+    property-information "^7.0.0"
+    vfile "^6.0.0"
+    vfile-location "^5.0.0"
+    web-namespaces "^2.0.0"
+
+hast-util-parse-selector@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz#352879fa86e25616036037dd8931fb5f34cb4a27"
+  integrity sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==
+  dependencies:
+    "@types/hast" "^3.0.0"
+
+hast-util-raw@^9.0.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/hast-util-raw/-/hast-util-raw-9.1.0.tgz#79b66b26f6f68fb50dfb4716b2cdca90d92adf2e"
+  integrity sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    "@ungap/structured-clone" "^1.0.0"
+    hast-util-from-parse5 "^8.0.0"
+    hast-util-to-parse5 "^8.0.0"
+    html-void-elements "^3.0.0"
+    mdast-util-to-hast "^13.0.0"
+    parse5 "^7.0.0"
+    unist-util-position "^5.0.0"
+    unist-util-visit "^5.0.0"
+    vfile "^6.0.0"
+    web-namespaces "^2.0.0"
+    zwitch "^2.0.0"
+
 hast-util-sanitize@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz#edb260d94e5bba2030eb9375790a8753e5bf391f"
@@ -3230,12 +3280,36 @@ hast-util-to-jsx-runtime@^2.0.0:
     unist-util-position "^5.0.0"
     vfile-message "^4.0.0"
 
+hast-util-to-parse5@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/hast-util-to-parse5/-/hast-util-to-parse5-8.0.0.tgz#477cd42d278d4f036bc2ea58586130f6f39ee6ed"
+  integrity sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    comma-separated-tokens "^2.0.0"
+    devlop "^1.0.0"
+    property-information "^6.0.0"
+    space-separated-tokens "^2.0.0"
+    web-namespaces "^2.0.0"
+    zwitch "^2.0.0"
+
 hast-util-whitespace@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz#7778ed9d3c92dd9e8c5c8f648a49c21fc51cb621"
   integrity sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==
   dependencies:
     "@types/hast" "^3.0.0"
+
+hastscript@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-9.0.1.tgz#dbc84bef6051d40084342c229c451cd9dc567dff"
+  integrity sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    comma-separated-tokens "^2.0.0"
+    hast-util-parse-selector "^4.0.0"
+    property-information "^7.0.0"
+    space-separated-tokens "^2.0.0"
 
 hoist-non-react-statics@^3.3.1:
   version "3.3.2"
@@ -3267,6 +3341,11 @@ html-url-attributes@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/html-url-attributes/-/html-url-attributes-3.0.1.tgz#83b052cd5e437071b756cd74ae70f708870c2d87"
   integrity sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==
+
+html-void-elements@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-3.0.0.tgz#fc9dbd84af9e747249034d4d62602def6517f1d7"
+  integrity sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==
 
 http-proxy-agent@^7.0.2:
   version "7.0.2"
@@ -4026,6 +4105,16 @@ math-intrinsics@^1.1.0:
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
 
+mdast-util-find-and-replace@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz#70a3174c894e14df722abf43bc250cbae44b11df"
+  integrity sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    escape-string-regexp "^5.0.0"
+    unist-util-is "^6.0.0"
+    unist-util-visit-parents "^6.0.0"
+
 mdast-util-from-markdown@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz#4850390ca7cf17413a9b9a0fbefcd1bc0eb4160a"
@@ -4085,6 +4174,14 @@ mdast-util-mdxjs-esm@^2.0.0:
     devlop "^1.0.0"
     mdast-util-from-markdown "^2.0.0"
     mdast-util-to-markdown "^2.0.0"
+
+mdast-util-newline-to-break@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz#4e73ef621b6b1a590240336cfe6c29915e198df0"
+  integrity sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    mdast-util-find-and-replace "^3.0.0"
 
 mdast-util-phrasing@^4.0.0:
   version "4.1.0"
@@ -4699,6 +4796,13 @@ parse-json@^5.0.0, parse-json@^5.2.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parse5@^7.0.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.3.0.tgz#d7e224fa72399c7a175099f45fc2ad024b05ec05"
+  integrity sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==
+  dependencies:
+    entities "^6.0.0"
+
 parse5@^7.1.2:
   version "7.2.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.2.1.tgz#8928f55915e6125f430cc44309765bf17556a33a"
@@ -4827,6 +4931,11 @@ prop-types@^15.6.2, prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+property-information@^6.0.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-6.5.0.tgz#6212fbb52ba757e92ef4fb9d657563b933b7ffec"
+  integrity sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==
 
 property-information@^7.0.0:
   version "7.0.0"
@@ -5022,6 +5131,15 @@ regexp.prototype.flags@^1.5.3:
     gopd "^1.2.0"
     set-function-name "^2.0.2"
 
+rehype-raw@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/rehype-raw/-/rehype-raw-7.0.0.tgz#59d7348fd5dbef3807bbaa1d443efd2dd85ecee4"
+  integrity sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-raw "^9.0.0"
+    vfile "^6.0.0"
+
 rehype-sanitize@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz#16e95f4a67a69cbf0f79e113c8e0df48203db73c"
@@ -5029,6 +5147,15 @@ rehype-sanitize@^6.0.0:
   dependencies:
     "@types/hast" "^3.0.0"
     hast-util-sanitize "^5.0.0"
+
+remark-breaks@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/remark-breaks/-/remark-breaks-4.0.0.tgz#dcc19a2891733906f3b97eaa8acb8621e8da8852"
+  integrity sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==
+  dependencies:
+    "@types/mdast" "^4.0.0"
+    mdast-util-newline-to-break "^2.0.0"
+    unified "^11.0.0"
 
 remark-parse@^11.0.0:
   version "11.0.0"
@@ -6100,6 +6227,14 @@ v8-compile-cache-lib@^3.0.1:
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
+vfile-location@^5.0.0:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-5.0.3.tgz#cb9eacd20f2b6426d19451e0eafa3d0a846225c3"
+  integrity sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    vfile "^6.0.0"
+
 vfile-message@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-4.0.2.tgz#c883c9f677c72c166362fd635f21fc165a7d1181"
@@ -6205,6 +6340,11 @@ wcwidth@^1.0.1:
   integrity sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==
   dependencies:
     defaults "^1.0.3"
+
+web-namespaces@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
+  integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
This PR adds the "preview" for the "IO template message" set in the DebType wizard (step 2).

#### List of Changes
- add dependecies: remark-breaks , rehype-raw
- create a specific component MarkdownPreview
- set a dialog window to manage the preview 

#### Motivation and Context
The final aim is to have a useful preview to show to the editor when edit a IO message, using default placeholders

#### How Has This Been Tested?

- unit test
- visual test

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
