### PR TITLE
fix: [P4ADEV-2680] "loadedDiscarded" datagrid column shows cell value correctly

### DIFF
--- a/src/components/ImportFlowOverview/ImportFlowOverview.test.tsx
+++ b/src/components/ImportFlowOverview/ImportFlowOverview.test.tsx
@@ -685,9 +685,9 @@ describe('TelematicReceiptImportFlowOverview', () => {
           ?.textContent
       ).toBe('');
       expect(
-        undefinedValuesRow?.querySelector('[data-field="discardedRows"]')
+        undefinedValuesRow?.querySelector('[data-field="loadedDiscarded"]')
           ?.textContent
-      ).toBe('');
+      ).toBe('-/-');
     });
   });
 

--- a/src/components/ImportFlowOverview/ImportFlowOverview.tsx
+++ b/src/components/ImportFlowOverview/ImportFlowOverview.tsx
@@ -26,6 +26,7 @@ import {
 import { useFlowFilters } from '../../hooks/useFlowFilters';
 import { STATE } from '../../store/types';
 import {
+  IngestionFlowFile,
   IngestionFlowFileStatus,
   IngestionFlowFileTypeEnum
 } from '../../../generated/apiClient';
@@ -167,12 +168,17 @@ const ImportFlowOverview = ({
       type: 'string'
     },
     {
-      field: 'discardedRows',
+      field: 'loadedDiscarded',
       headerName: t('flowDataGrid.loadedDiscarded'),
       flex: 1,
-      type: 'number',
+      type: 'string',
       headerAlign: 'left',
-      align: 'left'
+      align: 'left',
+      renderCell: ({ row }: { row: IngestionFlowFile }) => {
+        const loaded = row.correctlyImportedRows ?? '-';
+        const discarded = row.discardedRows ?? '-';
+        return <>{`${loaded}/${discarded}`}</>;
+      }
     },
     {
       field: 'status',


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Added the renderCell method to the "loadedDiscarded" DataGrid column so that "correctlyImportedRows" and "discardedRows" values can be aggregated and shown correctly together

<!--- Describe your changes in detail -->

#### Motivation and Context
This is required because the "correctlyImportedRows" value was ignored and not shown before this change
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

Tested manually and by unit tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
