### PR TITLE
fix: [P4ADEV-2843] Fix next-back on Edit mode

### DIFF
--- a/src/routes/DebtTypeCreate/components/Step1Configuration.tsx
+++ b/src/routes/DebtTypeCreate/components/Step1Configuration.tsx
@@ -120,6 +120,14 @@ export const Step1Configuration = ({
     }
     onNext();
   };
+  /** This function test if in editmode. If true the validation is skipped
+   * cause the first step contains not-required field when call the PATCH service
+   */
+  const onInvalid = async () => {
+    if (editmode) {
+      onNext();
+    }
+  }
 
   return (
     <form aria-label="form">
@@ -374,7 +382,7 @@ export const Step1Configuration = ({
         </SectionBox>
       </WizardStepWrapper>
 
-      <WizardStepButtons onBack={onBack} onNext={handleSubmit(onSubmit)} />
+      <WizardStepButtons onBack={onBack} onNext={handleSubmit(onSubmit, onInvalid)} />
     </form>
   );
 };


### PR DESCRIPTION
This PR fixes the bug on the "edit mode" of a DebtType (Broker).

#### List of Changes
- manage a failed validation

#### Motivation and Context
When the user is in "edit mode" the first step data is not needed to update the target, so we not need a validation on the fields present in the first page.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
