### PR TITLE
feat: [P4ADEV-2748] debt position creation debt position draft

### DIFF
--- a/src/components/Wizard/WizardStepButtons.test.tsx
+++ b/src/components/Wizard/WizardStepButtons.test.tsx
@@ -2,132 +2,210 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import WizardStepButtons from './WizardStepButtons';
 
-// Mock della funzione di traduzione
 vi.mock('react-i18next', () => ({
   useTranslation: vi.fn(() => ({
     t: (key: string) => {
       if (key === 'commons.back') return 'Indietro';
       if (key === 'commons.continue') return 'Continua';
+      if (key === 'commons.saveDraft') return 'Salva bozza';
       return key;
     }
   }))
 }));
 
 describe('WizardStepButtons', () => {
-  it('renderizza correttamente i pulsanti con le etichette predefinite', () => {
+  it('renders the buttons correctly with default labels', () => {
     const onNext = vi.fn();
     const onBack = vi.fn();
-
     render(<WizardStepButtons onNext={onNext} onBack={onBack} />);
-
-    // Verifica che i pulsanti siano presenti con le etichette predefinite
     expect(screen.getByText('Indietro')).toBeInTheDocument();
     expect(screen.getByText('Continua')).toBeInTheDocument();
   });
 
-  it("utilizza l'etichetta personalizzata per il pulsante Next quando fornita", () => {
+  it('renders the next button with the custom label', () => {
     const onNext = vi.fn();
     const onBack = vi.fn();
-
     render(
       <WizardStepButtons onNext={onNext} onBack={onBack} nextLabel="Avanti" />
     );
-
-    // Verifica che il pulsante Next abbia l'etichetta personalizzata
     expect(screen.getByText('Avanti')).toBeInTheDocument();
   });
 
-  it('chiama onNext quando il pulsante Next viene cliccato', () => {
+  it('renders the back button with the custom label', () => {
     const onNext = vi.fn();
     const onBack = vi.fn();
+    render(
+      <WizardStepButtons onNext={onNext} onBack={onBack} backLabel="Torna" />
+    );
 
+    expect(screen.getByText('Torna')).toBeInTheDocument();
+  });
+
+  it('calls onNext when the Next button is clicked', () => {
+    const onNext = vi.fn();
+    const onBack = vi.fn();
     render(<WizardStepButtons onNext={onNext} onBack={onBack} />);
-
-    // Clicca sul pulsante Next
     fireEvent.click(screen.getByText('Continua'));
-
-    // Verifica che onNext sia stato chiamato
     expect(onNext).toHaveBeenCalledTimes(1);
   });
 
-  it('chiama onBack quando il pulsante Back viene cliccato', () => {
+  it('calls onBack when the Back button is clicked', () => {
     const onNext = vi.fn();
     const onBack = vi.fn();
-
     render(<WizardStepButtons onNext={onNext} onBack={onBack} />);
-
-    // Clicca sul pulsante Back
     fireEvent.click(screen.getByText('Indietro'));
-
-    // Verifica che onBack sia stato chiamato
     expect(onBack).toHaveBeenCalledTimes(1);
   });
 
-  it('disabilita il pulsante Next quando disableNext è true', () => {
+  it('disables the Next button when disableNext is true', () => {
     const onNext = vi.fn();
     const onBack = vi.fn();
-
     render(
       <WizardStepButtons onNext={onNext} onBack={onBack} disableNext={true} />
     );
-
-    // Verifica che il pulsante Next sia disabilitato
     expect(screen.getByText('Continua')).toBeDisabled();
   });
 
-  it('disabilita il pulsante Back quando disableBack è true', () => {
+  it('disables the Back button when disableBack is true', () => {
     const onNext = vi.fn();
     const onBack = vi.fn();
-
     render(
       <WizardStepButtons onNext={onNext} onBack={onBack} disableBack={true} />
     );
-
-    // Verifica che il pulsante Back sia disabilitato
     expect(screen.getByText('Indietro')).toBeDisabled();
   });
 
-  it('non chiama onBack quando il pulsante Back è disabilitato e viene cliccato', () => {
+  it('does not call onBack when the Back button is disabled and clicked', () => {
     const onNext = vi.fn();
     const onBack = vi.fn();
-
     render(
       <WizardStepButtons onNext={onNext} onBack={onBack} disableBack={true} />
     );
-
-    // Clicca sul pulsante Back disabilitato
     fireEvent.click(screen.getByText('Indietro'));
-
-    // Verifica che onBack non sia stato chiamato
     expect(onBack).not.toHaveBeenCalled();
   });
 
-  it('non chiama onNext quando il pulsante Next è disabilitato e viene cliccato', () => {
+  it('does not call onNext when the Next button is disabled and clicked', () => {
     const onNext = vi.fn();
     const onBack = vi.fn();
-
     render(
       <WizardStepButtons onNext={onNext} onBack={onBack} disableNext={true} />
     );
-
-    // Clicca sul pulsante Next disabilitato
     fireEvent.click(screen.getByText('Continua'));
-
-    // Verifica che onNext non sia stato chiamato
     expect(onNext).not.toHaveBeenCalled();
   });
 
-  it('funziona correttamente quando onBack non è fornito', () => {
+  it('works correctly when onBack is not provided', () => {
     const onNext = vi.fn();
-
     render(<WizardStepButtons onNext={onNext} />);
-
-    // Verifica che il pulsante Back sia presente
     expect(screen.getByText('Indietro')).toBeInTheDocument();
-
-    // Clicca sul pulsante Back
     fireEvent.click(screen.getByText('Indietro'));
+  });
 
-    // Non dovrebbe generare errori
+  it('works correctly when onNext is not provided', () => {
+    const onBack = vi.fn();
+    render(<WizardStepButtons onBack={onBack} />);
+    expect(screen.getByText('Continua')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Continua'));
+  });
+
+  it('does not show the Save Draft button by default', () => {
+    const onNext = vi.fn();
+    const onBack = vi.fn();
+    render(<WizardStepButtons onNext={onNext} onBack={onBack} />);
+    expect(screen.queryByText('Salva bozza')).not.toBeInTheDocument();
+  });
+
+  it('shows the Save Draft button when showSaveDraft is true', () => {
+    const onNext = vi.fn();
+    const onBack = vi.fn();
+    const onSaveDraft = vi.fn();
+
+    render(
+      <WizardStepButtons
+        onNext={onNext}
+        onBack={onBack}
+        onSaveDraft={onSaveDraft}
+        showSaveDraft={true}
+      />
+    );
+    expect(screen.getByText('Salva bozza')).toBeInTheDocument();
+  });
+
+  it('calls onSaveDraft when the Save Draft button is clicked', () => {
+    const onNext = vi.fn();
+    const onBack = vi.fn();
+    const onSaveDraft = vi.fn();
+    render(
+      <WizardStepButtons
+        onNext={onNext}
+        onBack={onBack}
+        onSaveDraft={onSaveDraft}
+        showSaveDraft={true}
+      />
+    );
+    fireEvent.click(screen.getByText('Salva bozza'));
+    expect(onSaveDraft).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the custom label for the Save Draft button when provided', () => {
+    const onNext = vi.fn();
+    const onBack = vi.fn();
+    const onSaveDraft = vi.fn();
+
+    render(
+      <WizardStepButtons
+        onNext={onNext}
+        onBack={onBack}
+        onSaveDraft={onSaveDraft}
+        showSaveDraft={true}
+        saveDraftLabel="Salva come bozza"
+      />
+    );
+    expect(screen.getByText('Salva come bozza')).toBeInTheDocument();
+  });
+
+  it('disables the Save Draft button when disableSaveDraft is true', () => {
+    const onNext = vi.fn();
+    const onBack = vi.fn();
+    const onSaveDraft = vi.fn();
+
+    render(
+      <WizardStepButtons
+        onNext={onNext}
+        onBack={onBack}
+        onSaveDraft={onSaveDraft}
+        showSaveDraft={true}
+        disableSaveDraft={true}
+      />
+    );
+    expect(screen.getByText('Salva bozza')).toBeDisabled();
+  });
+
+  it('does not call onSaveDraft when the Save Draft button is disabled and clicked', () => {
+    const onNext = vi.fn();
+    const onBack = vi.fn();
+    const onSaveDraft = vi.fn();
+    render(
+      <WizardStepButtons
+        onNext={onNext}
+        onBack={onBack}
+        onSaveDraft={onSaveDraft}
+        showSaveDraft={true}
+        disableSaveDraft={true}
+      />
+    );
+    fireEvent.click(screen.getByText('Salva bozza'));
+    expect(onSaveDraft).not.toHaveBeenCalled();
+  });
+
+  it('works correctly when onSaveDraft is not provided but showSaveDraft is true', () => {
+    const onNext = vi.fn();
+    const onBack = vi.fn();
+    render(
+      <WizardStepButtons onNext={onNext} onBack={onBack} showSaveDraft={true} />
+    );
+    expect(screen.getByText('Salva bozza')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Salva bozza'));
   });
 });

--- a/src/components/Wizard/WizardStepButtons.tsx
+++ b/src/components/Wizard/WizardStepButtons.tsx
@@ -1,44 +1,66 @@
 import { Box, Button } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { ArrowBack } from '@mui/icons-material';
+import { ArrowBack, Save } from '@mui/icons-material';
 
 type Props = {
   onBack?: () => void;
   onNext?: () => void;
+  onSaveDraft?: () => void;
   disableNext?: boolean;
   disableBack?: boolean;
+  disableSaveDraft?: boolean;
   nextLabel?: string;
   backLabel?: string;
+  showSaveDraft?: boolean;
+  saveDraftLabel?: string;
 };
 
 const WizardStepButtons = ({
   onBack,
   onNext,
+  onSaveDraft,
   disableNext,
   disableBack = false,
+  disableSaveDraft = false,
   nextLabel = 'commons.continue',
-  backLabel = 'commons.back'
+  backLabel = 'commons.back',
+  showSaveDraft = false,
+  saveDraftLabel = 'commons.saveDraft'
 }: Props) => {
   const { t } = useTranslation();
 
   return (
     <Box mt={4} display="flex" justifyContent="space-between">
-      <Button
-        variant="outlined"
-        onClick={onBack}
-        disabled={disableBack}
-        startIcon={<ArrowBack />}
-      >
-        {t(backLabel)}
-      </Button>
-      <Button
-        variant="contained"
-        onClick={onNext}
-        type="submit"
-        disabled={disableNext}
-      >
-        {t(nextLabel)}
-      </Button>
+      <Box>
+        <Button
+          variant="outlined"
+          onClick={onBack}
+          disabled={disableBack}
+          startIcon={<ArrowBack />}
+        >
+          {t(backLabel)}
+        </Button>
+      </Box>
+      <Box display="flex" gap={4}>
+        {showSaveDraft && (
+          <Button
+            variant="naked"
+            onClick={onSaveDraft}
+            disabled={disableSaveDraft}
+            startIcon={<Save />}
+          >
+            {t(saveDraftLabel)}
+          </Button>
+        )}
+        <Button
+          variant="contained"
+          onClick={onNext}
+          type="submit"
+          disabled={disableNext}
+        >
+          {t(nextLabel)}
+        </Button>
+      </Box>
     </Box>
   );
 };

--- a/src/models/BeneficiarySchema.ts
+++ b/src/models/BeneficiarySchema.ts
@@ -36,7 +36,7 @@ export const createAmountFieldSchema = (t: TFunction) => {
       if (numValue <= 0) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: t('debtPositionCreateWizard.step3.amount.negative')
+          message: t('debtPositionCreateWizard.step3.amount.positive')
         });
         return;
       }

--- a/src/models/InstallmentSchema.ts
+++ b/src/models/InstallmentSchema.ts
@@ -25,7 +25,7 @@ export const createInstallmentAmountFieldSchema = (t: TFunction) => {
       if (numValue <= 0) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: t('debtPositionCreateWizard.step3.amount.negative')
+          message: t('debtPositionCreateWizard.step3.amount.positive')
         });
         return;
       }

--- a/src/models/Step3Schema.ts
+++ b/src/models/Step3Schema.ts
@@ -94,7 +94,7 @@ export const createAmountSchema = (t: TFunction) =>
         )
         .refine(
           (val) => parseFloat(val.replace(',', '.')) > 0,
-          t('debtPositionCreateWizard.step3.amount.negative')
+          t('debtPositionCreateWizard.step3.amount.positive')
         )
         .refine((val) => {
           const parts = val.replace(',', '.').split('.');
@@ -201,7 +201,7 @@ function validateSinglePayment(
   if (numericAmount <= 0) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: t('debtPositionCreateWizard.step3.amount.negative'),
+      message: t('debtPositionCreateWizard.step3.amount.positive'),
       path: ['amount', 'value']
     });
   }

--- a/src/models/paymentTypes.ts
+++ b/src/models/paymentTypes.ts
@@ -154,7 +154,7 @@ export type AmountValidationRules = {
   /** Error message if the value is invalid */
   invalidValue: string;
   /** Error message if the value is negative */
-  negative: string;
+  positive: string;
   /** Error message if the value is zero */
   zero: string;
   /** Error message if the beneficiaries total doesn't match */

--- a/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizardCompleted.tsx
+++ b/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizardCompleted.tsx
@@ -95,14 +95,16 @@ function DebtPositionCreateWizardCompleted() {
           )}
         </Typography>
 
-        <Button
-          role="button"
-          variant="contained"
-          onClick={handleViewDebtPosition}
-        >
-          {t(translationKeys.viewDebtPosition)}
-        </Button>
-      </Box>{' '}
+        {isDraft && (
+          <Button
+            role="button"
+            variant="contained"
+            onClick={handleViewDebtPosition}
+          >
+            {t(translationKeys.viewDebtPosition)}
+          </Button>
+        )}
+      </Box>
       <Button
         role="button"
         variant="naked"

--- a/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizardCompleted.tsx
+++ b/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizardCompleted.tsx
@@ -4,13 +4,39 @@ import { useLocation, useNavigate } from 'react-router';
 import config from '../../utils/config';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { theme } from '@pagopa/mui-italia';
+import { DebtPositionStatus } from '../../../generated/data-contracts';
 
 function DebtPositionCreateWizardCompleted() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
   const deployPath = config.deployPath;
-  const description = location.state?.description || '';
+
+  const { description = '', status, debtPositionId } = location.state || {};
+  const isDraft = status === DebtPositionStatus.DRAFT;
+
+  const translationKeys = {
+    title: isDraft
+      ? 'debtPositionCreateWizardCompleted.draft'
+      : 'debtPositionCreateWizardCompleted.title',
+    description: isDraft
+      ? 'debtPositionCreateWizardCompleted.descriptionDraft'
+      : 'debtPositionCreateWizardCompleted.description',
+    viewDebtPosition: 'debtPositionCreateWizardCompleted.viewDebtPosition',
+    backToStart: 'debtPositionCreateWizardCompleted.backToStart'
+  };
+
+  const translationParams = {
+    paymentObject: description
+  };
+
+  function handleViewDebtPosition() {
+    if (isDraft) {
+      navigate(`${deployPath}/debt-positions/${debtPositionId}`);
+    } else {
+      navigate(`${deployPath}/debt-positions/`);
+    }
+  }
 
   return (
     <Box
@@ -53,9 +79,7 @@ function DebtPositionCreateWizardCompleted() {
             maxWidth: (theme) => theme.spacing(50)
           }}
         >
-          {t('debtPositionCreateWizardCompleted.title', {
-            paymentObject: description
-          })}
+          {t(translationKeys.title, translationParams)}
         </Typography>
 
         <Typography
@@ -65,17 +89,27 @@ function DebtPositionCreateWizardCompleted() {
             fontWeight: 400
           }}
         >
-          {t('debtPositionCreateWizardCompleted.description')}
+          {t(
+            translationKeys.description,
+            isDraft ? translationParams : undefined
+          )}
         </Typography>
 
         <Button
           role="button"
           variant="contained"
-          onClick={() => navigate(`${deployPath}/debt-positions/`)}
+          onClick={handleViewDebtPosition}
         >
-          {t('debtPositionCreateWizardCompleted.backToStart')}
+          {t(translationKeys.viewDebtPosition)}
         </Button>
-      </Box>
+      </Box>{' '}
+      <Button
+        role="button"
+        variant="naked"
+        onClick={() => navigate(`${deployPath}/debt-positions/`)}
+      >
+        {t(translationKeys.backToStart)}
+      </Button>
     </Box>
   );
 }

--- a/src/routes/DebtPositionCreateWizard/components/Step/Step3.test.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step/Step3.test.tsx
@@ -8,13 +8,17 @@ import {
   Step3Data,
   DebtPositionTypeEnum
 } from '../../../../models/DebtPositionType';
-import { PaymentOptionTypeEnum } from '../../../../../generated/data-contracts';
+import {
+  PaymentOptionTypeEnum,
+  DebtPositionStatus
+} from '../../../../../generated/data-contracts';
 import { MemoryRouter } from 'react-router-dom';
 import { useStore } from '../../../../store/GlobalStore';
 import debtPositionsApi from '../../../../api/debtPositions';
 
 // Import the mocked utility to access directly in tests
 import * as paymentUtility from '../../../../utils/paymentUtility';
+import * as installmentValidation from '../../../../utils/paymentUtility';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -140,10 +144,12 @@ vi.mock('../../../../components/Wizard/WizardStepButtons', () => ({
   default: ({
     onBack,
     onNext,
+    onSaveDraft,
     nextLabel
   }: {
     onBack: () => void;
     onNext: () => void;
+    onSaveDraft: () => void;
     nextLabel: string;
   }) => (
     <div data-testid="wizard-step-buttons">
@@ -152,6 +158,9 @@ vi.mock('../../../../components/Wizard/WizardStepButtons', () => ({
       </button>
       <button onClick={onNext} data-testid="next-button">
         {nextLabel}
+      </button>
+      <button onClick={onSaveDraft} data-testid="save-draft-button">
+        Save Draft
       </button>
     </div>
   )
@@ -289,9 +298,17 @@ describe('Step3 Component', () => {
     expect(screen.queryByTestId('date-picker')).not.toBeInTheDocument();
   });
 
-  it('should handle multi-beneficiary toggle', async () => {
+  it('should handle multi-beneficiary toggle and amount change', async () => {
+    // Mock della funzione triggerValidationForAllBeneficiaries
+    const triggerSpy = vi.fn();
+    vi.spyOn(
+      paymentUtility,
+      'triggerValidationForAllBeneficiaries'
+    ).mockImplementation(triggerSpy);
+
     renderComponent();
 
+    // Enable multi-beneficiary
     const multiBeneficiarySwitch = screen.getByRole('checkbox', {
       name: /Multiple Beneficiaries/i
     });
@@ -300,6 +317,15 @@ describe('Step3 Component', () => {
     await waitFor(() => {
       expect(screen.getByTestId('beneficiary-field')).toBeInTheDocument();
     });
+
+    // Imposta un valore per l'importo
+    const amountInput = screen.getByRole('textbox', { name: /Amount/i });
+    fireEvent.change(amountInput, { target: { value: '200,00' } });
+    fireEvent.blur(amountInput);
+
+    // Verifichiamo che il componente sia stato renderizzato correttamente
+    expect(screen.getByTestId('beneficiary-field')).toBeInTheDocument();
+    expect(amountInput).toHaveValue('200,00');
   });
 
   it('should handle form submission for single payment', async () => {
@@ -410,5 +436,153 @@ describe('Step3 Component', () => {
         paymentUtility.triggerValidationForAllBeneficiaries
       ).toHaveBeenCalled();
     });
+  });
+
+  it('should handle save as draft functionality', async () => {
+    renderComponent();
+
+    const paymentObjectInput = screen.getByRole('textbox', {
+      name: /Payment Object/i
+    });
+    fireEvent.change(paymentObjectInput, {
+      target: { value: 'Draft Payment Object' }
+    });
+
+    const amountInput = screen.getByRole('textbox', { name: /Amount/i });
+    fireEvent.change(amountInput, { target: { value: '150,75' } });
+    fireEvent.blur(amountInput);
+
+    const datePicker = screen.getByTestId('date-picker-input');
+    fireEvent.change(datePicker, { target: { value: '2025-08-20' } });
+
+    const saveDraftButton = screen.getByTestId('save-draft-button');
+    fireEvent.click(saveDraftButton);
+
+    await waitFor(() => {
+      expect(mockSetData).toHaveBeenCalledWith(
+        expect.objectContaining({
+          paymentObject: { value: 'Draft Payment Object', readonly: false },
+          amount: { value: '150.75', readonly: false }
+        })
+      );
+    });
+
+    expect(mockCreateDebtPosition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          status: DebtPositionStatus.DRAFT
+        })
+      })
+    );
+  });
+
+  it('should validate installments when submitting with installment payment option', async () => {
+    renderComponent();
+
+    // Change payment option to installments
+    const selectNativeInput = screen.getByDisplayValue('SINGLE');
+    fireEvent.change(selectNativeInput, {
+      target: { value: PaymentOptionTypeEnum.INSTALLMENTS }
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('installment-field')).toBeInTheDocument();
+    });
+
+    // Mock the validateInstallmentsData result
+    vi.spyOn(installmentValidation, 'validateInstallments').mockReturnValueOnce(
+      {
+        hasInvalidBeneficiaries: false,
+        hasInvalidPaymentFields: false,
+        hasInvalidAmounts: false,
+        hasEmptyRemittance: false
+      }
+    );
+
+    // Set up mock for syncInstallmentBeneficiaries to return valid data
+    vi.spyOn(
+      installmentValidation,
+      'syncInstallmentBeneficiaries'
+    ).mockReturnValueOnce({
+      installments: [
+        {
+          amount: '100',
+          dueDate: '2025-07-15',
+          remittance: 'Test payment',
+          isMultibeneficiary: false,
+          beneficiaries: []
+        }
+      ],
+      modified: true
+    });
+
+    const submitButton = screen.getByTestId('next-button');
+    fireEvent.click(submitButton);
+
+    // Verifichiamo che la funzione createDebtPosition sia stata chiamata
+    await waitFor(() => {
+      expect(mockCreateDebtPosition).toHaveBeenCalled();
+    });
+  });
+
+  it('should handle mandatory due date validation failure', async () => {
+    // Create component with mandatory due date flag set to true
+    render(
+      <MemoryRouter>
+        <Step3
+          data={{ ...initialData, flagMandatoryDueDate: true }}
+          setData={mockSetData}
+          onNext={mockOnNext}
+          onBack={mockOnBack}
+          step1Data={mockStep1Data}
+          step2Data={mockStep2Data}
+        />
+      </MemoryRouter>
+    );
+
+    // Clear the date picker
+    const datePicker = screen.getByTestId('date-picker-input');
+    fireEvent.change(datePicker, { target: { value: '' } });
+    fireEvent.blur(datePicker);
+
+    const submitButton = screen.getByTestId('next-button');
+    fireEvent.click(submitButton);
+
+    // Verifichiamo che la funzione createDebtPosition non sia stata chiamata
+    // poiché la validazione dovrebbe fallire
+    await waitFor(() => {
+      expect(mockCreateDebtPosition).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should validate due date when date changes and it is mandatory', async () => {
+    // Create component with mandatory due date flag set to true
+    render(
+      <MemoryRouter>
+        <Step3
+          data={{ ...initialData, flagMandatoryDueDate: true }}
+          setData={mockSetData}
+          onNext={mockOnNext}
+          onBack={mockOnBack}
+          step1Data={mockStep1Data}
+          step2Data={mockStep2Data}
+        />
+      </MemoryRouter>
+    );
+
+    // Get the date picker and trigger a change
+    const datePicker = screen.getByTestId('date-picker-input');
+
+    // First set a valid date
+    fireEvent.change(datePicker, { target: { value: '2025-07-15' } });
+
+    // Then clear it to trigger validation
+    fireEvent.change(datePicker, { target: { value: '' } });
+
+    // Simulate the DatePicker onClose event
+    fireEvent.blur(datePicker);
+
+    // Verifichiamo che il campo sia vuoto
+    expect(datePicker).toHaveValue('');
   });
 });

--- a/src/routes/DebtPositionCreateWizard/components/Step/Step3.test.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step/Step3.test.tsx
@@ -299,7 +299,6 @@ describe('Step3 Component', () => {
   });
 
   it('should handle multi-beneficiary toggle and amount change', async () => {
-    // Mock della funzione triggerValidationForAllBeneficiaries
     const triggerSpy = vi.fn();
     vi.spyOn(
       paymentUtility,
@@ -318,12 +317,10 @@ describe('Step3 Component', () => {
       expect(screen.getByTestId('beneficiary-field')).toBeInTheDocument();
     });
 
-    // Imposta un valore per l'importo
     const amountInput = screen.getByRole('textbox', { name: /Amount/i });
     fireEvent.change(amountInput, { target: { value: '200,00' } });
     fireEvent.blur(amountInput);
 
-    // Verifichiamo che il componente sia stato renderizzato correttamente
     expect(screen.getByTestId('beneficiary-field')).toBeInTheDocument();
     expect(amountInput).toHaveValue('200,00');
   });
@@ -518,8 +515,6 @@ describe('Step3 Component', () => {
 
     const submitButton = screen.getByTestId('next-button');
     fireEvent.click(submitButton);
-
-    // Verifichiamo che la funzione createDebtPosition sia stata chiamata
     await waitFor(() => {
       expect(mockCreateDebtPosition).toHaveBeenCalled();
     });
@@ -547,9 +542,6 @@ describe('Step3 Component', () => {
 
     const submitButton = screen.getByTestId('next-button');
     fireEvent.click(submitButton);
-
-    // Verifichiamo che la funzione createDebtPosition non sia stata chiamata
-    // poiché la validazione dovrebbe fallire
     await waitFor(() => {
       expect(mockCreateDebtPosition).not.toHaveBeenCalled();
     });
@@ -582,7 +574,6 @@ describe('Step3 Component', () => {
     // Simulate the DatePicker onClose event
     fireEvent.blur(datePicker);
 
-    // Verifichiamo che il campo sia vuoto
     expect(datePicker).toHaveValue('');
   });
 });

--- a/src/routes/DebtPositionCreateWizard/components/Step/Step3.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step/Step3.tsx
@@ -319,7 +319,7 @@ const Step3 = ({ data, setData, onBack, step1Data, step2Data }: Props) => {
     return { isValid: true, syncedInstallments };
   };
 
-  const onSubmit = async (values: Step3FormValues) => {
+  const onSubmit = async (values: Step3FormValues, isDraft = false) => {
     // Check due date field if mandatory
     if (!isInstallment && values.flagMandatoryDueDate) {
       if (!values.dueDate.value) {
@@ -380,7 +380,7 @@ const Step3 = ({ data, setData, onBack, step1Data, step2Data }: Props) => {
     // Prepare API POST body
     const postBody: DebtPositionDTO = {
       description: formattedValues.step1Data?.description.value || '',
-      status: DebtPositionStatus.UNPAID,
+      status: isDraft ? DebtPositionStatus.DRAFT : DebtPositionStatus.UNPAID,
       organizationId: organizationId,
       debtPositionTypeOrgId: Number(
         formattedValues.step1Data?.debtPositionType.value || 0
@@ -418,7 +418,7 @@ const Step3 = ({ data, setData, onBack, step1Data, step2Data }: Props) => {
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form onSubmit={handleSubmit((values) => onSubmit(values, false))}>
       <WizardStepWrapper
         title={t('debtPositionCreateWizard.configurationAlert.title')}
         subtitle={t('debtPositionCreateWizard.configurationAlert.subtitle')}
@@ -657,9 +657,12 @@ const Step3 = ({ data, setData, onBack, step1Data, step2Data }: Props) => {
       )}
       <WizardStepButtons
         onBack={onBack}
-        onNext={handleSubmit(onSubmit)}
+        onNext={handleSubmit((values) => onSubmit(values, false))}
+        onSaveDraft={() => handleSubmit((values) => onSubmit(values, true))()}
         disableNext={false}
         nextLabel="commons.create"
+        showSaveDraft={true}
+        saveDraftLabel="commons.saveDraft"
       />
     </form>
   );

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -239,6 +239,7 @@
       "TREASURY_SEARCH_RESULTS": "Risultato ricerca",
       "USERS": "Utenti"
     },
+    "saveDraft": "Salva bozza",
     "search": "Cerca",
     "searchCF": "Cerca CF",
     "searchFor": "Cerca per",
@@ -508,8 +509,11 @@
   },
   "debtPositionCreateWizardCompleted": {
     "backToStart": "Torna al'inizio",
+    "viewDebtPosition": "Vedi la posizione debitoria",
     "description": "La trovi nella sezione Dovuti, dove puoi tenere traccia dell'andamento.",
-    "title": "La posizione debitoria '{{paymentObject}}' è stata creata!"
+    "descriptionDraft": "La trovi nella sezione Dovuti, dove puoi vederla e modificarla.",
+    "title": "La posizione debitoria '{{paymentObject}}' è stata creata!",
+    "draft": "La posizione debitoria '{{paymentObject}}' è stata salvata in bozza."
   },
   "debtPositionDetail": {
     "debtPositionInfo": "Informazioni sulla posizione debitoria",


### PR DESCRIPTION
This PR enables the ability to save a Debt Position as a draft at the end of the creation wizard.


#### List of Changes

-Added a CTA (Call to Action) allowing the user to save the Debt Position as a draft.

-The final step of the wizard now allows saving the Debt Position either as final or draft.

-To save as a draft, the STATUS field is set to DRAFT.

-The createDebtPosition API is invoked with STATUS: DRAFT when the user selects the draft option.


#### How Has This Been Tested?
-visual testing
-unit tests

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
