### PR TITLE
feat: [P4ADEV-2560] Edit debtposition types

### DIFF
--- a/src/api/debtPositionsTypes.ts
+++ b/src/api/debtPositionsTypes.ts
@@ -5,7 +5,10 @@ import {
   debtPositionTypeSchema,
   pagedDebtPositionTypeWithCountSchema
 } from '../../generated/zod-schema';
-import { DebtPositionTypeRequestBody } from '../../generated/data-contracts';
+import {
+  DebtPositionTypePatchRequestBody,
+  DebtPositionTypeRequestBody
+} from '../../generated/data-contracts';
 
 export const getDebtPositionsTypes = ({
   organizationId
@@ -69,6 +72,18 @@ export const postDebtPositionType = () =>
     mutationFn: async (query: DebtPositionTypeRequestBody) => {
       const response = await utils.apiClient.bff.createDebtPositionType(query);
       parseAndLog(debtPositionTypeSchema, response.data);
+      return response.data;
+    }
+  });
+
+export const patchDebtPositionType = (debtPositionTypeId: number) =>
+  useMutation({
+    mutationKey: ['patchDebtPositionType'],
+    mutationFn: async (data: DebtPositionTypePatchRequestBody) => {
+      const response = await utils.apiClient.bff.patchDebtPositionType(
+        debtPositionTypeId,
+        data
+      );
       return response.data;
     }
   });

--- a/src/models/DebtTypeCatalogSectionsConfig.ts
+++ b/src/models/DebtTypeCatalogSectionsConfig.ts
@@ -59,11 +59,11 @@ export const getAccordionSectionsConfig = (
           data: [
             {
               label: t('commons.organizationType'),
-              value: checkStringValue(data?.organizationTypeDescription)
+              value: checkStringValue(data?.orgType)
             },
             {
               label: t('commons.macroarea'),
-              value: checkStringValue(data?.macroAreaName)
+              value: checkStringValue(data?.macroArea)
             },
             {
               label: t('commons.serviceType'),
@@ -71,7 +71,7 @@ export const getAccordionSectionsConfig = (
             },
             {
               label: t('commons.collectionReason'),
-              value: checkStringValue(data?.collectionReason)
+              value: checkStringValue(data?.collectingReason)
             },
             {
               label: t('commons.taxCode'),
@@ -108,7 +108,7 @@ export const getAccordionSectionsConfig = (
             },
             {
               label: t('commons.subject'),
-              value: '-'
+              value: checkStringValue(data?.ioTemplateSubject)
             },
             {
               label: t('commons.message'),

--- a/src/routes/DebtTypeCatalogDetailView/DebtTypeCatalogDetailView.tsx
+++ b/src/routes/DebtTypeCatalogDetailView/DebtTypeCatalogDetailView.tsx
@@ -2,7 +2,7 @@ import { Box, Button, Stack } from '@mui/material';
 import { Delete, Edit } from '@mui/icons-material';
 import { useTranslation } from 'react-i18next';
 import TitleComponent from '../../components/TitleComponent/TitleComponent';
-import { useNavigate, useParams } from 'react-router-dom';
+import { generatePath, useNavigate, useParams } from 'react-router-dom';
 import { DetailAccordion } from '../../components/DetailAccordion/DetailAccordion';
 import {
   AccordionSectionConfig,
@@ -74,7 +74,12 @@ export const DebtTypeCatalogDetailView = () => {
       buttonText: t('commons.edit'),
       color: 'primary' as const,
       variant: 'contained' as const,
-      onActionClick: () => console.log('edit')
+      onActionClick: () =>
+        navigate(
+          generatePath(PageRoutes.DEBT_TYPE_CATALOG_EDIT, {
+            debtPositionTypeId: debtPositionTypeId
+          })
+        )
     }
   ];
 

--- a/src/routes/DebtTypeCatalogEdit/DebtTypeCatalogEditSuccess.test.tsx
+++ b/src/routes/DebtTypeCatalogEdit/DebtTypeCatalogEditSuccess.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import { DebtTypeCatalogEditSuccess } from './DebtTypeCatalogEditSuccess';
+
+// Mock dependencies
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, string>) => {
+      if (
+        key === 'debtTypeCatalogEditSuccess.title' &&
+        options?.paymentObject
+      ) {
+        return `${key} ${options.paymentObject}`;
+      }
+      return key;
+    }
+  })
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router', () => ({
+  useNavigate: () => mockNavigate,
+  useLocation: () => ({
+    state: {
+      formData: {
+        description: 'Test Debt Type'
+      }
+    }
+  })
+}));
+
+vi.mock('@pagopa/mui-italia', () => ({
+  theme: {
+    palette: {
+      success: {
+        main: '#00FF00'
+      }
+    },
+    spacing: (val: number) => `${val * 8}px`
+  }
+}));
+
+vi.mock('../../App', () => ({
+  PageRoutes: {
+    DEBT_TYPES_CATALOG: '/debt-types-catalog'
+  }
+}));
+
+describe('DebtTypeCatalogEditSuccess', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders success message with correct debt type name', async () => {
+    render(<DebtTypeCatalogEditSuccess />);
+
+    // Verify the success icon is displayed
+    expect(screen.getByTestId('CheckCircleOutlineIcon')).toBeInTheDocument();
+
+    // Verify the title includes the debt type name from location state
+    await waitFor(() => {
+      expect(
+        screen.getByText('debtTypeCatalogEditSuccess.title Test Debt Type')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('navigates to catalog when button is clicked', () => {
+    render(<DebtTypeCatalogEditSuccess />);
+
+    // Find and click the button
+    const button = screen.getByRole('button', {
+      name: 'debtTypeCatalogEditSuccess.backToStart'
+    });
+    fireEvent.click(button);
+
+    // Verify navigation was called with the correct route
+    expect(mockNavigate).toHaveBeenCalledWith('/debt-types-catalog');
+  });
+
+  it('renders with correct styling', () => {
+    const { container } = render(<DebtTypeCatalogEditSuccess />);
+
+    // Check for main container
+    const mainContainer = container.firstChild;
+    expect(mainContainer).toHaveStyle({
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      minHeight: '80vh',
+      textAlign: 'center'
+    });
+
+    // Check for inner container
+    const innerContainer = container.querySelector('div > div');
+    expect(innerContainer).toHaveStyle({
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center'
+    });
+
+    // Check icon styling
+    const icon = screen.getByTestId('CheckCircleOutlineIcon');
+    expect(icon).toHaveStyle({
+      fontSize: '64px',
+      color: '#00FF00',
+      borderRadius: '50%'
+    });
+  });
+});

--- a/src/routes/DebtTypeCatalogEdit/DebtTypeCatalogEditSuccess.tsx
+++ b/src/routes/DebtTypeCatalogEdit/DebtTypeCatalogEditSuccess.tsx
@@ -1,0 +1,85 @@
+import { Box, Typography, Button } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { useLocation, useNavigate } from 'react-router';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import { theme } from '@pagopa/mui-italia';
+import { PageRoutes } from '../../App';
+import { DebtPositionType } from '../../../generated/data-contracts';
+
+export const DebtTypeCatalogEditSuccess = () => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  // TODO: error if no formData is provided
+  const formData = location.state?.formData as DebtPositionType;
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '80vh',
+        textAlign: 'center',
+        padding: 3,
+        margin: '0 auto'
+      }}
+    >
+      <Box
+        sx={{
+          padding: 4,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: 3,
+          width: '100%'
+        }}
+      >
+        <CheckCircleOutlineIcon
+          sx={{
+            fontSize: 64,
+            color: theme.palette.success.main,
+            borderRadius: '50%'
+          }}
+        />
+
+        {formData?.description && (
+          <Typography
+            variant="h4"
+            component="h1"
+            fontSize={24}
+            sx={{
+              fontWeight: 700,
+              textAlign: 'center',
+              maxWidth: (theme) => theme.spacing(50)
+            }}
+          >
+            {t('debtTypeCatalogEditSuccess.title', {
+              paymentObject: formData.description
+            })}
+          </Typography>
+        )}
+
+        <Typography
+          fontSize={16}
+          sx={{
+            textAlign: 'center',
+            fontWeight: 400
+          }}
+        >
+          {t('debtTypeCatalogEditSuccess.description')}
+        </Typography>
+
+        <Button
+          role="button"
+          variant="contained"
+          onClick={() => navigate(PageRoutes.DEBT_TYPES_CATALOG)}
+        >
+          {t('debtTypeCatalogEditSuccess.backToStart')}
+        </Button>
+      </Box>
+    </Box>
+  );
+};

--- a/src/routes/DebtTypeCatalogEdit/index.tsx
+++ b/src/routes/DebtTypeCatalogEdit/index.tsx
@@ -15,6 +15,7 @@ import {
 import { useStore } from '../../store/GlobalStore';
 import { getDebtPositionTypeDetail } from '../../api/debtPositionTypeDetail';
 import { STATE } from '../../store/types';
+import utils from '../../utils';
 
 const initialData: DebtPositionTypeRequestBody = {
   code: '',
@@ -37,26 +38,28 @@ export const DebtTypeCatalogEdit = () => {
   const { state } = useStore();
   const { debtPositionTypeId } = useParams<{ debtPositionTypeId: string }>();
   const organizationId = Number(state[STATE.ORGANIZATION_ID]);
-  const { data } = getDebtPositionTypeDetail({
-    organizationId,
-    debtPositionTypeId: Number(debtPositionTypeId)
-  });
   const [step, setStep] = useState(0);
   const formData = useSignal<DebtPositionTypeRequestBody>(initialData);
   const debtTypeEdit = patchDebtPositionType(Number(debtPositionTypeId));
 
-  const submit = () => {
-    debtTypeEdit.mutate(formData.value, {
-      onSuccess: (formData) => {
-        navigate(PageRoutes.DEBT_TYPE_CATALOG_EDIT_SUCCESS, {
-          replace: true,
-          state: {
-            formData
-          }
-        });
-      },
-      onError: console.error
-    });
+  const { data, isSuccess } = getDebtPositionTypeDetail({
+    organizationId,
+    debtPositionTypeId: Number(debtPositionTypeId)
+  });
+
+  const submit = async () => {
+    try {
+      const response = await debtTypeEdit.mutateAsync(formData.value);
+      navigate(PageRoutes.DEBT_TYPE_CATALOG_EDIT_SUCCESS, {
+        replace: true,
+        state: {
+          formData: response
+        }
+      });
+    } catch (error) {
+      console.error(error);
+      utils.notify.emit('an error message feedback');
+    }
   };
 
   const steps: Stepper['steps'] = [
@@ -91,11 +94,13 @@ export const DebtTypeCatalogEdit = () => {
   ];
 
   return (
-    <StepperContainer
-      title={t('debtTypeCatalogEdit.title')}
-      description={t('debtTypeCatalogEdit.description')}
-      steps={steps}
-      activeStep={step}
-    />
+    (isSuccess && (
+      <StepperContainer
+        title={t('debtTypeCatalogEdit.title')}
+        description={t('debtTypeCatalogEdit.description')}
+        steps={steps}
+        activeStep={step}
+      />
+    )) || <></>
   );
 };

--- a/src/routes/DebtTypeCatalogEdit/index.tsx
+++ b/src/routes/DebtTypeCatalogEdit/index.tsx
@@ -91,13 +91,11 @@ export const DebtTypeCatalogEdit = () => {
   ];
 
   return (
-
     <StepperContainer
       title={t('debtTypeCatalogEdit.title')}
       description={t('debtTypeCatalogEdit.description')}
       steps={steps}
       activeStep={step}
     />
-
   );
 };

--- a/src/routes/DebtTypeCatalogEdit/index.tsx
+++ b/src/routes/DebtTypeCatalogEdit/index.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Stepper } from '../../components/Stepper/types';
+import { StepperContainer } from '../../components/Stepper';
+import { useNavigate, useParams } from 'react-router';
+import { PageRoutes } from '../../App';
+import { useSignal } from '@preact/signals-react';
+import { patchDebtPositionType } from '../../api/debtPositionsTypes';
+import { DebtPositionTypeRequestBody } from '../../../generated/data-contracts';
+import { Step1Configuration } from '../DebtTypeCreate/components/Step1Configuration';
+import {
+  Step2Data,
+  Step2Settings
+} from '../DebtTypeCreate/components/Step2Settings';
+import { useStore } from '../../store/GlobalStore';
+import { getDebtPositionTypeDetail } from '../../api/debtPositionTypeDetail';
+import { STATE } from '../../store/types';
+
+const initialData: DebtPositionTypeRequestBody = {
+  code: '',
+  description: '',
+  orgType: '',
+  macroArea: '',
+  serviceType: '',
+  collectingReason: '',
+  taxonomyCode: '',
+  flagMandatoryDueDate: false,
+  flagAnonymousFiscalCode: false,
+  flagNotifyIo: false,
+  ioTemplateSubject: '',
+  ioTemplateMessage: ''
+};
+
+export const DebtTypeCatalogEdit = () => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { state } = useStore();
+  const { debtPositionTypeId } = useParams<{ debtPositionTypeId: string }>();
+  const organizationId = Number(state[STATE.ORGANIZATION_ID]);
+  const { data } = getDebtPositionTypeDetail({
+    organizationId,
+    debtPositionTypeId: Number(debtPositionTypeId)
+  });
+  const [step, setStep] = useState(0);
+  const formData = useSignal<DebtPositionTypeRequestBody>(initialData);
+  const debtTypeEdit = patchDebtPositionType(Number(debtPositionTypeId));
+
+  const submit = () => {
+    debtTypeEdit.mutate(formData.value, {
+      onSuccess: (formData) => {
+        navigate(PageRoutes.DEBT_TYPE_CATALOG_EDIT_SUCCESS, {
+          replace: true,
+          state: {
+            formData
+          }
+        });
+      },
+      onError: console.error
+    });
+  };
+
+  const steps: Stepper['steps'] = [
+    {
+      label: t('debtTypeCreate.stepper.step1'),
+      content: (
+        <Step1Configuration
+          key="step1"
+          onNext={() => setStep(1)}
+          onBack={() => navigate(PageRoutes.DEBT_TYPES_CATALOG)}
+          editmode={true}
+          prefilledData={data}
+        />
+      )
+    },
+    {
+      label: t('debtTypeCreate.stepper.step2'),
+      optional: true,
+      content: (
+        <Step2Settings
+          key="step2"
+          setData={(data: Step2Data) => {
+            formData.value = { ...formData.value, ...data };
+          }}
+          onBack={() => setStep(0)}
+          onNext={submit}
+          editmode={true}
+          prefilledData={data}
+        />
+      )
+    }
+  ];
+
+  return (
+
+    <StepperContainer
+      title={t('debtTypeCatalogEdit.title')}
+      description={t('debtTypeCatalogEdit.description')}
+      steps={steps}
+      activeStep={step}
+    />
+
+  );
+};

--- a/src/routes/DebtTypeCreate/DebtTypeCreate.test.tsx
+++ b/src/routes/DebtTypeCreate/DebtTypeCreate.test.tsx
@@ -11,15 +11,17 @@ vi.mock('./components/Step1Configuration', () => ({
     <div data-testid="step1-configuration">
       <button
         onClick={() => {
-          setData && setData({
-            description: 'Test Debt Type',
-            code: 'CODE1',
-            orgType: 'ORG1',
-            macroArea: 'MACRO1',
-            serviceType: 'SERVICE1',
-            collectingReason: 'REASON1',
-            taxonomyCode: 'TAX1'
-          });
+          if (setData) {
+            setData({
+              description: 'Test Debt Type',
+              code: 'CODE1',
+              orgType: 'ORG1',
+              macroArea: 'MACRO1',
+              serviceType: 'SERVICE1',
+              collectingReason: 'REASON1',
+              taxonomyCode: 'TAX1'
+            });
+          }
           onNext();
         }}
       >

--- a/src/routes/DebtTypeCreate/DebtTypeCreate.test.tsx
+++ b/src/routes/DebtTypeCreate/DebtTypeCreate.test.tsx
@@ -11,7 +11,7 @@ vi.mock('./components/Step1Configuration', () => ({
     <div data-testid="step1-configuration">
       <button
         onClick={() => {
-          setData({
+          setData && setData({
             description: 'Test Debt Type',
             code: 'CODE1',
             orgType: 'ORG1',

--- a/src/routes/DebtTypeCreate/components/Step1Configuration.tsx
+++ b/src/routes/DebtTypeCreate/components/Step1Configuration.tsx
@@ -20,7 +20,10 @@ import {
   getTaxonomyCode
 } from '../../../api/taxonomy';
 import { useFormDependencies } from '../../../hooks/useFormDependecies';
-import { DebtPositionTypeRequestBody } from '../../../../generated/data-contracts';
+import {
+  DebtPositionTypeDetailDTO,
+  DebtPositionTypeRequestBody
+} from '../../../../generated/data-contracts';
 
 export type Step1Data = Partial<DebtPositionTypeRequestBody> &
   Pick<
@@ -35,9 +38,11 @@ export type Step1Data = Partial<DebtPositionTypeRequestBody> &
   >;
 
 export type Step1Props = {
-  setData: (data: Step1Data) => void;
+  setData?: (data: Step1Data) => void;
   onNext: () => void;
   onBack: () => void;
+  editmode?: boolean;
+  prefilledData?: DebtPositionTypeDetailDTO;
 };
 
 const validationSchema = (t: TFunction) =>
@@ -70,7 +75,13 @@ const validationSchema = (t: TFunction) =>
     })
   });
 
-export const Step1Configuration = ({ setData, onNext, onBack }: Step1Props) => {
+export const Step1Configuration = ({
+  setData,
+  onNext,
+  onBack,
+  editmode = false,
+  prefilledData = undefined
+}: Step1Props) => {
   const { t } = useTranslation();
   const schema = validationSchema(t);
 
@@ -104,7 +115,9 @@ export const Step1Configuration = ({ setData, onNext, onBack }: Step1Props) => {
   const isVisible = !!organizationType;
 
   const onSubmit = async (values: Step1Data) => {
-    setData(values);
+    if (setData) {
+      setData(values);
+    }
     onNext();
   };
 
@@ -113,7 +126,9 @@ export const Step1Configuration = ({ setData, onNext, onBack }: Step1Props) => {
       <WizardStepWrapper
         title={t('debtTypeCreate.configuration.title')}
         subtitle={t('debtTypeCreate.configuration.subtitle')}
-        alertMessage={t('debtTypeCreate.configuration.alertMessage')}
+        alertMessage={
+          (!editmode && t('debtTypeCreate.configuration.alertMessage')) || ''
+        }
       >
         <SectionBox
           title={t('debtTypeCreate.configuration.debtType.title')}
@@ -123,7 +138,8 @@ export const Step1Configuration = ({ setData, onNext, onBack }: Step1Props) => {
             <Controller
               name="code"
               control={control}
-              defaultValue=""
+              disabled={editmode}
+              defaultValue={editmode ? prefilledData?.code : ''}
               render={({ field }) => (
                 <FormComponent.TextField
                   {...field}
@@ -142,7 +158,8 @@ export const Step1Configuration = ({ setData, onNext, onBack }: Step1Props) => {
               <Controller
                 name="description"
                 control={control}
-                defaultValue=""
+                disabled={editmode}
+                defaultValue={editmode ? prefilledData?.description : ''}
                 render={({ field }) => (
                   <FormComponent.TextField
                     {...field}
@@ -165,83 +182,194 @@ export const Step1Configuration = ({ setData, onNext, onBack }: Step1Props) => {
             </Stack>
           </Stack>
         </SectionBox>
-
         <SectionBox
           title={t('debtTypeCreate.configuration.taxonomyCode.title')}
           adornment={<LocalOffer />}
         >
-          <FormComponent.ControlledSelect
-            control={control}
-            label={t('debtTypeCreate.configuration.organizationType.label')}
-            name="orgType"
-            fetchFn={getOrganizationsTypes}
-            key={keys.orgType}
-          />
-
+          <Stack>
+            {!editmode && (
+              <FormComponent.ControlledSelect
+                control={control}
+                label={t('debtTypeCreate.configuration.organizationType.label')}
+                name="orgType"
+                fetchFn={getOrganizationsTypes}
+                key={keys.orgType}
+              />
+            )}
+            {editmode && (
+              <Controller
+                name="orgType"
+                control={control}
+                disabled={editmode}
+                defaultValue={editmode ? prefilledData?.orgType : ''}
+                render={({ field }) => (
+                  <FormComponent.TextField
+                    {...field}
+                    ref={null}
+                    required
+                    label={t('debtTypeCreate.configuration.debtType.label')}
+                    id="orgType"
+                    placeholder={t(
+                      'debtTypeCreate.configuration.debtType.placeholder'
+                    )}
+                    noAdornment
+                  />
+                )}
+              />
+            )}
+          </Stack>
           <Stack
             visibility={isVisible ? 'visible' : 'hidden'}
             display={isVisible ? 'flex' : 'none'}
             gap={2}
           >
-            <FormComponent.ControlledSelect
-              control={control}
-              label={t('debtTypeCreate.configuration.macroArea.label')}
-              name="macroArea"
-              fetchFn={() => getMacroAreas({ organizationType })}
-              key={keys.macroArea}
-              disabled={!organizationType}
-            />
-
-            <Stack direction="row" gap={2}>
+            {!editmode && (
               <FormComponent.ControlledSelect
                 control={control}
-                label={t('debtTypeCreate.configuration.serviceType.label')}
-                name="serviceType"
-                fetchFn={() =>
-                  getServiceTypes({ organizationType, macroAreaCode })
-                }
-                key={keys.serviceType}
-                disabled={!macroAreaCode || !organizationType}
+                label={t('debtTypeCreate.configuration.macroArea.label')}
+                name="macroArea"
+                fetchFn={() => getMacroAreas({ organizationType })}
+                key={keys.macroArea}
+                disabled={!organizationType}
               />
-
-              <FormComponent.ControlledSelect
+            )}
+            {editmode && (
+              <Controller
+                name="macroArea"
                 control={control}
-                label={t('debtTypeCreate.configuration.collectionReason.label')}
-                name="collectingReason"
-                fetchFn={() =>
-                  getCollectionReasons({
-                    organizationType,
-                    serviceTypeCode,
-                    macroAreaCode
-                  })
-                }
-                key={keys.collectingReason}
-                disabled={
-                  !serviceTypeCode || !macroAreaCode || !organizationType
-                }
+                disabled={editmode}
+                defaultValue={editmode ? prefilledData?.macroArea : ''}
+                render={({ field }) => (
+                  <FormComponent.TextField
+                    {...field}
+                    ref={null}
+                    required
+                    label={t('debtTypeCreate.configuration.debtType.label')}
+                    id="macroArea"
+                    placeholder={t(
+                      'debtTypeCreate.configuration.debtType.placeholder'
+                    )}
+                    noAdornment
+                  />
+                )}
               />
+            )}
 
-              <FormComponent.ControlledSelect
-                control={control}
-                label={t('debtTypeCreate.configuration.taxonomyCode.label')}
-                name="taxonomyCode"
-                disabled={
-                  !collectionReason ||
-                  !serviceTypeCode ||
-                  !macroAreaCode ||
-                  !organizationType
-                }
-                fetchFn={() =>
-                  getTaxonomyCode({
-                    organizationType,
-                    macroAreaCode,
-                    serviceTypeCode,
-                    collectionReason
-                  })
-                }
-                key={keys.taxonomyCode}
-              />
-            </Stack>
+            {!editmode && (
+              <Stack direction="row" gap={2}>
+                <FormComponent.ControlledSelect
+                  control={control}
+                  label={t('debtTypeCreate.configuration.serviceType.label')}
+                  name="serviceType"
+                  fetchFn={() =>
+                    getServiceTypes({ organizationType, macroAreaCode })
+                  }
+                  key={keys.serviceType}
+                  disabled={!macroAreaCode || !organizationType}
+                />
+
+                <FormComponent.ControlledSelect
+                  control={control}
+                  label={t(
+                    'debtTypeCreate.configuration.collectionReason.label'
+                  )}
+                  name="collectingReason"
+                  fetchFn={() =>
+                    getCollectionReasons({
+                      organizationType,
+                      serviceTypeCode,
+                      macroAreaCode
+                    })
+                  }
+                  key={keys.collectingReason}
+                  disabled={
+                    !serviceTypeCode || !macroAreaCode || !organizationType
+                  }
+                />
+
+                <FormComponent.ControlledSelect
+                  control={control}
+                  label={t('debtTypeCreate.configuration.taxonomyCode.label')}
+                  name="taxonomyCode"
+                  disabled={
+                    !collectionReason ||
+                    !serviceTypeCode ||
+                    !macroAreaCode ||
+                    !organizationType
+                  }
+                  fetchFn={() =>
+                    getTaxonomyCode({
+                      organizationType,
+                      macroAreaCode,
+                      serviceTypeCode,
+                      collectionReason
+                    })
+                  }
+                  key={keys.taxonomyCode}
+                />
+              </Stack>
+            )}
+            {editmode && (
+              <Stack direction="row" gap={2}>
+                <Controller
+                  name="serviceType"
+                  control={control}
+                  disabled={editmode}
+                  defaultValue={editmode ? prefilledData?.serviceType : ''}
+                  render={({ field }) => (
+                    <FormComponent.TextField
+                      {...field}
+                      ref={null}
+                      required
+                      label={t('debtTypeCreate.configuration.debtType.label')}
+                      id="serviceType"
+                      placeholder={t(
+                        'debtTypeCreate.configuration.debtType.placeholder'
+                      )}
+                      noAdornment
+                    />
+                  )}
+                />
+                <Controller
+                  name="collectingReason"
+                  control={control}
+                  disabled={editmode}
+                  defaultValue={editmode ? prefilledData?.collectingReason : ''}
+                  render={({ field }) => (
+                    <FormComponent.TextField
+                      {...field}
+                      ref={null}
+                      required
+                      label={t('debtTypeCreate.configuration.debtType.label')}
+                      id="collectingReason"
+                      placeholder={t(
+                        'debtTypeCreate.configuration.debtType.placeholder'
+                      )}
+                      noAdornment
+                    />
+                  )}
+                />
+                <Controller
+                  name="taxonomyCode"
+                  control={control}
+                  disabled={editmode}
+                  defaultValue={editmode ? prefilledData?.taxonomyCode : ''}
+                  render={({ field }) => (
+                    <FormComponent.TextField
+                      {...field}
+                      ref={null}
+                      required
+                      label={t('debtTypeCreate.configuration.debtType.label')}
+                      id="taxonomyCode"
+                      placeholder={t(
+                        'debtTypeCreate.configuration.debtType.placeholder'
+                      )}
+                      noAdornment
+                    />
+                  )}
+                />
+              </Stack>
+            )}
           </Stack>
         </SectionBox>
       </WizardStepWrapper>

--- a/src/routes/DebtTypeCreate/components/Step2Settings.test.tsx
+++ b/src/routes/DebtTypeCreate/components/Step2Settings.test.tsx
@@ -66,7 +66,7 @@ describe('Step2Settings', () => {
       expect(mockSetData).toHaveBeenCalledWith({
         flagMandatoryDueDate: false,
         flagAnonymousFiscalCode: false,
-        flagNotifyIo: undefined,
+        flagNotifyIo: false,
         ioTemplateSubject: '',
         ioTemplateMessage: ''
       } as DebtPositionTypeRequestBody);
@@ -177,7 +177,7 @@ describe('Step2Settings', () => {
       expect(mockSetData).toHaveBeenCalledWith({
         flagMandatoryDueDate: false,
         flagAnonymousFiscalCode: false,
-        flagNotifyIo: undefined,
+        flagNotifyIo: false,
         ioTemplateSubject: '',
         ioTemplateMessage: ''
       } as DebtPositionTypeRequestBody);

--- a/src/routes/DebtTypeCreate/components/Step2Settings.tsx
+++ b/src/routes/DebtTypeCreate/components/Step2Settings.tsx
@@ -20,7 +20,10 @@ import WizardStepWrapper from '../../../components/Wizard/WizardStepWrapper';
 import SectionBox from '../../../components/Wizard/SectionBox';
 import WizardStepButtons from '../../../components/Wizard/WizardStepButtons';
 import { FormComponent } from '../../../components/FormComponent';
-import { DebtPositionTypeRequestBody } from '../../../../generated/data-contracts';
+import {
+  DebtPositionTypeDetailDTO,
+  DebtPositionTypeRequestBody
+} from '../../../../generated/data-contracts';
 import { useState } from 'react';
 import { MarkdownPreview } from './MarkdownPreview';
 
@@ -38,9 +41,17 @@ export type Step2Props = {
   setData: (data: Step2Data) => void;
   onNext: () => void;
   onBack?: () => void;
+  editmode?: boolean;
+  prefilledData?: DebtPositionTypeDetailDTO;
 };
 
-export const Step2Settings = ({ onBack, setData, onNext }: Step2Props) => {
+export const Step2Settings = ({
+  onBack,
+  setData,
+  onNext,
+  editmode = false,
+  prefilledData = undefined
+}: Step2Props) => {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
 
@@ -95,31 +106,39 @@ export const Step2Settings = ({ onBack, setData, onNext }: Step2Props) => {
           adornment={<TuneIcon />}
         >
           <FormGroup>
-            {options.map((optionKey) => (
-              <Controller
-                key={optionKey}
-                name={optionKey}
-                control={control}
-                defaultValue={false}
-                render={({ field }) => (
-                  <FormControlLabel
-                    control={<Checkbox {...field} checked={!!field.value} />}
-                    label={
-                      <Box>
-                        <Typography variant="body1">
-                          {t(
-                            `debtTypeCreate.settings.${optionKey}.description`
-                          )}
-                        </Typography>
-                        <Typography variant="caption" color="textSecondary">
-                          {t(`debtTypeCreate.settings.${optionKey}.subtitle`)}
-                        </Typography>
-                      </Box>
-                    }
-                  />
-                )}
-              />
-            ))}
+            {options.map((optionKey) => {
+              const defaultValue: boolean | undefined =
+                prefilledData &&
+                (prefilledData[
+                  optionKey as keyof DebtPositionTypeDetailDTO
+                ] as boolean);
+
+              return (
+                <Controller
+                  key={optionKey}
+                  name={optionKey}
+                  control={control}
+                  defaultValue={(editmode && defaultValue) || false}
+                  render={({ field }) => (
+                    <FormControlLabel
+                      control={<Checkbox {...field} checked={!!field.value} />}
+                      label={
+                        <Box>
+                          <Typography variant="body1">
+                            {t(
+                              `debtTypeCreate.settings.${optionKey}.description`
+                            )}
+                          </Typography>
+                          <Typography variant="caption" color="textSecondary">
+                            {t(`debtTypeCreate.settings.${optionKey}.subtitle`)}
+                          </Typography>
+                        </Box>
+                      }
+                    />
+                  )}
+                />
+              );
+            })}
           </FormGroup>
         </SectionBox>
 
@@ -133,6 +152,7 @@ export const Step2Settings = ({ onBack, setData, onNext }: Step2Props) => {
               <Controller
                 name="flagNotifyIo"
                 control={control}
+                defaultValue={editmode ? prefilledData?.flagNotifyIo : false}
                 render={({ field }) => (
                   <FormControlLabel
                     control={<Checkbox {...field} checked={!!field.value} />}
@@ -146,7 +166,9 @@ export const Step2Settings = ({ onBack, setData, onNext }: Step2Props) => {
                   <Controller
                     name="ioTemplateSubject"
                     control={control}
-                    defaultValue=""
+                    defaultValue={
+                      editmode ? prefilledData?.ioTemplateSubject : ''
+                    }
                     render={({ field }) => (
                       <FormComponent.TextField
                         {...field}
@@ -188,6 +210,9 @@ export const Step2Settings = ({ onBack, setData, onNext }: Step2Props) => {
                   <Controller
                     name="ioTemplateMessage"
                     control={control}
+                    defaultValue={
+                      editmode ? prefilledData?.ioTemplateMessage : ''
+                    }
                     render={({ field }) => (
                       <TextField
                         required={flagNotifyIo}
@@ -197,7 +222,6 @@ export const Step2Settings = ({ onBack, setData, onNext }: Step2Props) => {
                         helperText={
                           flagNotifyIo && errors.ioTemplateMessage?.message
                         }
-                        defaultValue=""
                         fullWidth
                         multiline
                         rows={7}
@@ -263,7 +287,7 @@ export const Step2Settings = ({ onBack, setData, onNext }: Step2Props) => {
       </WizardStepWrapper>
       <WizardStepButtons
         onBack={onBack}
-        nextLabel={t('commons.create')}
+        nextLabel={editmode ? t('commons.edit') : t('commons.create')}
         onNext={handleSubmit(onSubmit)}
       />
     </form>

--- a/src/routes/debtTypes.tsx
+++ b/src/routes/debtTypes.tsx
@@ -5,6 +5,8 @@ import DebtTypes from './DebtTypes/DebtTypes';
 import DebtTypeDetailView from './DebtTypeCatalogDetailView/DebtTypeCatalogDetailView';
 import { DebtTypeCreate } from './DebtTypeCreate';
 import { DebtTypeCreateSuccess } from './DebtTypeCreate/DebtTypeCreateSuccess';
+import { DebtTypeCatalogEdit } from './DebtTypeCatalogEdit';
+import { DebtTypeCatalogEditSuccess } from './DebtTypeCatalogEdit/DebtTypeCatalogEditSuccess';
 
 const deployPath = config.deployPath;
 
@@ -63,6 +65,31 @@ export const debtTypesRoutes = [
         element: <DebtTypeCreateSuccess />,
         handle: {
           backButton: false,
+          hideBreadcrumbs: true,
+          sidebar: {
+            visible: false
+          }
+        } as RouteHandleObject
+      },
+      {
+        id: 'DEBT_TYPE_CATALOG_EDIT_SUCCESS',
+        path: 'edit/ok',
+        element: <DebtTypeCatalogEditSuccess />,
+        handle: {
+          backButton: false,
+          hideBreadcrumbs: true,
+          sidebar: {
+            visible: false
+          }
+        } as RouteHandleObject
+      },
+      {
+        id: 'DEBT_TYPE_CATALOG_EDIT',
+        path: 'catalog/edit/:debtPositionTypeId',
+        element: <DebtTypeCatalogEdit />,
+        handle: {
+          backButton: true,
+          backButtonText: 'commons.exit',
           hideBreadcrumbs: true,
           sidebar: {
             visible: false

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -29,7 +29,7 @@
     },
     "error": {
       "flowFile": "Qualcosa non ha funzionato: impossibile scaricare il file",
-      "errorFlowFile": "Qualcosa non ha funzionato: impossibile scaricare il file" 
+      "errorFlowFile": "Qualcosa non ha funzionato: impossibile scaricare il file"
     }
   },
   "commons": {
@@ -542,6 +542,15 @@
       "genericErrorDescription": "Siamo spiacenti, al momento non è possibile eliminare questo tipo di dovuto.",
       "title": "Il tipo dovuto non può essere eliminato"
     }
+  },
+  "debtTypeCatalogEdit": {
+    "title": "Modifica il Tipo dovuto",
+    "description": "Compila i campi e modifica il Tipo dovuto nel propio catalogo."
+  },
+  "debtTypeCatalogEditSuccess": {
+    "backToStart": "Torna alla sezione",
+    "description": "",
+    "title": "Il tipo dovuto '{{paymentObject}}' è stato modificato!"
   },
   "debtTypeCreate": {
     "title": "Crea un nuovo Tipo dovuto",


### PR DESCRIPTION
This PR add the "edit mode" for Debt position types.

#### List of Changes
- Add editmode to the existing creation form to manage also editing
- add specific route
- mod deb type detail view to link the edit route
- update dictionary

#### Motivation and Context
We've to edit Debt types in only second step of the wizard

#### How Has This Been Tested?
- unit
- visual

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
