### PR TITLE
fix: [P4ADEV-2612] refactor filter management to use specific filter keys and added a function to reset a filter to its default value

### DIFF
--- a/src/components/Drawer/FilterDrawer.test.tsx
+++ b/src/components/Drawer/FilterDrawer.test.tsx
@@ -6,8 +6,8 @@ import { useMultiFilters } from '../../hooks/useMultiFilters';
 
 vi.mock('../../hooks/useFilters', () => ({
   useFilters: () => ({
-    FILTER_TYPE_1: {
-      label: 'Filtro 1',
+    AMOUNT: {
+      label: 'AMOUNT',
       fields: [{ type: COMPONENT_TYPE.textField, label: 'commons.searchFor' }]
     }
   })
@@ -31,7 +31,7 @@ describe('Drawer Component', () => {
       />
     );
 
-    const selectLabels = screen.getAllByText('commons.searchFor');
+    const selectLabels = screen.getAllByText('commons.addfilter');
     expect(selectLabels[0]).toBeTruthy();
   });
 });

--- a/src/components/MultiFilter/Filter.test.tsx
+++ b/src/components/MultiFilter/Filter.test.tsx
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent } from '../../__tests__/renderers';
 import { Filter } from './Filter';
 import { FilterItem, COMPONENT_TYPE } from '../FilterContainer/FilterContainer';
+import { FilterMap } from '../../hooks/useMultiFilters';
+import { KeyofFilterMap } from '../../store/FilterStore';
 
 vi.mock('../FilterContainer/FilterContainer', () => ({
   default: vi.fn(({ items }) => (
@@ -20,22 +22,85 @@ vi.mock('../FilterContainer/FilterContainer', () => ({
   }
 }));
 
-const mockFilterMap = {
-  search: {
-    label: 'Search',
+const mockFilterMap: FilterMap = {
+  AMOUNT: {
+    label: 'AMOUNT',
     fields: [
       {
         type: COMPONENT_TYPE.textField,
-        label: 'Search Field'
+        label: 'AMOUNT Field'
       }
     ]
   },
-  name: {
-    label: 'Name',
+  BILL_CODE: {
+    label: 'BILL_CODE',
     fields: [
       {
         type: COMPONENT_TYPE.textField,
-        label: 'Name Field'
+        label: 'BILL_CODE Field'
+      }
+    ]
+  },
+  IUV: {
+    label: 'IUV',
+    fields: [
+      {
+        type: COMPONENT_TYPE.textField,
+        label: 'IUV Field'
+      }
+    ]
+  },
+  DOCUMENT_CODE: {
+    label: 'DOCUMENT_CODE',
+    fields: [
+      {
+        type: COMPONENT_TYPE.textField,
+        label: 'DOCUMENT_CODE Field'
+      }
+    ]
+  },
+  PAYER: {
+    label: 'PAYER',
+    fields: [
+      {
+        type: COMPONENT_TYPE.textField,
+        label: 'PAYER Field'
+      }
+    ]
+  },
+  REPORT_ID: {
+    label: 'REPORT_ID',
+    fields: [
+      {
+        type: COMPONENT_TYPE.textField,
+        label: 'REPORT_ID Field'
+      }
+    ]
+  },
+  TEMPORARY_CODE: {
+    label: 'TEMPORARY_CODE',
+    fields: [
+      {
+        type: COMPONENT_TYPE.textField,
+        label: 'TEMPORARY_CODE Field'
+      }
+    ]
+  },
+  ACCOUNTING_DATE: {
+    label: 'ACCOUNTING_DATE',
+    fields: [
+      {
+        type: COMPONENT_TYPE.textField,
+        label: 'ACCOUNTING_DATE Field'
+      }
+    ]
+  },
+  VALUE_DATE: {
+    label: 'VALUE_DATE',
+    fields: [
+      {
+        type: COMPONENT_TYPE.textField,
+        label: 'VALUE_DATE Field'
       }
     ]
   }
@@ -43,8 +108,8 @@ const mockFilterMap = {
 
 describe('Filter Component', () => {
   const onChange = vi.fn();
-  const value = 'search';
-  const selectedFilters = ['name'];
+  const value = 'AMOUNT';
+  const selectedFilters: Array<KeyofFilterMap> = ['AMOUNT'];
 
   it('renders select with options from filterMap', () => {
     render(
@@ -62,12 +127,12 @@ describe('Filter Component', () => {
 
     // Verify that the options are rendered correctly
     const options = screen.getAllByRole('option');
-    expect(options).toHaveLength(2);
-    expect(options[0]).toHaveTextContent('Search');
-    expect(options[1]).toHaveTextContent('Name');
+    expect(options).toHaveLength(9);
+    expect(options[0]).toHaveTextContent('AMOUNT');
+    expect(options[1]).toHaveTextContent('BILL_CODE');
 
     // Verify that the selectedFilters disable the correct option
-    expect(options[1]).toHaveAttribute('aria-disabled', 'true');
+    expect(options[0]).toHaveAttribute('aria-disabled', 'true');
   });
 
   it('renders fields from the selected filter', () => {
@@ -85,7 +150,7 @@ describe('Filter Component', () => {
     expect(filterContainer).toBeInTheDocument();
 
     // Verify that the fields for the selected value are rendered
-    const searchField = screen.getByText('Search Field');
+    const searchField = screen.getByText('AMOUNT Field');
     expect(searchField).toBeInTheDocument();
   });
 });

--- a/src/components/MultiFilter/Filter.tsx
+++ b/src/components/MultiFilter/Filter.tsx
@@ -4,12 +4,13 @@ import { FormComponent } from '../FormComponent';
 import FilterContainer from '../FilterContainer/FilterContainer';
 import { FilterMap } from '../../hooks/useMultiFilters';
 import { useTranslation } from 'react-i18next';
+import { KeyofFilterMap } from '../../store/FilterStore';
 
 export type FilterProps = {
   filterMap: FilterMap;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
-  value: string;
-  selectedFilters: Array<string>;
+  value: keyof FilterMap;
+  selectedFilters: Array<KeyofFilterMap>;
 };
 
 export const Filter = ({
@@ -24,7 +25,7 @@ export const Filter = ({
   const sortedOptions = Object.entries(filterMap).map(([key, value]) => ({
     label: value.label,
     value: key,
-    disabled: selectedFilters.includes(key)
+    disabled: selectedFilters.includes(key as KeyofFilterMap)
   }));
 
   return (

--- a/src/components/MultiFilter/MultiFilter.test.tsx
+++ b/src/components/MultiFilter/MultiFilter.test.tsx
@@ -23,21 +23,84 @@ vi.mock('../FilterContainer/FilterContainer', () => ({
 }));
 
 const mockFilterMap: FilterMap = {
-  search: {
-    label: 'Search',
+  AMOUNT: {
+    label: 'AMOUNT',
     fields: [
       {
         type: COMPONENT_TYPE.textField,
-        label: 'Search Field'
+        label: 'AMOUNT Field'
       }
     ]
   },
-  name: {
-    label: 'Name',
+  BILL_CODE: {
+    label: 'BILL_CODE',
     fields: [
       {
         type: COMPONENT_TYPE.textField,
-        label: 'Name Field'
+        label: 'BILL_CODE Field'
+      }
+    ]
+  },
+  IUV: {
+    label: 'IUV',
+    fields: [
+      {
+        type: COMPONENT_TYPE.textField,
+        label: 'IUV Field'
+      }
+    ]
+  },
+  DOCUMENT_CODE: {
+    label: 'DOCUMENT_CODE',
+    fields: [
+      {
+        type: COMPONENT_TYPE.textField,
+        label: 'DOCUMENT_CODE Field'
+      }
+    ]
+  },
+  PAYER: {
+    label: 'PAYER',
+    fields: [
+      {
+        type: COMPONENT_TYPE.textField,
+        label: 'PAYER Field'
+      }
+    ]
+  },
+  REPORT_ID: {
+    label: 'REPORT_ID',
+    fields: [
+      {
+        type: COMPONENT_TYPE.textField,
+        label: 'REPORT_ID Field'
+      }
+    ]
+  },
+  TEMPORARY_CODE: {
+    label: 'TEMPORARY_CODE',
+    fields: [
+      {
+        type: COMPONENT_TYPE.textField,
+        label: 'TEMPORARY_CODE Field'
+      }
+    ]
+  },
+  ACCOUNTING_DATE: {
+    label: 'ACCOUNTING_DATE',
+    fields: [
+      {
+        type: COMPONENT_TYPE.textField,
+        label: 'ACCOUNTING_DATE Field'
+      }
+    ]
+  },
+  VALUE_DATE: {
+    label: 'VALUE_DATE',
+    fields: [
+      {
+        type: COMPONENT_TYPE.textField,
+        label: 'VALUE_DATE Field'
       }
     ]
   }
@@ -46,12 +109,12 @@ const mockFilterMap: FilterMap = {
 describe('MultiFilter Component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    setSelectedFilters(['search']);
+    setSelectedFilters(['AMOUNT']);
   });
 
   it('invokes removeFilterRow with correct ID on remove button click', () => {
     // Start with both filters
-    setSelectedFilters(['search', 'name']);
+    setSelectedFilters(['AMOUNT', 'BILL_CODE']);
 
     render(<MultiFilter filterMap={mockFilterMap} />);
 
@@ -62,6 +125,6 @@ describe('MultiFilter Component', () => {
     // Remove firs filter row
     fireEvent.click(removeButtons[0]);
 
-    expect(selectedFilters.value).toEqual(['name']);
+    expect(selectedFilters.value).toEqual(['BILL_CODE']);
   });
 });

--- a/src/components/MultiFilter/MultiFilter.tsx
+++ b/src/components/MultiFilter/MultiFilter.tsx
@@ -8,7 +8,7 @@ import {
   addFilterRow,
   removeFilterRow,
   updateFilter,
-  KeyofFilterValues
+  KeyofFilterMap
 } from '../../store/FilterStore';
 import { ChangeEvent } from 'react';
 
@@ -25,14 +25,14 @@ const MultiFilter = ({ filterMap }: MultiFilterProps) => {
   } = useStore();
 
   const onChange = (e: ChangeEvent<HTMLInputElement>, index: number) => {
-    updateFilter(e.target.value as KeyofFilterValues, index);
+    updateFilter(e.target.value as KeyofFilterMap, index);
   };
 
   // Add the next not already selected filter
   const addNextFilterRow = () => {
-    const next: KeyofFilterValues | undefined = Object.keys(filterMap).find(
-      (id) => !selectedFilters.includes(id as KeyofFilterValues)
-    ) as KeyofFilterValues | undefined;
+    const next: KeyofFilterMap | undefined = Object.keys(filterMap).find(
+      (id) => !selectedFilters.includes(id as KeyofFilterMap)
+    ) as KeyofFilterMap;
     if (next) addFilterRow(next);
   };
 
@@ -48,7 +48,7 @@ const MultiFilter = ({ filterMap }: MultiFilterProps) => {
           {selectedFilters.length > 1 && (
             <IconButton
               sx={{ color: theme.palette.error.dark, alignSelf: 'flex-start' }}
-              onClick={() => removeFilterRow(filterId as KeyofFilterValues)}
+              onClick={() => removeFilterRow(filterId)}
               aria-label="remove"
             >
               <RemoveCircleOutline fontSize="small" />

--- a/src/components/MultiFilter/MultiFilter.tsx
+++ b/src/components/MultiFilter/MultiFilter.tsx
@@ -7,7 +7,8 @@ import { useStore } from '../../store/GlobalStore';
 import {
   addFilterRow,
   removeFilterRow,
-  updateFilter
+  updateFilter,
+  KeyofFilterValues
 } from '../../store/FilterStore';
 import { ChangeEvent } from 'react';
 
@@ -24,14 +25,16 @@ const MultiFilter = ({ filterMap }: MultiFilterProps) => {
   } = useStore();
 
   const onChange = (e: ChangeEvent<HTMLInputElement>, index: number) => {
-    updateFilter(e.target.value, index);
+    updateFilter(e.target.value as KeyofFilterValues, index);
   };
 
   // Add the next not already selected filter
-  const addNextFilterRow = () =>
-    addFilterRow(
-      Object.keys(filterMap).find((id: string) => !selectedFilters.includes(id))
-    );
+  const addNextFilterRow = () => {
+    const next: KeyofFilterValues | undefined = Object.keys(filterMap).find(
+      (id) => !selectedFilters.includes(id as KeyofFilterValues)
+    ) as KeyofFilterValues | undefined;
+    if (next) addFilterRow(next);
+  };
 
   return (
     <Stack gap={3}>
@@ -45,7 +48,7 @@ const MultiFilter = ({ filterMap }: MultiFilterProps) => {
           {selectedFilters.length > 1 && (
             <IconButton
               sx={{ color: theme.palette.error.dark, alignSelf: 'flex-start' }}
-              onClick={() => removeFilterRow(filterId)}
+              onClick={() => removeFilterRow(filterId as KeyofFilterValues)}
               aria-label="remove"
             >
               <RemoveCircleOutline fontSize="small" />

--- a/src/components/SearchCard/SearchCard.test.tsx
+++ b/src/components/SearchCard/SearchCard.test.tsx
@@ -17,18 +17,90 @@ describe('SearchCard', () => {
     ],
     button: [
       {
-        text: 'Search',
+        text: 'Filter',
         variant: 'contained' as const,
         onClick: vi.fn()
       }
     ],
     multiFilterConfig: {
-      searchTest: {
-        label: 'Test Search',
+      AMOUNT: {
+        label: 'Amount',
         fields: [
           {
             type: COMPONENT_TYPE.textField,
-            label: 'Test Field'
+            label: 'Amount Field'
+          }
+        ]
+      },
+      BILL_CODE: {
+        label: 'Bill Code',
+        fields: [
+          {
+            type: COMPONENT_TYPE.textField,
+            label: 'Bill Code Field'
+          }
+        ]
+      },
+      DOCUMENT_CODE: {
+        label: 'Document Code',
+        fields: [
+          {
+            type: COMPONENT_TYPE.textField,
+            label: 'Document Code Field'
+          }
+        ]
+      },
+      IUV: {
+        label: 'IUV',
+        fields: [
+          {
+            type: COMPONENT_TYPE.textField,
+            label: 'IUV Field'
+          }
+        ]
+      },
+      PAYER: {
+        label: 'PAYER',
+        fields: [
+          {
+            type: COMPONENT_TYPE.textField,
+            label: 'PAYER Field'
+          }
+        ]
+      },
+      REPORT_ID: {
+        label: 'REPORT_ID',
+        fields: [
+          {
+            type: COMPONENT_TYPE.textField,
+            label: 'REPORT_ID Field'
+          }
+        ]
+      },
+      TEMPORARY_CODE: {
+        label: 'TEMPORARY_CODE',
+        fields: [
+          {
+            type: COMPONENT_TYPE.textField,
+            label: 'TEMPORARY_CODE Field'
+          }
+        ]
+      },
+      ACCOUNTING_DATE: {
+        label: 'ACCOUNTING_DATE',
+        fields: [
+          {
+            type: COMPONENT_TYPE.textField,
+            label: 'ACCOUNTING_DATE Field'
+          }
+        ]
+      },
+      VALUE_DATE: {
+        label: 'VALUE_DATE',
+        fields: [
+          {
+            type: COMPONENT_TYPE.textField,
+            label: 'VALUE_DATE Field'
           }
         ]
       }
@@ -52,7 +124,7 @@ describe('SearchCard', () => {
   it('renders select field with options', () => {
     render(<SearchCard {...defaultProps} />);
 
-    const select = screen.getByLabelText('commons.searchFor');
+    const select = screen.getByLabelText('Search Field');
     expect(select).toBeInTheDocument();
   });
 
@@ -60,7 +132,7 @@ describe('SearchCard', () => {
     render(<SearchCard {...defaultProps} />);
 
     const button = screen.getByRole('button', { name: '' });
-    expect(button).toHaveAttribute('text', 'Search');
+    expect(button).toHaveAttribute('text', 'Filter');
 
     fireEvent.click(button);
     expect(defaultProps.button[0].onClick).toHaveBeenCalled();
@@ -69,7 +141,7 @@ describe('SearchCard', () => {
   it('renders MultiFilter when enabled', () => {
     render(<SearchCard {...defaultProps} />);
 
-    expect(screen.getByLabelText('commons.searchFor')).toBeInTheDocument();
+    expect(screen.getByLabelText('Search Field')).toBeInTheDocument();
   });
 
   it('does not render MultiFilter when disabled', () => {

--- a/src/components/Treasury/Treasury.tsx
+++ b/src/components/Treasury/Treasury.tsx
@@ -10,20 +10,11 @@ import { useMultiFilters } from '../../hooks/useMultiFilters';
 
 export const Treasury = () => {
   const { t } = useTranslation();
-  const {
-    filterMap,
-    removeAllFilters,
-    noFilterIsSelected,
-    filterValues,
-    selectedFilters
-  } = useMultiFilters({
+  const { filterMap, removeAllFilters, noFilterIsSelected } = useMultiFilters({
     clearOnMount: true
   });
   const navigate = useNavigate();
 
-  console.log('filterMap', filterMap);
-  console.log('filterValues', filterValues);
-  console.log('selectedFilters', selectedFilters);
   return (
     <>
       <TitleComponent

--- a/src/components/Treasury/Treasury.tsx
+++ b/src/components/Treasury/Treasury.tsx
@@ -15,6 +15,7 @@ export const Treasury = () => {
   });
   const navigate = useNavigate();
 
+  console.log('filterMap', filterMap);
   return (
     <>
       <TitleComponent

--- a/src/components/Treasury/Treasury.tsx
+++ b/src/components/Treasury/Treasury.tsx
@@ -10,12 +10,20 @@ import { useMultiFilters } from '../../hooks/useMultiFilters';
 
 export const Treasury = () => {
   const { t } = useTranslation();
-  const { filterMap, removeAllFilters, noFilterIsSelected } = useMultiFilters({
+  const {
+    filterMap,
+    removeAllFilters,
+    noFilterIsSelected,
+    filterValues,
+    selectedFilters
+  } = useMultiFilters({
     clearOnMount: true
   });
   const navigate = useNavigate();
 
   console.log('filterMap', filterMap);
+  console.log('filterValues', filterValues);
+  console.log('selectedFilters', selectedFilters);
   return (
     <>
       <TitleComponent

--- a/src/components/TreasurySearchResults/TreasurySearchResults.tsx
+++ b/src/components/TreasurySearchResults/TreasurySearchResults.tsx
@@ -69,7 +69,7 @@ const TreasurySearchResults = () => {
           startIcon={<FilterAlt />}
           onClick={toggleDrawer}
         >
-          {`${t('commons.filters.filtersField')} (${selectedFilters[0] === '' ? 0 : selectedFilters.length})`}
+          {`${t('commons.filters.filtersField')} (${selectedFilters.length})`}
         </ButtonNaked>
       </Grid>
 

--- a/src/hooks/useMultiFilters.tsx
+++ b/src/hooks/useMultiFilters.tsx
@@ -10,9 +10,21 @@ import {
   removeAllFilters,
   setFilterValues
 } from '../store/FilterStore';
+import { FilterValues } from '../models/Filters';
 
 export type FilterMap = Record<
-  string,
+  | keyof Omit<
+      FilterValues,
+      | 'ACCOUNTING_DATE_FROM'
+      | 'ACCOUNTING_DATE_TO'
+      | 'BILL_FROM'
+      | 'DOCUMENT_CODE_FROM'
+      | 'TEMPORARY_CODE_FROM'
+      | 'VALUE_DATE_FROM'
+      | 'VALUE_DATE_TO'
+    >
+  | 'ACCOUNTING_DATE'
+  | 'VALUE_DATE',
   { label: string; fields: Array<FilterItem> }
 >;
 
@@ -68,7 +80,7 @@ export const useMultiFilters = (props?: { clearOnMount?: boolean }) => {
         }
       ]
     },
-    BILL: {
+    BILL_CODE: {
       label: t('commons.filters.bill.label'),
       fields: [
         {

--- a/src/store/FilterStore.test.ts
+++ b/src/store/FilterStore.test.ts
@@ -19,41 +19,35 @@ describe('FilterStore', () => {
   });
 
   it('should set selectedFilters to a new state', () => {
-    setSelectedFilters(['ACCOUNTING_DATE_FROM', 'ACCOUNTING_DATE_TO']);
-    expect(selectedFilters.value).toEqual([
-      'ACCOUNTING_DATE_FROM',
-      'ACCOUNTING_DATE_TO'
-    ]);
+    setSelectedFilters(['ACCOUNTING_DATE', 'AMOUNT']);
+    expect(selectedFilters.value).toEqual(['ACCOUNTING_DATE', 'AMOUNT']);
   });
 
   it('should add a new filter row', () => {
-    addFilterRow('ACCOUNTING_DATE_FROM');
-    expect(selectedFilters.value).toEqual(['ACCOUNTING_DATE_FROM']);
+    addFilterRow('ACCOUNTING_DATE');
+    expect(selectedFilters.value).toEqual(['ACCOUNTING_DATE']);
   });
 
   it('should remove a filter row by its ID', () => {
-    setSelectedFilters(['ACCOUNTING_DATE_FROM', 'ACCOUNTING_DATE_TO']);
-    removeFilterRow('ACCOUNTING_DATE_TO');
-    expect(selectedFilters.value).toEqual(['ACCOUNTING_DATE_FROM']);
+    setSelectedFilters(['ACCOUNTING_DATE', 'AMOUNT']);
+    removeFilterRow('AMOUNT');
+    expect(selectedFilters.value).toEqual(['ACCOUNTING_DATE']);
   });
 
-  it('should not remove the last filter row', () => {
-    setSelectedFilters(['ACCOUNTING_DATE_FROM']);
-    removeFilterRow('ACCOUNTING_DATE_FROM');
-    expect(selectedFilters.value).toEqual(['ACCOUNTING_DATE_FROM']);
+  it('should remove the last filter row', () => {
+    setSelectedFilters(['ACCOUNTING_DATE']);
+    removeFilterRow('ACCOUNTING_DATE');
+    expect(selectedFilters.value).toEqual(['ACCOUNTING_DATE']);
   });
 
   it('should update a filter by index', () => {
-    setSelectedFilters(['ACCOUNTING_DATE_FROM', 'ACCOUNTING_DATE_TO']);
-    updateFilter('ACCOUNTING_DATE_TO', 1);
-    expect(selectedFilters.value).toEqual([
-      'ACCOUNTING_DATE_FROM',
-      'ACCOUNTING_DATE_TO'
-    ]);
+    setSelectedFilters(['ACCOUNTING_DATE', 'AMOUNT']);
+    updateFilter('AMOUNT', 1);
+    expect(selectedFilters.value).toEqual(['ACCOUNTING_DATE', 'AMOUNT']);
   });
 
   it('should remove all filters and reset to initial state', () => {
-    setSelectedFilters(['ACCOUNTING_DATE_FROM', 'ACCOUNTING_DATE_TO']);
+    setSelectedFilters(['ACCOUNTING_DATE', 'AMOUNT']);
     removeAllFilters();
     expect(selectedFilters.value).toEqual([]);
   });

--- a/src/store/FilterStore.test.ts
+++ b/src/store/FilterStore.test.ts
@@ -11,49 +11,50 @@ import {
 describe('FilterStore', () => {
   beforeEach(() => {
     // Reset selectedFilters to its initial value before each test
-    selectedFilters.value = [''];
+    selectedFilters.value = [];
   });
 
-  it('should initialize selectedFilters with an empty string', () => {
-    expect(selectedFilters.value).toEqual(['']);
+  it('should initialize selectedFilters with an empty array', () => {
+    expect(selectedFilters.value).toEqual([]);
   });
 
   it('should set selectedFilters to a new state', () => {
-    setSelectedFilters(['search', 'name']);
-    expect(selectedFilters.value).toEqual(['search', 'name']);
+    setSelectedFilters(['ACCOUNTING_DATE_FROM', 'ACCOUNTING_DATE_TO']);
+    expect(selectedFilters.value).toEqual([
+      'ACCOUNTING_DATE_FROM',
+      'ACCOUNTING_DATE_TO'
+    ]);
   });
 
   it('should add a new filter row', () => {
-    addFilterRow('search');
-    expect(selectedFilters.value).toEqual(['', 'search']);
+    addFilterRow('ACCOUNTING_DATE_FROM');
+    expect(selectedFilters.value).toEqual(['ACCOUNTING_DATE_FROM']);
   });
 
-  it('should add an empty filter row if no nextId is provided', () => {
-    addFilterRow();
-    expect(selectedFilters.value).toEqual(['', '']);
-  });
-
-  it('should remove a filter row by ID', () => {
-    setSelectedFilters(['search', 'name']);
-    removeFilterRow('search');
-    expect(selectedFilters.value).toEqual(['name']);
+  it('should remove a filter row by its ID', () => {
+    setSelectedFilters(['ACCOUNTING_DATE_FROM', 'ACCOUNTING_DATE_TO']);
+    removeFilterRow('ACCOUNTING_DATE_TO');
+    expect(selectedFilters.value).toEqual(['ACCOUNTING_DATE_FROM']);
   });
 
   it('should not remove the last filter row', () => {
-    setSelectedFilters(['search']);
-    removeFilterRow('search');
-    expect(selectedFilters.value).toEqual(['search']);
+    setSelectedFilters(['ACCOUNTING_DATE_FROM']);
+    removeFilterRow('ACCOUNTING_DATE_FROM');
+    expect(selectedFilters.value).toEqual(['ACCOUNTING_DATE_FROM']);
   });
 
   it('should update a filter by index', () => {
-    setSelectedFilters(['search', 'name']);
-    updateFilter('date', 1);
-    expect(selectedFilters.value).toEqual(['search', 'date']);
+    setSelectedFilters(['ACCOUNTING_DATE_FROM', 'ACCOUNTING_DATE_TO']);
+    updateFilter('ACCOUNTING_DATE_TO', 1);
+    expect(selectedFilters.value).toEqual([
+      'ACCOUNTING_DATE_FROM',
+      'ACCOUNTING_DATE_TO'
+    ]);
   });
 
   it('should remove all filters and reset to initial state', () => {
-    setSelectedFilters(['search', 'name', 'date']);
+    setSelectedFilters(['ACCOUNTING_DATE_FROM', 'ACCOUNTING_DATE_TO']);
     removeAllFilters();
-    expect(selectedFilters.value).toEqual(['']);
+    expect(selectedFilters.value).toEqual([]);
   });
 });

--- a/src/store/FilterStore.ts
+++ b/src/store/FilterStore.ts
@@ -18,7 +18,7 @@ export const initialFilterValues: FilterValues = {
   VALUE_DATE_TO: null
 };
 
-type KeyofFilterValues = keyof FilterValues;
+export type KeyofFilterValues = keyof FilterValues;
 
 export const selectedFilters = signal<Array<KeyofFilterValues>>([]);
 

--- a/src/store/FilterStore.ts
+++ b/src/store/FilterStore.ts
@@ -18,25 +18,28 @@ export const initialFilterValues: FilterValues = {
   VALUE_DATE_TO: null
 };
 
-export const selectedFilters = signal<Array<string>>(['']);
+type KeyofFilterValues = keyof FilterValues;
 
-export function setSelectedFilters(newState: Array<string>) {
+export const selectedFilters = signal<Array<KeyofFilterValues>>([]);
+
+export function setSelectedFilters(newState: Array<KeyofFilterValues>) {
   selectedFilters.value = newState;
 }
 
-export const addFilterRow = (nextId?: string) => {
+export const addFilterRow = (nextId: KeyofFilterValues) => {
   const filters = selectedFilters.value;
-  setSelectedFilters([...filters, nextId ?? '']);
+  setSelectedFilters([...filters, nextId]);
 };
 
-export const removeFilterRow = (id: string) => {
+export const removeFilterRow = (id: KeyofFilterValues) => {
   const filters = selectedFilters.value;
   if (filters.length > 1) {
     setSelectedFilters(filters.filter((filterId) => filterId !== id));
+    setFilterValue(id);
   }
 };
 
-export const updateFilter = (id: string, index: number) => {
+export const updateFilter = (id: KeyofFilterValues, index: number) => {
   const filters = [...selectedFilters.value];
   filters[index] = id;
   setSelectedFilters(filters);
@@ -52,7 +55,14 @@ export const setFilterValues = (newState: FilterValues) => {
   filterValues.value = newState;
 };
 
+export const setFilterValue = (id: KeyofFilterValues) => {
+  filterValues.value = {
+    ...filterValues.value,
+    [id]: initialFilterValues[id]
+  };
+};
+
 export const removeAllFilters = () => {
-  setSelectedFilters(['']);
+  setSelectedFilters([]);
   setFilterValues(initialFilterValues);
 };

--- a/src/store/FilterStore.ts
+++ b/src/store/FilterStore.ts
@@ -1,5 +1,6 @@
 import { computed, signal } from '@preact/signals-react';
 import { FilterValues } from '../models/Filters';
+import { FilterMap } from '../hooks/useMultiFilters';
 
 export const initialFilterValues: FilterValues = {
   ACCOUNTING_DATE_FROM: null,
@@ -18,28 +19,46 @@ export const initialFilterValues: FilterValues = {
   VALUE_DATE_TO: null
 };
 
+export const mapFilterNameToFilterValues: Record<
+  KeyofFilterMap,
+  Array<keyof FilterValues>
+> = {
+  ACCOUNTING_DATE: ['ACCOUNTING_DATE_FROM', 'ACCOUNTING_DATE_TO'],
+  AMOUNT: ['AMOUNT'],
+  BILL_CODE: ['BILL_CODE', 'BILL_FROM'],
+  DOCUMENT_CODE: ['DOCUMENT_CODE', 'DOCUMENT_CODE_FROM'],
+  IUV: ['IUV'],
+  PAYER: ['PAYER'],
+  REPORT_ID: ['REPORT_ID'],
+  TEMPORARY_CODE: ['TEMPORARY_CODE', 'TEMPORARY_CODE_FROM'],
+  VALUE_DATE: ['VALUE_DATE_FROM', 'VALUE_DATE_TO']
+};
+
+export type KeyofFilterMap = keyof FilterMap;
 export type KeyofFilterValues = keyof FilterValues;
 
-export const selectedFilters = signal<Array<KeyofFilterValues>>([]);
+export const selectedFilters = signal<Array<KeyofFilterMap>>([]);
 
-export function setSelectedFilters(newState: Array<KeyofFilterValues>) {
+export function setSelectedFilters(newState: Array<KeyofFilterMap>) {
   selectedFilters.value = newState;
 }
 
-export const addFilterRow = (nextId: KeyofFilterValues) => {
+export const addFilterRow = (nextId: KeyofFilterMap) => {
   const filters = selectedFilters.value;
   setSelectedFilters([...filters, nextId]);
 };
 
-export const removeFilterRow = (id: KeyofFilterValues) => {
+export const removeFilterRow = (id: KeyofFilterMap) => {
   const filters = selectedFilters.value;
   if (filters.length > 1) {
     setSelectedFilters(filters.filter((filterId) => filterId !== id));
-    setFilterValue(id);
+    mapFilterNameToFilterValues[id].forEach((filter) => {
+      resetFilterValue(filter);
+    });
   }
 };
 
-export const updateFilter = (id: KeyofFilterValues, index: number) => {
+export const updateFilter = (id: KeyofFilterMap, index: number) => {
   const filters = [...selectedFilters.value];
   filters[index] = id;
   setSelectedFilters(filters);
@@ -55,7 +74,7 @@ export const setFilterValues = (newState: FilterValues) => {
   filterValues.value = newState;
 };
 
-export const setFilterValue = (id: KeyofFilterValues) => {
+export const resetFilterValue = (id: keyof FilterValues) => {
   filterValues.value = {
     ...filterValues.value,
     [id]: initialFilterValues[id]

--- a/src/store/GlobalStore.test.tsx
+++ b/src/store/GlobalStore.test.tsx
@@ -47,7 +47,7 @@ describe('StoreContext', () => {
         [STATE.APP_STATE]: { loading: false },
         [STATE.CONFIG_FE]: null,
         [STATE.ORGANIZATION_ID]: null,
-        [STATE.SELECTED_FILTERS]: [''],
+        [STATE.SELECTED_FILTERS]: [],
         [STATE.FILTER_VALUES]: initialFilterValues
       })
     );

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -5,14 +5,14 @@ import { OperatoRole } from '../models/OperatorRole';
 import { OrganizationIdMemo } from '../models/Organization';
 import { UserInfo } from '../../generated/data-contracts';
 import { IdTokenPayload } from '../models/IdTokenPayload';
-import { KeyofFilterValues } from './FilterStore';
+import { FilterMap } from '../hooks/useMultiFilters';
 
 export type State = {
   [STATE.USER_INFO]: UserInfo | undefined;
   [STATE.ORGANIZATION_ID]: OrganizationIdMemo;
   [STATE.CONFIG_FE]: ConfigFE | undefined;
   [STATE.APP_STATE]: AppState;
-  [STATE.SELECTED_FILTERS]: Array<KeyofFilterValues>;
+  [STATE.SELECTED_FILTERS]: Array<keyof FilterMap>;
   [STATE.FILTER_VALUES]: FilterValues;
   [STATE.OPERATOR_ROLE]: OperatoRole | undefined;
   [STATE.ID_TOKEN]: IdTokenPayload | undefined;

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -5,13 +5,14 @@ import { OperatoRole } from '../models/OperatorRole';
 import { OrganizationIdMemo } from '../models/Organization';
 import { UserInfo } from '../../generated/data-contracts';
 import { IdTokenPayload } from '../models/IdTokenPayload';
+import { KeyofFilterValues } from './FilterStore';
 
 export type State = {
   [STATE.USER_INFO]: UserInfo | undefined;
   [STATE.ORGANIZATION_ID]: OrganizationIdMemo;
   [STATE.CONFIG_FE]: ConfigFE | undefined;
   [STATE.APP_STATE]: AppState;
-  [STATE.SELECTED_FILTERS]: Array<string>;
+  [STATE.SELECTED_FILTERS]: Array<KeyofFilterValues>;
   [STATE.FILTER_VALUES]: FilterValues;
   [STATE.OPERATOR_ROLE]: OperatoRole | undefined;
   [STATE.ID_TOKEN]: IdTokenPayload | undefined;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- a refactor on filters business logic to adopt more specific types
- added a new function to reset a specific filter to its default value
- fixing a bug with filter reset on filter removal
- unit test update

<!--- Describe your changes in detail -->

#### Motivation and Context

This PR fixes a bug about the reset of the filters status when they are removed

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

Tested by manual testing and through unit tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
