### PR TITLE
feat: [P4ADEV-2782] DebtPositionTypeOrg create api

### DIFF
--- a/src/api/debtPositionsTypeOrg.test.ts
+++ b/src/api/debtPositionsTypeOrg.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
+import { renderHook, waitFor } from '../__tests__/renderers';
+import utils from '../utils';
+import { getDebtPositionTypeOrgs } from './debtPositionsTypeOrg';
+
+vi.mock('../utils', () => ({
+  default: {
+    apiClient: {
+      bff: {
+        getDebtPositionTypeOrgs: vi.fn()
+      }
+    }
+  }
+}));
+
+vi.mock('../utils/loaders', () => ({
+  parseAndLog: vi.fn()
+}));
+describe('getDebtPositionTypeOrgs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should fetch and return debt position types', async () => {
+    const mockData = [
+      { id: 1, description: 'Type A' },
+      { id: 2, description: 'Type B' }
+    ];
+
+    (utils.apiClient.bff.getDebtPositionTypeOrgs as Mock).mockResolvedValue({
+      data: mockData
+    });
+
+    const { result } = renderHook(() =>
+      getDebtPositionTypeOrgs({ organizationId: 123 })
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockData);
+    expect(utils.apiClient.bff.getDebtPositionTypeOrgs).toHaveBeenCalledWith(
+      123
+    );
+  });
+});

--- a/src/api/debtPositionsTypeOrg.test.ts
+++ b/src/api/debtPositionsTypeOrg.test.ts
@@ -1,13 +1,19 @@
 import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
-import { renderHook, waitFor } from '../__tests__/renderers';
+import { renderHook, waitFor, act } from '../__tests__/renderers';
 import utils from '../utils';
-import { getDebtPositionTypeOrgs } from './debtPositionsTypeOrg';
+import {
+  getDebtPositionTypeOrgs,
+  createDebtPositionTypeOrg,
+  CreateDebtPositionTypeOrg
+} from './debtPositionsTypeOrg';
+import { parseAndLog } from '../utils/loaders';
 
 vi.mock('../utils', () => ({
   default: {
     apiClient: {
       bff: {
-        getDebtPositionTypeOrgs: vi.fn()
+        getDebtPositionTypeOrgs: vi.fn(),
+        createDebtPositionTypeOrg: vi.fn()
       }
     }
   }
@@ -16,6 +22,7 @@ vi.mock('../utils', () => ({
 vi.mock('../utils/loaders', () => ({
   parseAndLog: vi.fn()
 }));
+
 describe('getDebtPositionTypeOrgs', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -43,5 +50,64 @@ describe('getDebtPositionTypeOrgs', () => {
     expect(utils.apiClient.bff.getDebtPositionTypeOrgs).toHaveBeenCalledWith(
       123
     );
+  });
+});
+
+describe('createDebtPositionTypeOrg', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should call API and parseAndLog, then return data on success', async () => {
+    const mockInput = {
+      organizationId: 123,
+      data: { name: 'Test Type', code: 'TST' }
+    };
+    const mockResponse = { id: 1, name: 'Test Type', code: 'TST' };
+
+    (utils.apiClient.bff.createDebtPositionTypeOrg as Mock).mockResolvedValue({
+      data: mockResponse
+    });
+
+    const { result } = renderHook(() => createDebtPositionTypeOrg());
+
+    await act(async () => {
+      result.current.mutate(mockInput as unknown as CreateDebtPositionTypeOrg);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(utils.apiClient.bff.createDebtPositionTypeOrg).toHaveBeenCalledWith(
+      mockInput.organizationId,
+      mockInput.data
+    );
+    expect(parseAndLog).toHaveBeenCalled();
+    expect(result.current.data).toEqual(mockResponse);
+  });
+
+  it('should handle errors from the API', async () => {
+    const mockInput = {
+      organizationId: 123,
+      data: { name: 'Test Type', code: 'TST' }
+    };
+    const error = new Error('API error');
+
+    (utils.apiClient.bff.createDebtPositionTypeOrg as Mock).mockRejectedValue(
+      error
+    );
+
+    const { result } = renderHook(() => createDebtPositionTypeOrg());
+
+    await act(async () => {
+      result.current.mutate(mockInput as unknown as CreateDebtPositionTypeOrg);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toBe(error);
   });
 });

--- a/src/api/debtPositionsTypeOrg.ts
+++ b/src/api/debtPositionsTypeOrg.ts
@@ -1,0 +1,37 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import utils from '../utils';
+import { SaveDebtPositionTypeOrgDTO } from '../../generated/data-contracts';
+import { debtPositionTypeOrgSchema } from '../../generated/zod-schema';
+import { parseAndLog } from '../utils/loaders';
+
+export const getDebtPositionTypeOrgs = ({
+  organizationId
+}: {
+  organizationId: number;
+}) =>
+  useQuery({
+    queryKey: ['getDebtPositionTypeOrgs', organizationId],
+    queryFn: async () => {
+      const { data: response } =
+        await utils.apiClient.bff.getDebtPositionTypeOrgs(organizationId);
+      return response;
+    }
+  });
+
+export type CreateDebtPositionTypeOrg = {
+  organizationId: number;
+  data: SaveDebtPositionTypeOrgDTO;
+};
+
+export const createDebtPositionTypeOrg = () =>
+  useMutation({
+    mutationKey: ['postDebtPositionTypeOrg'],
+    mutationFn: async (query: CreateDebtPositionTypeOrg) => {
+      const { data } = await utils.apiClient.bff.createDebtPositionTypeOrg(
+        query.organizationId,
+        query.data
+      );
+      parseAndLog(debtPositionTypeOrgSchema, data);
+      return data;
+    }
+  });

--- a/src/api/debtPositionsTypes.test.ts
+++ b/src/api/debtPositionsTypes.test.ts
@@ -1,17 +1,13 @@
 import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
 import { renderHook, waitFor } from '../__tests__/renderers';
 import utils from '../utils';
-import {
-  getDebtPositionsTypes,
-  getDebtPositionTypeWithCount
-} from './debtPositionsTypes';
+import { getDebtPositionTypeWithCount } from './debtPositionsTypes';
 import { parseAndLog } from '../utils/loaders';
 
 vi.mock('../utils', () => ({
   default: {
     apiClient: {
       bff: {
-        getDebtPositionTypeOrgs: vi.fn(),
         getDebtPositionTypeWithCount: vi.fn()
       }
     }
@@ -21,36 +17,6 @@ vi.mock('../utils', () => ({
 vi.mock('../utils/loaders', () => ({
   parseAndLog: vi.fn()
 }));
-
-describe('getDebtPositionsTypes', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('should fetch and return debt position types', async () => {
-    const mockData = [
-      { id: 1, description: 'Type A' },
-      { id: 2, description: 'Type B' }
-    ];
-
-    (utils.apiClient.bff.getDebtPositionTypeOrgs as Mock).mockResolvedValue({
-      data: mockData
-    });
-
-    const { result } = renderHook(() =>
-      getDebtPositionsTypes({ organizationId: 123 })
-    );
-
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
-
-    expect(result.current.data).toEqual(mockData);
-    expect(utils.apiClient.bff.getDebtPositionTypeOrgs).toHaveBeenCalledWith(
-      123
-    );
-  });
-});
 
 describe('getDebtPositionTypeWithCount', () => {
   beforeEach(() => {

--- a/src/api/debtPositionsTypes.ts
+++ b/src/api/debtPositionsTypes.ts
@@ -10,26 +10,10 @@ import {
   DebtPositionTypeRequestBody
 } from '../../generated/data-contracts';
 
-export const getDebtPositionsTypes = ({
-  organizationId
-}: {
-  organizationId: number;
-}) =>
-  useQuery({
-    queryKey: ['getDebtPositionsTypes', organizationId],
-    queryFn: async () => {
-      const { data: response } =
-        await utils.apiClient.bff.getDebtPositionTypeOrgs(organizationId);
-      return response;
-    }
-  });
-
 type DebtPositionTypeWithCountParams = Parameters<
   typeof utils.apiClient.bff.getDebtPositionTypeWithCount
 >;
-
 export type DebtPositionTypeWithCountQuery = DebtPositionTypeWithCountParams[1];
-
 export type DebtPositionTypeWithCountRequest = {
   organizationId: DebtPositionTypeWithCountParams[0];
   query: DebtPositionTypeWithCountQuery;
@@ -85,5 +69,21 @@ export const patchDebtPositionType = (debtPositionTypeId: number) =>
         data
       );
       return response.data;
+    }
+  });
+
+export const getDebtPositionTypesByOrganizationId = ({
+  organizationId
+}: {
+  organizationId: number;
+}) =>
+  useQuery({
+    queryKey: ['getDebtPositionTypesByOrganizationId', organizationId],
+    queryFn: async () => {
+      const { data: response } =
+        await utils.apiClient.bff.getDebtPositionTypesByOrganizationId(
+          organizationId
+        );
+      return response;
     }
   });

--- a/src/hooks/useDebtPositionTypesByOrg.test.tsx
+++ b/src/hooks/useDebtPositionTypesByOrg.test.tsx
@@ -1,0 +1,115 @@
+import { renderHook } from '../__tests__/renderers';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useDebtPositionTypesByOrg } from './useDebtPositionTypesByOrg';
+import utils from '../utils';
+import { getDebtPositionTypesByOrganizationId } from '../api/debtPositionsTypes';
+import { QueryObserverPendingResult } from '@tanstack/react-query';
+import { DebtPositionType } from '../../generated/data-contracts';
+
+const mockT = vi.fn((key: string) => key);
+
+vi.mock('../api/debtPositionsTypes', () => ({
+  getDebtPositionTypesByOrganizationId: vi.fn()
+}));
+
+vi.mock('../utils', () => ({
+  default: {
+    notify: {
+      emit: vi.fn()
+    }
+  }
+}));
+
+type MockQueryType = QueryObserverPendingResult<Array<DebtPositionType>, Error>;
+
+describe('useDebtPositionTypesByOrg', () => {
+  const mockQueryResult = {
+    data: null,
+    isLoading: false,
+    isError: false,
+    isSuccess: false,
+    error: null
+  } as unknown as MockQueryType;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockT.mockClear();
+  });
+
+  it('should initialize with an empty options list', () => {
+    vi.mocked(getDebtPositionTypesByOrganizationId).mockReturnValue(
+      mockQueryResult
+    );
+
+    const { result } = renderHook(() =>
+      useDebtPositionTypesByOrg({ organizationId: 1 })
+    );
+
+    expect(result.current.optionsMap).toEqual([]);
+  });
+
+  it('should set options correctly on successful response', () => {
+    const mockData = [
+      { description: 'Type B', debtPositionTypeId: 2 },
+      { description: 'Type A', debtPositionTypeId: 1 }
+    ];
+
+    vi.mocked(getDebtPositionTypesByOrganizationId).mockReturnValue({
+      ...mockQueryResult,
+      data: mockData,
+      isSuccess: true
+    } as unknown as MockQueryType);
+
+    const { result } = renderHook(() =>
+      useDebtPositionTypesByOrg({ organizationId: 1 })
+    );
+
+    // Should be sorted alphabetically by description
+    expect(result.current.optionsMap).toEqual([
+      { label: 'Type A', value: 1 },
+      { label: 'Type B', value: 2 }
+    ]);
+  });
+
+  it('should handle empty or invalid response', () => {
+    vi.mocked(getDebtPositionTypesByOrganizationId).mockReturnValue({
+      ...mockQueryResult,
+      data: [],
+      isSuccess: true
+    } as unknown as MockQueryType);
+
+    const { result } = renderHook(() =>
+      useDebtPositionTypesByOrg({ organizationId: 1 })
+    );
+
+    expect(result.current.optionsMap).toEqual([]);
+  });
+
+  it('should handle API error and show notification', () => {
+    vi.mocked(getDebtPositionTypesByOrganizationId).mockReturnValue({
+      ...mockQueryResult,
+      isError: true,
+      error: new Error('API error')
+    } as unknown as MockQueryType);
+
+    renderHook(() => useDebtPositionTypesByOrg({ organizationId: 1 }));
+
+    expect(utils.notify.emit).toHaveBeenCalledWith(
+      'errors.fetchDebtPositionsTypes',
+      'error'
+    );
+  });
+
+  it('should keep options empty while loading', () => {
+    vi.mocked(getDebtPositionTypesByOrganizationId).mockReturnValue({
+      ...mockQueryResult,
+      isLoading: true
+    });
+
+    const { result } = renderHook(() =>
+      useDebtPositionTypesByOrg({ organizationId: 1 })
+    );
+
+    expect(result.current.optionsMap).toEqual([]);
+  });
+});

--- a/src/hooks/useDebtPositionTypesByOrg.tsx
+++ b/src/hooks/useDebtPositionTypesByOrg.tsx
@@ -19,7 +19,7 @@ export const useDebtPositionTypesByOrg = ({
     organizationId
   });
 
-  const { data, isLoading, isError, isSuccess } = debtPositionsTypesQuery;
+  const { data, isError, isSuccess } = debtPositionsTypesQuery;
 
   useEffect(() => {
     if (isSuccess && data) {
@@ -36,7 +36,7 @@ export const useDebtPositionTypesByOrg = ({
     if (isError) {
       utils.notify.emit(t('errors.fetchDebtPositionsTypes'), 'error');
     }
-  }, [data, isLoading, isError, isSuccess, t]);
+  }, [data, isError, isSuccess, t]);
 
   return { optionsMap: debtPositionsTypes, ...debtPositionsTypesQuery };
 };

--- a/src/hooks/useDebtPositionTypesByOrg.tsx
+++ b/src/hooks/useDebtPositionTypesByOrg.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import utils from '../utils';
+import { getDebtPositionTypesByOrganizationId } from '../api/debtPositionsTypes';
+import { DebtPositionType } from '../../generated/data-contracts';
+import { SelectOptions } from '../components/FormComponent/_Select';
+
+export const useDebtPositionTypesByOrg = ({
+  organizationId
+}: {
+  organizationId: number;
+}) => {
+  const [debtPositionsTypes, setDebtPositionsTypes] = useState<SelectOptions>(
+    []
+  );
+  const { t } = useTranslation();
+
+  const debtPositionsTypesQuery = getDebtPositionTypesByOrganizationId({
+    organizationId
+  });
+
+  const { data, isLoading, isError, isSuccess } = debtPositionsTypesQuery;
+
+  useEffect(() => {
+    if (isSuccess && data) {
+      const dueTypesMap = [...data]
+        .sort((a, b) => a.description.localeCompare(b.description))
+        .map((type: DebtPositionType) => ({
+          label: type.description,
+          value: type.debtPositionTypeId
+        }));
+
+      setDebtPositionsTypes(dueTypesMap);
+    }
+
+    if (isError) {
+      utils.notify.emit(t('errors.fetchDebtPositionsTypes'), 'error');
+    }
+  }, [data, isLoading, isError, isSuccess, t]);
+
+  return { optionsMap: debtPositionsTypes, ...debtPositionsTypesQuery };
+};

--- a/src/hooks/useDebtPositionsFilters.test.tsx
+++ b/src/hooks/useDebtPositionsFilters.test.tsx
@@ -6,10 +6,10 @@ import {
   ButtonField,
   SelectField
 } from '../components/FilterContainer/FilterContainer';
-import { getDebtPositionsTypes } from '../api/debtPositionsTypes';
+import { getDebtPositionTypeOrgs } from '../api/debtPositionsTypeOrg';
 
-vi.mock('../api/debtPositionsTypes', () => ({
-  getDebtPositionsTypes: vi.fn()
+vi.mock('../api/debtPositionsTypeOrg', () => ({
+  getDebtPositionTypeOrgs: vi.fn()
 }));
 
 vi.mock('./useDebtPositionsTypeOrg', () => ({
@@ -29,7 +29,7 @@ describe('useDebtPositionFilters', () => {
   });
 
   it('should return correct filters for DEBT_POSITION search type', async () => {
-    (getDebtPositionsTypes as unknown as Mock).mockReturnValue({
+    (getDebtPositionTypeOrgs as unknown as Mock).mockReturnValue({
       isSuccess: true,
       data: {
         data: {
@@ -74,7 +74,7 @@ describe('useDebtPositionFilters', () => {
   });
 
   it('should return correct filters for IUV search type', () => {
-    (getDebtPositionsTypes as unknown as Mock).mockReturnValue({
+    (getDebtPositionTypeOrgs as unknown as Mock).mockReturnValue({
       isSuccess: true,
       data: {
         data: {
@@ -104,7 +104,7 @@ describe('useDebtPositionFilters', () => {
   });
 
   it('should call onFilter when the apply button is triggered', () => {
-    (getDebtPositionsTypes as unknown as Mock).mockReturnValue({
+    (getDebtPositionTypeOrgs as unknown as Mock).mockReturnValue({
       isSuccess: true,
       data: {
         data: {

--- a/src/hooks/useDebtPositionsTypeOrg.test.tsx
+++ b/src/hooks/useDebtPositionsTypeOrg.test.tsx
@@ -3,13 +3,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useDebtPositionsTypeOrg } from './useDebtPositionsTypeOrg';
 import { QueryObserverPendingResult } from '@tanstack/react-query';
 import { DebtPositionTypeOrg } from '../../generated/apiClient';
-import { getDebtPositionsTypes } from '../api/debtPositionsTypes';
 import utils from '../utils';
+import { getDebtPositionTypeOrgs } from '../api/debtPositionsTypeOrg';
 
 const mockT = vi.fn((key: string) => key);
 
-vi.mock('../api/debtPositionsTypes', () => ({
-  getDebtPositionsTypes: vi.fn()
+vi.mock('../api/debtPositionsTypeOrg', () => ({
+  getDebtPositionTypeOrgs: vi.fn()
 }));
 
 vi.mock('../utils', () => ({
@@ -55,7 +55,7 @@ describe('useDebtPositionsTypeOrg', () => {
   });
 
   it('should initialize with an empty options list', () => {
-    vi.mocked(getDebtPositionsTypes).mockReturnValue(mockQueryResult);
+    vi.mocked(getDebtPositionTypeOrgs).mockReturnValue(mockQueryResult);
 
     const { result } = renderHook(() =>
       useDebtPositionsTypeOrg({ organizationId: 1 })
@@ -70,7 +70,7 @@ describe('useDebtPositionsTypeOrg', () => {
       { description: 'Type B', debtPositionTypeOrgId: 2 }
     ];
 
-    vi.mocked(getDebtPositionsTypes).mockReturnValue({
+    vi.mocked(getDebtPositionTypeOrgs).mockReturnValue({
       ...mockQueryResult,
       data: mockData,
       isSuccess: true
@@ -93,7 +93,7 @@ describe('useDebtPositionsTypeOrg', () => {
       { description: 'Type B', debtPositionTypeOrgId: 2 }
     ];
 
-    vi.mocked(getDebtPositionsTypes).mockReturnValue({
+    vi.mocked(getDebtPositionTypeOrgs).mockReturnValue({
       ...mockQueryResult,
       data: mockData,
       isSuccess: true
@@ -110,7 +110,7 @@ describe('useDebtPositionsTypeOrg', () => {
   });
 
   it('should handle empty or invalid response with all option', () => {
-    vi.mocked(getDebtPositionsTypes).mockReturnValue({
+    vi.mocked(getDebtPositionTypeOrgs).mockReturnValue({
       ...mockQueryResult,
       data: [],
       isSuccess: true
@@ -126,7 +126,7 @@ describe('useDebtPositionsTypeOrg', () => {
   });
 
   it('should handle empty or invalid response without all option', () => {
-    vi.mocked(getDebtPositionsTypes).mockReturnValue({
+    vi.mocked(getDebtPositionTypeOrgs).mockReturnValue({
       ...mockQueryResult,
       data: [],
       isSuccess: true
@@ -140,7 +140,7 @@ describe('useDebtPositionsTypeOrg', () => {
   });
 
   it('should handle API error and show notification', () => {
-    vi.mocked(getDebtPositionsTypes).mockReturnValue({
+    vi.mocked(getDebtPositionTypeOrgs).mockReturnValue({
       ...mockQueryResult,
       isError: true,
       error: new Error('API error')

--- a/src/hooks/useDebtPositionsTypeOrg.tsx
+++ b/src/hooks/useDebtPositionsTypeOrg.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 import { DebtPositionTypeOrg } from '../../generated/apiClient';
 import { useTranslation } from 'react-i18next';
-import { getDebtPositionsTypes } from '../api/debtPositionsTypes';
 import { DebtPositionType } from '../models/DebtPositionType';
 import utils from '../utils';
+import { getDebtPositionTypeOrgs } from '../api/debtPositionsTypeOrg';
 
 export const useDebtPositionsTypeOrg = ({
   organizationId,
@@ -17,7 +17,7 @@ export const useDebtPositionsTypeOrg = ({
   >([]);
   const { t } = useTranslation();
 
-  const debtPositionsTypesQuery = getDebtPositionsTypes({
+  const debtPositionsTypesQuery = getDebtPositionTypeOrgs({
     organizationId
   });
 

--- a/src/hooks/useTelematicReceiptsFilters.test.tsx
+++ b/src/hooks/useTelematicReceiptsFilters.test.tsx
@@ -2,10 +2,10 @@ import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
 import { renderHook } from '../__tests__/renderers';
 import useTelematicReceiptsFilters from './useTelematicReceiptsFilters';
 import { ButtonField } from '../components/FilterContainer/FilterContainer';
-import { getDebtPositionsTypes } from '../api/debtPositionsTypes';
+import { getDebtPositionTypeOrgs } from '../api/debtPositionsTypeOrg';
 
-vi.mock('../api/debtPositionsTypes', () => ({
-  getDebtPositionsTypes: vi.fn()
+vi.mock('../api/debtPositionsTypeOrg', () => ({
+  getDebtPositionTypeOrgs: vi.fn()
 }));
 
 vi.mock('./useDebtPositionsTypeOrg', () => ({
@@ -25,7 +25,7 @@ describe('useTelematicReceiptsFilters', () => {
   });
 
   it('should return correct filters ', () => {
-    (getDebtPositionsTypes as unknown as Mock).mockReturnValue({
+    (getDebtPositionTypeOrgs as unknown as Mock).mockReturnValue({
       isSuccess: true,
       data: {
         data: {
@@ -53,7 +53,7 @@ describe('useTelematicReceiptsFilters', () => {
   });
 
   it('should call onFilter when the apply button is triggered', () => {
-    (getDebtPositionsTypes as unknown as Mock).mockReturnValue({
+    (getDebtPositionTypeOrgs as unknown as Mock).mockReturnValue({
       isSuccess: true,
       data: {
         data: {

--- a/src/routes/DebtTypeCreate/components/Step1Configuration.tsx
+++ b/src/routes/DebtTypeCreate/components/Step1Configuration.tsx
@@ -127,7 +127,7 @@ export const Step1Configuration = ({
     if (editmode) {
       onNext();
     }
-  }
+  };
 
   return (
     <form aria-label="form">
@@ -382,7 +382,10 @@ export const Step1Configuration = ({
         </SectionBox>
       </WizardStepWrapper>
 
-      <WizardStepButtons onBack={onBack} onNext={handleSubmit(onSubmit, onInvalid)} />
+      <WizardStepButtons
+        onBack={onBack}
+        onNext={handleSubmit(onSubmit, onInvalid)}
+      />
     </form>
   );
 };

--- a/src/routes/DebtTypeOrgCreate/index.tsx
+++ b/src/routes/DebtTypeOrgCreate/index.tsx
@@ -9,40 +9,78 @@ import { Step1Configuration, Step1Data } from './steps/Step1Configuration';
 import { Step2Behaviour, Step2Data } from './steps/Step2Behaviour';
 import { Step3Accounting, Step3Data } from './steps/Step3Accounting';
 import { Step4Data, Step4Notifications } from './steps/Step4Notifications';
-import {
-  OperatorSelection,
-  Step5Data,
-  Step5Operators
-} from './steps/Step5Operators';
+import { Step5Data, Step5Operators } from './steps/Step5Operators';
 import { PaymentMethodOption } from './steps/Step2Behaviour/components/PaymentMethodSelector';
+import { OperatorsSelection } from '../../../generated/data-contracts';
+import {
+  CreateDebtPositionTypeOrg,
+  createDebtPositionTypeOrg
+} from '../../api/debtPositionsTypeOrg';
+import { useStore } from '../../store/GlobalStore';
 
 type FormData = Step1Data & Step2Data & Step3Data & Step4Data & Step5Data;
+
 const initialData: FormData = {
-  debtType: 0,
-  selection: '',
-  operatorSelection: OperatorSelection.ALL,
+  debtPositionTypeId: 0,
+
+  code: '',
+  description: '',
+  iban: '',
+
+  operatorsSelection: OperatorsSelection.ALL,
   paymentMethod: PaymentMethodOption.FREE
 };
 
-export const DebtTypeCreateEC = () => {
+export const DebtTypeOrgCreate = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
   const [step, setStep] = useState(0);
   const formData = useSignal<FormData>(initialData);
+  const debtTypeCreate = createDebtPositionTypeOrg();
 
-  const submit = () => {
-    navigate(PageRoutes.DEBT_TYPE_CREATE_SUCCESS, {
-      replace: true,
-      state: {
-        formData: formData.value
+  const {
+    state: { organizationId }
+  } = useStore();
+
+  const requestMap = async (
+    data: FormData
+  ): Promise<CreateDebtPositionTypeOrg> => {
+    return {
+      organizationId,
+      data: {
+        debtPositionTypeOrg: {
+          ...data,
+          organizationId,
+          flagNotifyOutcomePush: data.flagNotifyOutcomePush === 'true',
+          xsdDefinitionRef:
+            data.paymentMethod === PaymentMethodOption.CUSTOM
+              ? await data.xsdDefinitionRef?.text()
+              : undefined
+        },
+        operatorsSelection: data.operatorsSelection
       }
+    };
+  };
+
+  const submit = async () => {
+    const request = await requestMap(formData.value);
+    debtTypeCreate.mutate(request, {
+      onSuccess: (formData) => {
+        navigate(PageRoutes.DEBT_TYPE_CREATE_SUCCESS, {
+          replace: true,
+          state: {
+            formData
+          }
+        });
+      },
+      onError: console.error
     });
   };
 
   const steps: Stepper['steps'] = [
     {
-      label: t('debtTypeCreateEC.stepper.step1'),
+      label: t('debtTypeOrgCreate.stepper.step1'),
       content: (
         <Step1Configuration
           key="step1"
@@ -55,7 +93,7 @@ export const DebtTypeCreateEC = () => {
       )
     },
     {
-      label: t('debtTypeCreateEC.stepper.step2'),
+      label: t('debtTypeOrgCreate.stepper.step2'),
       content: (
         <Step2Behaviour
           key="step2"
@@ -68,7 +106,7 @@ export const DebtTypeCreateEC = () => {
       )
     },
     {
-      label: t('debtTypeCreateEC.stepper.step3'),
+      label: t('debtTypeOrgCreate.stepper.step3'),
       content: (
         <Step3Accounting
           key="step3"
@@ -81,7 +119,7 @@ export const DebtTypeCreateEC = () => {
       )
     },
     {
-      label: t('debtTypeCreateEC.stepper.step4'),
+      label: t('debtTypeOrgCreate.stepper.step4'),
       optional: true,
       content: (
         <Step4Notifications
@@ -95,7 +133,7 @@ export const DebtTypeCreateEC = () => {
       )
     },
     {
-      label: t('debtTypeCreateEC.stepper.step5'),
+      label: t('debtTypeOrgCreate.stepper.step5'),
       content: (
         <Step5Operators
           key="step5"
@@ -111,8 +149,8 @@ export const DebtTypeCreateEC = () => {
 
   return (
     <StepperContainer
-      title={t('debtTypeCreateEC.title')}
-      description={t('debtTypeCreateEC.description')}
+      title={t('debtTypeOrgCreate.title')}
+      description={t('debtTypeOrgCreate.description')}
       steps={steps}
       activeStep={step}
     />

--- a/src/routes/DebtTypeOrgCreate/index.tsx
+++ b/src/routes/DebtTypeOrgCreate/index.tsx
@@ -17,6 +17,7 @@ import {
   createDebtPositionTypeOrg
 } from '../../api/debtPositionsTypeOrg';
 import { useStore } from '../../store/GlobalStore';
+import utils from '../../utils';
 
 type FormData = Step1Data & Step2Data & Step3Data & Step4Data & Step5Data;
 
@@ -64,18 +65,19 @@ export const DebtTypeOrgCreate = () => {
   };
 
   const submit = async () => {
-    const request = await requestMap(formData.value);
-    debtTypeCreate.mutate(request, {
-      onSuccess: (formData) => {
-        navigate(PageRoutes.DEBT_TYPE_CREATE_SUCCESS, {
-          replace: true,
-          state: {
-            formData
-          }
-        });
-      },
-      onError: console.error
-    });
+    try {
+      const request = await requestMap(formData.value);
+      const response = await debtTypeCreate.mutateAsync(request);
+      navigate(PageRoutes.DEBT_TYPE_CREATE_SUCCESS, {
+        replace: true,
+        state: {
+          formData: response
+        }
+      });
+    } catch (error) {
+      utils.notify.emit(t('errors.generic'));
+      console.error(error);
+    }
   };
 
   const steps: Stepper['steps'] = [

--- a/src/routes/DebtTypeOrgCreate/steps/Step1Configuration.test.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step1Configuration.test.tsx
@@ -8,8 +8,8 @@ import {
 } from '../../../__tests__/renderers';
 import { pickSelect } from '../../../__tests__/utils';
 
-vi.mock('../../../hooks/useDebtPositionsTypeOrg', () => ({
-  useDebtPositionsTypeOrg: () => ({
+vi.mock('../../../hooks/useDebtPositionTypesByOrg', () => ({
+  useDebtPositionTypesByOrg: () => ({
     optionsMap: [
       { value: 1, label: 'Type 1' },
       { value: 2, label: 'Type 2' },
@@ -38,7 +38,7 @@ describe('Step1Configuration', () => {
       />
     );
 
-    // Check if main titles are rendered
+    // Check main titles
     expect(
       screen.getByText('debtTypeOrgCreate.configuration.title')
     ).toBeInTheDocument();
@@ -48,36 +48,23 @@ describe('Step1Configuration', () => {
     expect(
       screen.getByText('debtTypeOrgCreate.configuration.debtTypeVersion.title')
     ).toBeInTheDocument();
-    expect(
-      screen.getByText('debtTypeOrgCreate.configuration.selection.title')
-    ).toBeInTheDocument();
 
-    // Check for form elements
+    // Check form controls
     expect(
       screen.getByRole('combobox', {
         name: 'debtTypeOrgCreate.configuration.debtType.label'
       })
     ).toBeInTheDocument();
+
     expect(
       screen.getByRole('textbox', {
         name: 'debtTypeOrgCreate.configuration.code.label'
       })
     ).toBeInTheDocument();
+
     expect(
       screen.getByRole('textbox', {
         name: 'debtTypeOrgCreate.configuration.description.label'
-      })
-    ).toBeInTheDocument();
-
-    // Check for radio buttons
-    expect(
-      screen.getByRole('radio', {
-        name: 'debtTypeOrgCreate.configuration.selection.option1'
-      })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('radio', {
-        name: 'debtTypeOrgCreate.configuration.selection.option2'
       })
     ).toBeInTheDocument();
   });
@@ -91,7 +78,6 @@ describe('Step1Configuration', () => {
       />
     );
 
-    // Find and click the back button
     const backButton = screen.getByRole('button', { name: 'commons.back' });
     fireEvent.click(backButton);
 
@@ -128,22 +114,15 @@ describe('Step1Configuration', () => {
       target: { value: 'Test description' }
     });
 
-    // Select the second radio option
-    const radioOption2 = screen.getByRole('radio', {
-      name: 'debtTypeOrgCreate.configuration.selection.option2'
-    });
-    fireEvent.click(radioOption2);
-
     // Submit the form
     const nextButton = screen.getByRole('button', { name: 'commons.continue' });
     fireEvent.click(nextButton);
 
     await waitFor(() => {
       expect(mockSetData).toHaveBeenCalledWith({
-        debtType: 2,
+        debtPositionTypeId: 2,
         code: 'CODE123',
-        description: 'Test description',
-        selection: 'option2'
+        description: 'Test description'
       });
       expect(mockOnNext).toHaveBeenCalledTimes(1);
     });
@@ -158,10 +137,8 @@ describe('Step1Configuration', () => {
       />
     );
 
-    // Initially should be 0/100
     expect(screen.getByText('0/100')).toBeInTheDocument();
 
-    // Type in the description field
     const descriptionInput = screen.getByRole('textbox', {
       name: 'debtTypeOrgCreate.configuration.description.label'
     });
@@ -169,56 +146,7 @@ describe('Step1Configuration', () => {
       target: { value: 'Test description' }
     });
 
-    // Should now show the correct count
     expect(screen.getByText('16/100')).toBeInTheDocument();
-  });
-
-  it('defaults to first radio option', () => {
-    render(
-      <Step1Configuration
-        setData={mockSetData}
-        onNext={mockOnNext}
-        onBack={mockOnBack}
-      />
-    );
-
-    const radioOption1 = screen.getByRole('radio', {
-      name: 'debtTypeOrgCreate.configuration.selection.option1'
-    });
-    const radioOption2 = screen.getByRole('radio', {
-      name: 'debtTypeOrgCreate.configuration.selection.option2'
-    });
-
-    // Check that first option is selected by default
-    expect(radioOption1).toBeChecked();
-    expect(radioOption2).not.toBeChecked();
-  });
-
-  it('allows selecting a different radio option', () => {
-    render(
-      <Step1Configuration
-        setData={mockSetData}
-        onNext={mockOnNext}
-        onBack={mockOnBack}
-      />
-    );
-
-    const radioOption1 = screen.getByRole('radio', {
-      name: 'debtTypeOrgCreate.configuration.selection.option1'
-    });
-    const radioOption2 = screen.getByRole('radio', {
-      name: 'debtTypeOrgCreate.configuration.selection.option2'
-    });
-
-    // Initially first option is selected
-    expect(radioOption1).toBeChecked();
-
-    // Click the second option
-    fireEvent.click(radioOption2);
-
-    // Now second option should be checked
-    expect(radioOption1).not.toBeChecked();
-    expect(radioOption2).toBeChecked();
   });
 
   it('validates required fields before submission', async () => {
@@ -230,33 +158,39 @@ describe('Step1Configuration', () => {
       />
     );
 
-    // Don't select a debt type (it's required)
-
-    // Submit the form
+    // Submit without selecting debtPositionTypeId (required)
     const nextButton = screen.getByRole('button', { name: 'commons.continue' });
     fireEvent.click(nextButton);
 
-    // Validation should prevent submission
     expect(mockSetData).not.toHaveBeenCalled();
     expect(mockOnNext).not.toHaveBeenCalled();
 
-    // Now select a debt type
+    // Now select a debt type and submit again
     await pickSelect(
       'debtTypeOrgCreate.configuration.debtType.label',
       'Type 1'
     );
 
-    // Try submitting again
+    // Fill code and description (both required)
+    const codeInput = screen.getByRole('textbox', {
+      name: 'debtTypeOrgCreate.configuration.code.label'
+    });
+    fireEvent.change(codeInput, { target: { value: 'CODE1' } });
+
+    const descriptionInput = screen.getByRole('textbox', {
+      name: 'debtTypeOrgCreate.configuration.description.label'
+    });
+    fireEvent.change(descriptionInput, { target: { value: 'Desc' } });
+
     fireEvent.click(nextButton);
 
-    // Now submission should work
     await waitFor(() => {
       expect(mockSetData).toHaveBeenCalled();
       expect(mockOnNext).toHaveBeenCalled();
     });
   });
 
-  it('submits form with only required fields filled', async () => {
+  it('does not submit if required fields are missing', async () => {
     render(
       <Step1Configuration
         setData={mockSetData}
@@ -265,24 +199,17 @@ describe('Step1Configuration', () => {
       />
     );
 
-    // Only select a debt type, leave optional fields empty
+    // Select debt type only, but no code or description
     await pickSelect(
       'debtTypeOrgCreate.configuration.debtType.label',
       'Type 3'
     );
 
-    // Submit the form
     const nextButton = screen.getByRole('button', { name: 'commons.continue' });
     fireEvent.click(nextButton);
 
-    await waitFor(() => {
-      expect(mockSetData).toHaveBeenCalledWith({
-        debtType: 3,
-        code: undefined,
-        description: undefined,
-        selection: 'option1' // Default selection
-      });
-      expect(mockOnNext).toHaveBeenCalled();
-    });
+    // Should not submit because code and description are required
+    expect(mockSetData).not.toHaveBeenCalled();
+    expect(mockOnNext).not.toHaveBeenCalled();
   });
 });

--- a/src/routes/DebtTypeOrgCreate/steps/Step1Configuration.test.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step1Configuration.test.tsx
@@ -40,44 +40,44 @@ describe('Step1Configuration', () => {
 
     // Check if main titles are rendered
     expect(
-      screen.getByText('debtTypeCreateEC.configuration.title')
+      screen.getByText('debtTypeOrgCreate.configuration.title')
     ).toBeInTheDocument();
     expect(
-      screen.getByText('debtTypeCreateEC.configuration.debtType.title')
+      screen.getByText('debtTypeOrgCreate.configuration.debtType.title')
     ).toBeInTheDocument();
     expect(
-      screen.getByText('debtTypeCreateEC.configuration.debtTypeVersion.title')
+      screen.getByText('debtTypeOrgCreate.configuration.debtTypeVersion.title')
     ).toBeInTheDocument();
     expect(
-      screen.getByText('debtTypeCreateEC.configuration.selection.title')
+      screen.getByText('debtTypeOrgCreate.configuration.selection.title')
     ).toBeInTheDocument();
 
     // Check for form elements
     expect(
       screen.getByRole('combobox', {
-        name: 'debtTypeCreateEC.configuration.debtType.label'
+        name: 'debtTypeOrgCreate.configuration.debtType.label'
       })
     ).toBeInTheDocument();
     expect(
       screen.getByRole('textbox', {
-        name: 'debtTypeCreateEC.configuration.code.label'
+        name: 'debtTypeOrgCreate.configuration.code.label'
       })
     ).toBeInTheDocument();
     expect(
       screen.getByRole('textbox', {
-        name: 'debtTypeCreateEC.configuration.description.label'
+        name: 'debtTypeOrgCreate.configuration.description.label'
       })
     ).toBeInTheDocument();
 
     // Check for radio buttons
     expect(
       screen.getByRole('radio', {
-        name: 'debtTypeCreateEC.configuration.selection.option1'
+        name: 'debtTypeOrgCreate.configuration.selection.option1'
       })
     ).toBeInTheDocument();
     expect(
       screen.getByRole('radio', {
-        name: 'debtTypeCreateEC.configuration.selection.option2'
+        name: 'debtTypeOrgCreate.configuration.selection.option2'
       })
     ).toBeInTheDocument();
   });
@@ -110,16 +110,19 @@ describe('Step1Configuration', () => {
     );
 
     // Select a debt type
-    await pickSelect('debtTypeCreateEC.configuration.debtType.label', 'Type 2');
+    await pickSelect(
+      'debtTypeOrgCreate.configuration.debtType.label',
+      'Type 2'
+    );
 
     // Enter values for text fields
     const codeInput = screen.getByRole('textbox', {
-      name: 'debtTypeCreateEC.configuration.code.label'
+      name: 'debtTypeOrgCreate.configuration.code.label'
     });
     fireEvent.change(codeInput, { target: { value: 'CODE123' } });
 
     const descriptionInput = screen.getByRole('textbox', {
-      name: 'debtTypeCreateEC.configuration.description.label'
+      name: 'debtTypeOrgCreate.configuration.description.label'
     });
     fireEvent.change(descriptionInput, {
       target: { value: 'Test description' }
@@ -127,7 +130,7 @@ describe('Step1Configuration', () => {
 
     // Select the second radio option
     const radioOption2 = screen.getByRole('radio', {
-      name: 'debtTypeCreateEC.configuration.selection.option2'
+      name: 'debtTypeOrgCreate.configuration.selection.option2'
     });
     fireEvent.click(radioOption2);
 
@@ -160,7 +163,7 @@ describe('Step1Configuration', () => {
 
     // Type in the description field
     const descriptionInput = screen.getByRole('textbox', {
-      name: 'debtTypeCreateEC.configuration.description.label'
+      name: 'debtTypeOrgCreate.configuration.description.label'
     });
     fireEvent.change(descriptionInput, {
       target: { value: 'Test description' }
@@ -180,10 +183,10 @@ describe('Step1Configuration', () => {
     );
 
     const radioOption1 = screen.getByRole('radio', {
-      name: 'debtTypeCreateEC.configuration.selection.option1'
+      name: 'debtTypeOrgCreate.configuration.selection.option1'
     });
     const radioOption2 = screen.getByRole('radio', {
-      name: 'debtTypeCreateEC.configuration.selection.option2'
+      name: 'debtTypeOrgCreate.configuration.selection.option2'
     });
 
     // Check that first option is selected by default
@@ -201,10 +204,10 @@ describe('Step1Configuration', () => {
     );
 
     const radioOption1 = screen.getByRole('radio', {
-      name: 'debtTypeCreateEC.configuration.selection.option1'
+      name: 'debtTypeOrgCreate.configuration.selection.option1'
     });
     const radioOption2 = screen.getByRole('radio', {
-      name: 'debtTypeCreateEC.configuration.selection.option2'
+      name: 'debtTypeOrgCreate.configuration.selection.option2'
     });
 
     // Initially first option is selected
@@ -238,7 +241,10 @@ describe('Step1Configuration', () => {
     expect(mockOnNext).not.toHaveBeenCalled();
 
     // Now select a debt type
-    await pickSelect('debtTypeCreateEC.configuration.debtType.label', 'Type 1');
+    await pickSelect(
+      'debtTypeOrgCreate.configuration.debtType.label',
+      'Type 1'
+    );
 
     // Try submitting again
     fireEvent.click(nextButton);
@@ -260,7 +266,10 @@ describe('Step1Configuration', () => {
     );
 
     // Only select a debt type, leave optional fields empty
-    await pickSelect('debtTypeCreateEC.configuration.debtType.label', 'Type 3');
+    await pickSelect(
+      'debtTypeOrgCreate.configuration.debtType.label',
+      'Type 3'
+    );
 
     // Submit the form
     const nextButton = screen.getByRole('button', { name: 'commons.continue' });

--- a/src/routes/DebtTypeOrgCreate/steps/Step1Configuration.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step1Configuration.tsx
@@ -3,7 +3,6 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useTranslation } from 'react-i18next';
 import PostAddIcon from '@mui/icons-material/PostAdd';
 import BookIcon from '@mui/icons-material/MenuBook';
-import PaymentIcon from '@mui/icons-material/Payment';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { TFunction } from 'i18next';
@@ -14,13 +13,12 @@ import WizardStepWrapper from '../../../components/Wizard/WizardStepWrapper';
 import { FormComponent } from '../../../components/FormComponent';
 import WizardStepButtons from '../../../components/Wizard/WizardStepButtons';
 import { useStore } from '../../../store/GlobalStore';
-import { useDebtPositionsTypeOrg } from '../../../hooks/useDebtPositionsTypeOrg';
+import { useDebtPositionTypesByOrg } from '../../../hooks/useDebtPositionTypesByOrg';
 
 export type Step1Data = {
-  debtType: number;
-  description?: string;
-  code?: string;
-  selection: string;
+  debtPositionTypeId: number;
+  description: string;
+  code: string;
 };
 
 export type Step1Props = {
@@ -31,15 +29,19 @@ export type Step1Props = {
 
 const validationSchema = (t: TFunction) =>
   z.object({
-    debtType: z.number({
-      required_error: t('debtTypeCreateEC.configuration.debtType.required')
+    debtPositionTypeId: z.number({
+      required_error: t('debtTypeOrgCreate.configuration.debtType.required')
     }),
-    code: z.string().optional(),
+    code: z.string({
+      required_error: t('debtTypeOrgCreate.configuration.code.required')
+    }),
     description: z
-      .string()
-      .max(100, t('debtTypeCreateEC.configuration.description.maxCharacters'))
-      .optional(),
-    selection: z.string()
+      .string({
+        required_error: t(
+          'debtTypeOrgCreate.configuration.description.required'
+        )
+      })
+      .max(100, t('debtTypeOrgCreate.configuration.description.maxCharacters'))
   });
 
 export const Step1Configuration = ({ setData, onNext, onBack }: Step1Props) => {
@@ -49,9 +51,8 @@ export const Step1Configuration = ({ setData, onNext, onBack }: Step1Props) => {
   const {
     state: { organizationId }
   } = useStore();
-  const { optionsMap } = useDebtPositionsTypeOrg({
-    organizationId,
-    includeAllOption: false
+  const { optionsMap } = useDebtPositionTypesByOrg({
+    organizationId
   });
 
   const { control, handleSubmit, watch } = useForm<Step1Data>({
@@ -69,27 +70,27 @@ export const Step1Configuration = ({ setData, onNext, onBack }: Step1Props) => {
   return (
     <form aria-label="form">
       <WizardStepWrapper
-        title={t('debtTypeCreateEC.configuration.title')}
-        subtitle={t('debtTypeCreateEC.configuration.subtitle')}
-        alertMessage={t('debtTypeCreateEC.configuration.alertMessage')}
+        title={t('debtTypeOrgCreate.configuration.title')}
+        subtitle={t('debtTypeOrgCreate.configuration.subtitle')}
+        alertMessage={t('debtTypeOrgCreate.configuration.alertMessage')}
       >
         <SectionBox
-          title={t('debtTypeCreateEC.configuration.debtType.title')}
+          title={t('debtTypeOrgCreate.configuration.debtType.title')}
           adornment={<BookIcon />}
         >
           <FormComponent.ControlledSelect
             control={control}
-            label={t('debtTypeCreateEC.configuration.debtType.label')}
-            name="debtType"
+            label={t('debtTypeOrgCreate.configuration.debtType.label')}
+            name="debtPositionTypeId"
             disabled={!optionsMap?.length}
             options={optionsMap}
           />
         </SectionBox>
 
         <SectionBox
-          title={t('debtTypeCreateEC.configuration.debtTypeVersion.title')}
+          title={t('debtTypeOrgCreate.configuration.debtTypeVersion.title')}
           subtitle={t(
-            'debtTypeCreateEC.configuration.debtTypeVersion.subtitle'
+            'debtTypeOrgCreate.configuration.debtTypeVersion.subtitle'
           )}
           adornment={<PostAddIcon />}
         >
@@ -98,43 +99,21 @@ export const Step1Configuration = ({ setData, onNext, onBack }: Step1Props) => {
               name="code"
               sx={{ flex: 1 }}
               control={control}
-              label={t('debtTypeCreateEC.configuration.code.label')}
+              label={t('debtTypeOrgCreate.configuration.code.label')}
               noAdornment
-              required={false}
             />
             <Stack flex={3}>
               <FormComponent.ControlledTextField
                 name="description"
                 control={control}
-                label={t('debtTypeCreateEC.configuration.description.label')}
+                label={t('debtTypeOrgCreate.configuration.description.label')}
                 adornment={`${description?.length || 0}/100`}
-                required={false}
               />
               <Typography variant="caption" px={1.5}>
-                {t('debtTypeCreateEC.configuration.description.caption')}
+                {t('debtTypeOrgCreate.configuration.description.caption')}
               </Typography>
             </Stack>
           </Stack>
-        </SectionBox>
-        <SectionBox
-          title={t('debtTypeCreateEC.configuration.selection.title')}
-          adornment={<PaymentIcon />}
-        >
-          <FormComponent.ControlledRadioGroup
-            name="selection"
-            control={control}
-            label={t('debtTypeCreateEC.configuration.selection.label')}
-            options={[
-              {
-                value: 'option1',
-                label: t('debtTypeCreateEC.configuration.selection.option1')
-              },
-              {
-                value: 'option2',
-                label: t('debtTypeCreateEC.configuration.selection.option2')
-              }
-            ]}
-          />
         </SectionBox>
       </WizardStepWrapper>
 

--- a/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/Step2Behaviour.test.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/Step2Behaviour.test.tsx
@@ -21,26 +21,26 @@ describe('Step2Behaviour', () => {
     );
 
     expect(
-      screen.getByText('debtTypeCreateEC.behaviour.title')
+      screen.getByText('debtTypeOrgCreate.behaviour.title')
     ).toBeInTheDocument();
     expect(
-      screen.getByText('debtTypeCreateEC.behaviour.subtitle')
+      screen.getByText('debtTypeOrgCreate.behaviour.subtitle')
     ).toBeInTheDocument();
     expect(
-      screen.getByText('debtTypeCreateEC.behaviour.alertMessage')
+      screen.getByText('debtTypeOrgCreate.behaviour.alertMessage')
     ).toBeInTheDocument();
 
     // Spontaneous payment switch
     expect(
       screen.getByRole('checkbox', {
-        name: 'debtTypeCreateEC.behaviour.postalAccount'
+        name: 'debtTypeOrgCreate.behaviour.postalAccount'
       })
     ).toBeInTheDocument();
 
     // Notification radio group
     expect(
       screen.getByRole('radiogroup', {
-        name: 'debtTypeCreateEC.behaviour.notifications.radioLabel'
+        name: 'debtTypeOrgCreate.behaviour.notifications.radioLabel'
       })
     ).toBeInTheDocument();
 
@@ -64,28 +64,28 @@ describe('Step2Behaviour', () => {
 
     // Initially, spontaneous payment disabled: behaviour section visible
     expect(
-      screen.getByText('debtTypeCreateEC.behaviour.section.behaviourTitle')
+      screen.getByText('debtTypeOrgCreate.behaviour.section.behaviourTitle')
     ).toBeInTheDocument();
     expect(
       screen.queryByText(
-        'debtTypeCreateEC.behaviour.section.spontaneousPaymentTitle'
+        'debtTypeOrgCreate.behaviour.section.spontaneousPaymentTitle'
       )
     ).not.toBeInTheDocument();
 
     // Enable spontaneous payment
     const spontaneousSwitch = screen.getByRole('checkbox', {
-      name: 'debtTypeCreateEC.behaviour.postalAccount'
+      name: 'debtTypeOrgCreate.behaviour.postalAccount'
     });
     fireEvent.click(spontaneousSwitch);
 
     // Now spontaneous payment section visible
     expect(
       screen.getByText(
-        'debtTypeCreateEC.behaviour.section.spontaneousPaymentTitle'
+        'debtTypeOrgCreate.behaviour.section.spontaneousPaymentTitle'
       )
     ).toBeInTheDocument();
     expect(
-      screen.queryByText('debtTypeCreateEC.behaviour.section.behaviourTitle')
+      screen.queryByText('debtTypeOrgCreate.behaviour.section.behaviourTitle')
     ).not.toBeInTheDocument();
   });
 
@@ -101,25 +101,25 @@ describe('Step2Behaviour', () => {
     // Initially notifications disabled: fields hidden
     expect(
       screen.queryByText(
-        'debtTypeCreateEC.behaviour.notifications.fields.retries'
+        'debtTypeOrgCreate.behaviour.notifications.fields.retries'
       )
     ).not.toBeInTheDocument();
 
     // Select "Yes" for enablePaymentNotifications
     const yesRadio = screen.getByRole('radio', {
-      name: 'debtTypeCreateEC.behaviour.notifications.options.yes'
+      name: 'debtTypeOrgCreate.behaviour.notifications.options.yes'
     });
     fireEvent.click(yesRadio);
 
     // Now notification fields rendered
     expect(
       screen.getByText(
-        'debtTypeCreateEC.behaviour.notifications.fields.retries'
+        'debtTypeOrgCreate.behaviour.notifications.fields.retries'
       )
     ).toBeInTheDocument();
     expect(
       screen.getByRole('combobox', {
-        name: 'debtTypeCreateEC.behaviour.notifications.fields.retries'
+        name: 'debtTypeOrgCreate.behaviour.notifications.fields.retries'
       })
     ).toBeInTheDocument();
   });
@@ -134,17 +134,17 @@ describe('Step2Behaviour', () => {
     );
 
     expect(
-      screen.getByText('debtTypeCreateEC.behaviour.updateAmount.title')
+      screen.getByText('debtTypeOrgCreate.behaviour.updateAmount.title')
     ).toBeInTheDocument();
     expect(
-      screen.getByText('debtTypeCreateEC.behaviour.updateAmount.subtitle')
+      screen.getByText('debtTypeOrgCreate.behaviour.updateAmount.subtitle')
     ).toBeInTheDocument();
 
     [
-      'debtTypeCreateEC.behaviour.updateAmount.notesLabel',
-      'debtTypeCreateEC.behaviour.updateAmount.amountLabel',
-      'debtTypeCreateEC.behaviour.updateAmount.authUrlLabel',
-      'debtTypeCreateEC.behaviour.updateAmount.updateUrlLabel'
+      'debtTypeOrgCreate.behaviour.updateAmount.notesLabel',
+      'debtTypeOrgCreate.behaviour.updateAmount.amountLabel',
+      'debtTypeOrgCreate.behaviour.updateAmount.authUrlLabel',
+      'debtTypeOrgCreate.behaviour.updateAmount.updateUrlLabel'
     ].forEach((label) => {
       expect(screen.getByRole('textbox', { name: label })).toBeInTheDocument();
     });
@@ -174,7 +174,7 @@ describe('Step2Behaviour', () => {
 
     // Enable spontaneous payment to show PaymentMethodSelector
     const spontaneousSwitch = screen.getByRole('checkbox', {
-      name: 'debtTypeCreateEC.behaviour.postalAccount'
+      name: 'debtTypeOrgCreate.behaviour.postalAccount'
     });
     fireEvent.click(spontaneousSwitch);
 

--- a/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/Step2Behaviour.test.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/Step2Behaviour.test.tsx
@@ -30,21 +30,18 @@ describe('Step2Behaviour', () => {
       screen.getByText('debtTypeOrgCreate.behaviour.alertMessage')
     ).toBeInTheDocument();
 
-    // Spontaneous payment switch
     expect(
       screen.getByRole('checkbox', {
         name: 'debtTypeOrgCreate.behaviour.postalAccount'
       })
     ).toBeInTheDocument();
 
-    // Notification radio group
     expect(
       screen.getByRole('radiogroup', {
         name: 'debtTypeOrgCreate.behaviour.notifications.radioLabel'
       })
     ).toBeInTheDocument();
 
-    // Wizard step buttons
     expect(
       screen.getByRole('button', { name: 'commons.back' })
     ).toBeInTheDocument();
@@ -62,7 +59,7 @@ describe('Step2Behaviour', () => {
       />
     );
 
-    // Initially, spontaneous payment disabled: behaviour section visible
+    // Initially spontaneous payment disabled: behaviour section visible
     expect(
       screen.getByText('debtTypeOrgCreate.behaviour.section.behaviourTitle')
     ).toBeInTheDocument();
@@ -177,9 +174,6 @@ describe('Step2Behaviour', () => {
       name: 'debtTypeOrgCreate.behaviour.postalAccount'
     });
     fireEvent.click(spontaneousSwitch);
-
-    // Select payment method (default is FREE, so no extra input required)
-    // Enable notifications "No" (default)
 
     // Submit form
     fireEvent.click(screen.getByRole('button', { name: 'commons.continue' }));

--- a/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/components/PaymentMethodSelector.test.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/components/PaymentMethodSelector.test.tsx
@@ -14,8 +14,8 @@ const renderWithForm = (
     const { control, watch } = useForm<Step2Data>({
       defaultValues: {
         paymentMethod: defaultValue,
-        fixedAmount: 0,
-        customFieldsSchema: undefined,
+        amountCents: 0,
+        xsdDefinitionRef: undefined,
         externalPaymentUrl: ''
       }
     });
@@ -84,8 +84,8 @@ describe('PaymentMethodSelector', () => {
       const { control, watch, setValue } = useForm<Step2Data>({
         defaultValues: {
           paymentMethod: PaymentMethodOption.FREE,
-          fixedAmount: 0,
-          customFieldsSchema: undefined,
+          amountCents: 0,
+          xsdDefinitionRef: undefined,
           externalPaymentUrl: ''
         }
       });

--- a/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/components/PaymentMethodSelector.test.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/components/PaymentMethodSelector.test.tsx
@@ -41,13 +41,13 @@ describe('PaymentMethodSelector', () => {
     renderWithForm();
 
     const select = screen.getByRole('combobox', {
-      name: 'debtTypeCreateEC.behaviour.spontaneous.label'
+      name: 'debtTypeOrgCreate.behaviour.spontaneous.label'
     });
     expect(select).toBeInTheDocument();
 
     // Check options labels are rendered
     expect(
-      screen.getByText('debtTypeCreateEC.behaviour.spontaneous.free')
+      screen.getByText('debtTypeOrgCreate.behaviour.spontaneous.free')
     ).toBeInTheDocument();
   });
 
@@ -63,7 +63,7 @@ describe('PaymentMethodSelector', () => {
     ).not.toBeInTheDocument();
     expect(
       screen.queryByText(
-        'debtTypeCreateEC.behaviour.spontaneous.file.description'
+        'debtTypeOrgCreate.behaviour.spontaneous.file.description'
       )
     ).not.toBeInTheDocument();
   });
@@ -74,7 +74,7 @@ describe('PaymentMethodSelector', () => {
     // The description text should be present
     expect(
       screen.getByText(
-        'debtTypeCreateEC.behaviour.spontaneous.file.description'
+        'debtTypeOrgCreate.behaviour.spontaneous.file.description'
       )
     ).toBeInTheDocument();
   });
@@ -144,7 +144,7 @@ describe('PaymentMethodSelector', () => {
     fireEvent.click(screen.getByTestId('set-amount'));
     expect(
       screen.getByRole('textbox', {
-        name: 'debtTypeCreateEC.behaviour.spontaneous.amountValue.label'
+        name: 'debtTypeOrgCreate.behaviour.spontaneous.amountValue.label'
       })
     ).toBeInTheDocument();
 
@@ -152,7 +152,7 @@ describe('PaymentMethodSelector', () => {
     fireEvent.click(screen.getByTestId('set-custom'));
     expect(
       screen.getByText(
-        'debtTypeCreateEC.behaviour.spontaneous.file.description'
+        'debtTypeOrgCreate.behaviour.spontaneous.file.description'
       )
     ).toBeInTheDocument();
 
@@ -160,7 +160,7 @@ describe('PaymentMethodSelector', () => {
     fireEvent.click(screen.getByTestId('set-external'));
     expect(
       screen.getByRole('textbox', {
-        name: 'debtTypeCreateEC.behaviour.spontaneous.externalUrl.label'
+        name: 'debtTypeOrgCreate.behaviour.spontaneous.externalUrl.label'
       })
     ).toBeInTheDocument();
 

--- a/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/components/PaymentMethodSelector.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/components/PaymentMethodSelector.tsx
@@ -30,9 +30,9 @@ export const SelectedField = ({
     case PaymentMethodOption.AMOUNT:
       return (
         <FormComponent.ControlledTextField
-          name="fixedAmount"
+          name="amountCents"
           control={control}
-          label={t('debtTypeCreateEC.behaviour.spontaneous.amountValue.label')}
+          label={t('debtTypeOrgCreate.behaviour.spontaneous.amountValue.label')}
           InputProps={{
             endAdornment: (
               <InputAdornment position="end">
@@ -46,15 +46,15 @@ export const SelectedField = ({
     case PaymentMethodOption.CUSTOM:
       return (
         <FormComponent.ControlledFileUploader
-          name="customFieldsSchema"
+          name="xsdDefinitionRef"
           control={control}
           description={t(
-            'debtTypeCreateEC.behaviour.spontaneous.file.description'
+            'debtTypeOrgCreate.behaviour.spontaneous.file.description'
           )}
           fileExtensionsAllowed={['xsd']}
           header={
             <Typography fontWeight="bold">
-              {t('debtTypeCreateEC.behaviour.spontaneous.file.header')}
+              {t('debtTypeOrgCreate.behaviour.spontaneous.file.header')}
               <Typography component="span" color="error">
                 *
               </Typography>
@@ -68,7 +68,7 @@ export const SelectedField = ({
         <FormComponent.ControlledTextField
           name="externalPaymentUrl"
           control={control}
-          label={t('debtTypeCreateEC.behaviour.spontaneous.externalUrl.label')}
+          label={t('debtTypeOrgCreate.behaviour.spontaneous.externalUrl.label')}
           defaultValue="https://"
         />
       );
@@ -90,24 +90,24 @@ export const PaymentMethodSelector = ({
       <FormComponent.ControlledSelect
         name={name}
         control={control}
-        label={t('debtTypeCreateEC.behaviour.spontaneous.label')}
+        label={t('debtTypeOrgCreate.behaviour.spontaneous.label')}
         required
         fullWidth
         options={[
           {
-            label: t('debtTypeCreateEC.behaviour.spontaneous.free'),
+            label: t('debtTypeOrgCreate.behaviour.spontaneous.free'),
             value: PaymentMethodOption.FREE
           },
           {
-            label: t('debtTypeCreateEC.behaviour.spontaneous.amount'),
+            label: t('debtTypeOrgCreate.behaviour.spontaneous.amount'),
             value: PaymentMethodOption.AMOUNT
           },
           {
-            label: t('debtTypeCreateEC.behaviour.spontaneous.custom'),
+            label: t('debtTypeOrgCreate.behaviour.spontaneous.custom'),
             value: PaymentMethodOption.CUSTOM
           },
           {
-            label: t('debtTypeCreateEC.behaviour.spontaneous.external'),
+            label: t('debtTypeOrgCreate.behaviour.spontaneous.external'),
             value: PaymentMethodOption.EXTERNAL
           }
         ]}

--- a/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/components/PaymentNotificationFields.test.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/components/PaymentNotificationFields.test.tsx
@@ -33,18 +33,18 @@ describe('PaymentNotificationFields', () => {
     // Select field
     expect(
       screen.getByRole('combobox', {
-        name: 'debtTypeCreateEC.behaviour.notifications.fields.retries'
+        name: 'debtTypeOrgCreate.behaviour.notifications.fields.retries'
       })
     ).toBeInTheDocument();
 
     // Text fields
     [
-      'debtTypeCreateEC.behaviour.notifications.fields.appName',
-      'debtTypeCreateEC.behaviour.notifications.fields.endpoint',
-      'debtTypeCreateEC.behaviour.notifications.fields.clientId',
-      'debtTypeCreateEC.behaviour.notifications.fields.clientEmail',
-      'debtTypeCreateEC.behaviour.notifications.fields.secretKeyId',
-      'debtTypeCreateEC.behaviour.notifications.fields.secretKey'
+      'debtTypeOrgCreate.behaviour.notifications.fields.appName',
+      'debtTypeOrgCreate.behaviour.notifications.fields.endpoint',
+      'debtTypeOrgCreate.behaviour.notifications.fields.clientId',
+      'debtTypeOrgCreate.behaviour.notifications.fields.clientEmail',
+      'debtTypeOrgCreate.behaviour.notifications.fields.secretKeyId',
+      'debtTypeOrgCreate.behaviour.notifications.fields.secretKey'
     ].forEach((label) => {
       expect(screen.getByRole('textbox', { name: label })).toBeInTheDocument();
     });
@@ -52,14 +52,14 @@ describe('PaymentNotificationFields', () => {
     // Checkbox
     expect(
       screen.getByRole('checkbox', {
-        name: 'debtTypeCreateEC.behaviour.notifications.fields.jwt'
+        name: 'debtTypeOrgCreate.behaviour.notifications.fields.jwt'
       })
     ).toBeInTheDocument();
 
     // Caption text for retries description
     expect(
       screen.getByText(
-        'debtTypeCreateEC.behaviour.notifications.fields.retriesDescription'
+        'debtTypeOrgCreate.behaviour.notifications.fields.retriesDescription'
       )
     ).toBeInTheDocument();
   });
@@ -68,20 +68,20 @@ describe('PaymentNotificationFields', () => {
     renderWithForm();
 
     await pickSelect(
-      'debtTypeCreateEC.behaviour.notifications.fields.retries',
+      'debtTypeOrgCreate.behaviour.notifications.fields.retries',
       '5'
     );
     expect(screen.getByDisplayValue('5')).toBeInTheDocument();
 
     // Type into text fields
     const appNameInput = screen.getByRole('textbox', {
-      name: 'debtTypeCreateEC.behaviour.notifications.fields.appName'
+      name: 'debtTypeOrgCreate.behaviour.notifications.fields.appName'
     });
     fireEvent.change(appNameInput, { target: { value: 'My App' } });
     expect(appNameInput).toHaveValue('My App');
 
     const endpointInput = screen.getByRole('textbox', {
-      name: 'debtTypeCreateEC.behaviour.notifications.fields.endpoint'
+      name: 'debtTypeOrgCreate.behaviour.notifications.fields.endpoint'
     });
     fireEvent.change(endpointInput, {
       target: { value: 'https://api.example.com' }
@@ -90,7 +90,7 @@ describe('PaymentNotificationFields', () => {
 
     // Toggle checkbox
     const jwtCheckbox = screen.getByRole('checkbox', {
-      name: 'debtTypeCreateEC.behaviour.notifications.fields.jwt'
+      name: 'debtTypeOrgCreate.behaviour.notifications.fields.jwt'
     });
     expect(jwtCheckbox).not.toBeChecked();
     fireEvent.click(jwtCheckbox);
@@ -98,14 +98,14 @@ describe('PaymentNotificationFields', () => {
 
     // Fill clientId
     const clientIdInput = screen.getByRole('textbox', {
-      name: 'debtTypeCreateEC.behaviour.notifications.fields.clientId'
+      name: 'debtTypeOrgCreate.behaviour.notifications.fields.clientId'
     });
     fireEvent.change(clientIdInput, { target: { value: 'client-123' } });
     expect(clientIdInput).toHaveValue('client-123');
 
     // Fill clientEmail
     const clientEmailInput = screen.getByRole('textbox', {
-      name: 'debtTypeCreateEC.behaviour.notifications.fields.clientEmail'
+      name: 'debtTypeOrgCreate.behaviour.notifications.fields.clientEmail'
     });
     fireEvent.change(clientEmailInput, {
       target: { value: 'client@example.com' }
@@ -114,14 +114,14 @@ describe('PaymentNotificationFields', () => {
 
     // Fill secretKeyId
     const secretKeyIdInput = screen.getByRole('textbox', {
-      name: 'debtTypeCreateEC.behaviour.notifications.fields.secretKeyId'
+      name: 'debtTypeOrgCreate.behaviour.notifications.fields.secretKeyId'
     });
     fireEvent.change(secretKeyIdInput, { target: { value: 'secret-key-id' } });
     expect(secretKeyIdInput).toHaveValue('secret-key-id');
 
     // Fill secretKey
     const secretKeyInput = screen.getByRole('textbox', {
-      name: 'debtTypeCreateEC.behaviour.notifications.fields.secretKey'
+      name: 'debtTypeOrgCreate.behaviour.notifications.fields.secretKey'
     });
     fireEvent.change(secretKeyInput, { target: { value: 'secret-key' } });
     expect(secretKeyInput).toHaveValue('secret-key');

--- a/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/components/PaymentNotificationFields.test.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/components/PaymentNotificationFields.test.tsx
@@ -30,7 +30,7 @@ describe('PaymentNotificationFields', () => {
   it('renders all select and input fields with correct labels', () => {
     renderWithForm();
 
-    // Select field
+    // Select field for retries
     expect(
       screen.getByRole('combobox', {
         name: 'debtTypeOrgCreate.behaviour.notifications.fields.retries'
@@ -49,7 +49,7 @@ describe('PaymentNotificationFields', () => {
       expect(screen.getByRole('textbox', { name: label })).toBeInTheDocument();
     });
 
-    // Checkbox
+    // Checkbox for JWT auth
     expect(
       screen.getByRole('checkbox', {
         name: 'debtTypeOrgCreate.behaviour.notifications.fields.jwt'
@@ -67,6 +67,7 @@ describe('PaymentNotificationFields', () => {
   it('allows user to interact with fields', async () => {
     renderWithForm();
 
+    // Select a different retries value
     await pickSelect(
       'debtTypeOrgCreate.behaviour.notifications.fields.retries',
       '5'

--- a/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/components/PaymentNotificationFields.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/components/PaymentNotificationFields.tsx
@@ -20,7 +20,7 @@ export const PaymentNotificationFields = ({
         <FormComponent.ControlledSelect
           name="notificationRetries"
           control={control}
-          label={t('debtTypeCreateEC.behaviour.notifications.fields.retries')}
+          label={t('debtTypeOrgCreate.behaviour.notifications.fields.retries')}
           options={[
             { label: '1', value: 1 },
             { label: '2', value: 2 },
@@ -30,7 +30,7 @@ export const PaymentNotificationFields = ({
         />
         <Typography variant="caption" ml={2}>
           {t(
-            'debtTypeCreateEC.behaviour.notifications.fields.retriesDescription'
+            'debtTypeOrgCreate.behaviour.notifications.fields.retriesDescription'
           )}
         </Typography>
       </Stack>
@@ -38,30 +38,30 @@ export const PaymentNotificationFields = ({
         <FormComponent.ControlledTextField
           name="notificationAppName"
           control={control}
-          label={t('debtTypeCreateEC.behaviour.notifications.fields.appName')}
+          label={t('debtTypeOrgCreate.behaviour.notifications.fields.appName')}
         />
         <FormComponent.ControlledTextField
           name="notificationEndpoint"
           control={control}
-          label={t('debtTypeCreateEC.behaviour.notifications.fields.endpoint')}
+          label={t('debtTypeOrgCreate.behaviour.notifications.fields.endpoint')}
         />
         <FormComponent.ControlledCheckbox
           name="enableJwtAuth"
           control={control}
-          label={t('debtTypeCreateEC.behaviour.notifications.fields.jwt')}
+          label={t('debtTypeOrgCreate.behaviour.notifications.fields.jwt')}
         />
       </Stack>
       <Stack direction="row" spacing={2}>
         <FormComponent.ControlledTextField
           name="clientId"
           control={control}
-          label={t('debtTypeCreateEC.behaviour.notifications.fields.clientId')}
+          label={t('debtTypeOrgCreate.behaviour.notifications.fields.clientId')}
         />
         <FormComponent.ControlledTextField
           name="clientEmail"
           control={control}
           label={t(
-            'debtTypeCreateEC.behaviour.notifications.fields.clientEmail'
+            'debtTypeOrgCreate.behaviour.notifications.fields.clientEmail'
           )}
         />
       </Stack>
@@ -70,13 +70,15 @@ export const PaymentNotificationFields = ({
           name="secretKeyId"
           control={control}
           label={t(
-            'debtTypeCreateEC.behaviour.notifications.fields.secretKeyId'
+            'debtTypeOrgCreate.behaviour.notifications.fields.secretKeyId'
           )}
         />
         <FormComponent.ControlledTextField
           name="secretKey"
           control={control}
-          label={t('debtTypeCreateEC.behaviour.notifications.fields.secretKey')}
+          label={t(
+            'debtTypeOrgCreate.behaviour.notifications.fields.secretKey'
+          )}
         />
       </Stack>
     </Stack>

--- a/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/index.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/index.tsx
@@ -19,18 +19,21 @@ import {
 import { PaymentNotificationFields } from './components/PaymentNotificationFields';
 
 export type Step2Data = {
-  isSpontaneousPaymentEnabled?: boolean;
+  flagSpontaneous?: boolean;
+
+  flagMandatoryDueDate?: boolean;
+  flagAnonymousFiscalCode?: boolean;
+
+  // FREE if nothing is passed
   paymentMethod: PaymentMethodOption;
-  enablePaymentNotifications?: 'true' | 'false';
-  authenticateUsername?: string;
-  authenticatePassword?: string;
-  authCallbackUrl?: string;
-  updateCallbackUrl?: string;
-  isDueDateRequired?: boolean;
-  isAnonymousFiscalCode?: boolean;
-  fixedAmount?: number;
-  customFieldsSchema?: File;
+
+  amountCents?: number;
   externalPaymentUrl?: string;
+  xsdDefinitionRef?: File;
+
+  flagNotifyOutcomePush?: 'true' | 'false';
+
+  // TODO Missing in api
   notificationRetries?: number;
   notificationAppName?: string;
   notificationEndpoint?: string;
@@ -39,6 +42,12 @@ export type Step2Data = {
   clientEmail?: string;
   secretKeyId?: string;
   secretKey?: string;
+
+  // TODO Missing in api
+  authenticateUsername?: string;
+  authenticatePassword?: string;
+  authCallbackUrl?: string;
+  updateCallbackUrl?: string;
 };
 
 export type Step2Props = {
@@ -59,8 +68,8 @@ export const Step2Behaviour = ({ setData, onNext, onBack }: Step2Props) => {
     }
   });
 
-  const isSpontaneous = watch('isSpontaneousPaymentEnabled');
-  const enableNotifications = watch('enablePaymentNotifications');
+  const isSpontaneous = watch('flagSpontaneous');
+  const enableNotifications = watch('flagNotifyOutcomePush');
 
   const onSubmit = (values: Step2Data) => {
     setData(values);
@@ -70,20 +79,20 @@ export const Step2Behaviour = ({ setData, onNext, onBack }: Step2Props) => {
   return (
     <form aria-label="form" onSubmit={handleSubmit(onSubmit)}>
       <WizardStepWrapper
-        title={t('debtTypeCreateEC.behaviour.title')}
-        subtitle={t('debtTypeCreateEC.behaviour.subtitle')}
-        alertMessage={t('debtTypeCreateEC.behaviour.alertMessage')}
+        title={t('debtTypeOrgCreate.behaviour.title')}
+        subtitle={t('debtTypeOrgCreate.behaviour.subtitle')}
+        alertMessage={t('debtTypeOrgCreate.behaviour.alertMessage')}
       >
         <FormComponent.ControlledSwitch
           control={control}
-          name="isSpontaneousPaymentEnabled"
-          label={t('debtTypeCreateEC.behaviour.postalAccount')}
+          name="flagSpontaneous"
+          label={t('debtTypeOrgCreate.behaviour.postalAccount')}
         />
 
         {isSpontaneous ? (
           <SectionBox
             title={t(
-              'debtTypeCreateEC.behaviour.section.spontaneousPaymentTitle'
+              'debtTypeOrgCreate.behaviour.section.spontaneousPaymentTitle'
             )}
             adornment={<OfflineBoltIcon />}
           >
@@ -95,41 +104,43 @@ export const Step2Behaviour = ({ setData, onNext, onBack }: Step2Props) => {
           </SectionBox>
         ) : (
           <SectionBox
-            title={t('debtTypeCreateEC.behaviour.section.behaviourTitle')}
+            title={t('debtTypeOrgCreate.behaviour.section.behaviourTitle')}
             adornment={<TuneIcon />}
           >
             <FormComponent.ControlledCheckbox
               control={control}
-              name="isDueDateRequired"
-              label={t('debtTypeCreateEC.behaviour.optionA.label')}
-              description={t('debtTypeCreateEC.behaviour.optionA.description')}
+              name="flagMandatoryDueDate"
+              label={t('debtTypeOrgCreate.behaviour.optionA.label')}
+              description={t('debtTypeOrgCreate.behaviour.optionA.description')}
             />
             <FormComponent.ControlledCheckbox
               control={control}
-              name="isAnonymousFiscalCode"
-              label={t('debtTypeCreateEC.behaviour.optionB.label')}
-              description={t('debtTypeCreateEC.behaviour.optionB.description')}
+              name="flagAnonymousFiscalCode"
+              label={t('debtTypeOrgCreate.behaviour.optionB.label')}
+              description={t('debtTypeOrgCreate.behaviour.optionB.description')}
             />
           </SectionBox>
         )}
 
         <SectionBox
-          title={t('debtTypeCreateEC.behaviour.notifications.title')}
+          title={t('debtTypeOrgCreate.behaviour.notifications.title')}
           adornment={<NotificationsIcon />}
         >
           <FormComponent.ControlledRadioGroup
-            name="enablePaymentNotifications"
+            name="flagNotifyOutcomePush"
             control={control}
-            label={t('debtTypeCreateEC.behaviour.notifications.radioLabel')}
+            label={t('debtTypeOrgCreate.behaviour.notifications.radioLabel')}
             sx={{ flexDirection: 'row' }}
             options={[
               {
                 value: 'false',
-                label: t('debtTypeCreateEC.behaviour.notifications.options.no')
+                label: t('debtTypeOrgCreate.behaviour.notifications.options.no')
               },
               {
                 value: 'true',
-                label: t('debtTypeCreateEC.behaviour.notifications.options.yes')
+                label: t(
+                  'debtTypeOrgCreate.behaviour.notifications.options.yes'
+                )
               }
             ]}
           />
@@ -139,21 +150,21 @@ export const Step2Behaviour = ({ setData, onNext, onBack }: Step2Props) => {
         </SectionBox>
 
         <SectionBox
-          title={t('debtTypeCreateEC.behaviour.updateAmount.title')}
-          subtitle={t('debtTypeCreateEC.behaviour.updateAmount.subtitle')}
+          title={t('debtTypeOrgCreate.behaviour.updateAmount.title')}
+          subtitle={t('debtTypeOrgCreate.behaviour.updateAmount.subtitle')}
           adornment={<MonetizationOnIcon />}
         >
           <Stack direction="row" spacing={2}>
             <FormComponent.ControlledTextField
               name="authenticateUsername"
               control={control}
-              label={t('debtTypeCreateEC.behaviour.updateAmount.notesLabel')}
+              label={t('debtTypeOrgCreate.behaviour.updateAmount.notesLabel')}
               required={false}
             />
             <FormComponent.ControlledTextField
               name="authenticatePassword"
               control={control}
-              label={t('debtTypeCreateEC.behaviour.updateAmount.amountLabel')}
+              label={t('debtTypeOrgCreate.behaviour.updateAmount.amountLabel')}
               required={false}
             />
           </Stack>
@@ -161,14 +172,14 @@ export const Step2Behaviour = ({ setData, onNext, onBack }: Step2Props) => {
             <FormComponent.ControlledTextField
               name="authCallbackUrl"
               control={control}
-              label={t('debtTypeCreateEC.behaviour.updateAmount.authUrlLabel')}
+              label={t('debtTypeOrgCreate.behaviour.updateAmount.authUrlLabel')}
               required={false}
             />
             <FormComponent.ControlledTextField
               name="updateCallbackUrl"
               control={control}
               label={t(
-                'debtTypeCreateEC.behaviour.updateAmount.updateUrlLabel'
+                'debtTypeOrgCreate.behaviour.updateAmount.updateUrlLabel'
               )}
               required={false}
             />

--- a/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/schema.test.ts
+++ b/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/schema.test.ts
@@ -8,44 +8,46 @@ const t = ((key: string) => key) as TFunction; // Simple mock for translation
 describe('step2Schema', () => {
   describe('Spontaneous Payment Validation', () => {
     const baseSpontaneousData = {
-      isSpontaneousPaymentEnabled: true,
-      isDueDateRequired: false,
+      flagSpontaneous: true,
+      flagMandatoryDueDate: false,
       isAnonymousFiscalCode: false,
-      enablePaymentNotifications: 'false'
+      flagNotifyOutcomePush: 'false',
+      paymentMethod: PaymentMethodOption.FREE
     };
 
-    it('should require fixedAmount for AMOUNT method', () => {
+    it('should require amountCents for AMOUNT method', () => {
       const data = {
         ...baseSpontaneousData,
         paymentMethod: PaymentMethodOption.AMOUNT,
-        fixedAmount: undefined
+        amountCents: undefined
       };
 
       const result = step2Schema(t).safeParse(data);
       expect(result.success).toBe(false);
       expect(result.error?.issues[0]).toMatchObject({
-        path: ['fixedAmount'],
+        path: ['amountCents'],
         message: 'commons.validation.amountRequired'
       });
     });
 
-    it('should require customFieldsSchema for CUSTOM method', () => {
+    it('should require xsdDefinitionRef for CUSTOM method', () => {
       const data = {
         ...baseSpontaneousData,
         paymentMethod: PaymentMethodOption.CUSTOM,
-        customFieldsSchema: null
+        xsdDefinitionRef: undefined
       };
 
       const result = step2Schema(t).safeParse(data);
       expect(result.success).toBe(false);
       expect(result.error?.issues[0]).toMatchObject({
-        path: ['customFieldsSchema'],
+        path: ['xsdDefinitionRef'],
         message: 'debtTypeOrgCreate.behaviour.spontaneous.file.required'
       });
     });
 
     it('should validate externalPaymentUrl for EXTERNAL method', () => {
       const testCases = [
+        { url: undefined, expectedError: 'fieldRequired' },
         { url: '', expectedError: 'fieldRequired' },
         { url: 'invalid-url', expectedError: 'invalidUrl' },
         { url: 'https://valid.com', expectedError: null }
@@ -71,9 +73,9 @@ describe('step2Schema', () => {
 
   describe('Payment Notifications Validation', () => {
     const baseNotificationData = {
-      isSpontaneousPaymentEnabled: false,
+      flagSpontaneous: false,
       paymentMethod: PaymentMethodOption.FREE,
-      enablePaymentNotifications: 'true',
+      flagNotifyOutcomePush: 'true',
       notificationRetries: 3,
       notificationAppName: 'Test App',
       notificationEndpoint: 'https://api.example.com',
@@ -84,7 +86,7 @@ describe('step2Schema', () => {
       secretKey: 'secret-123'
     };
 
-    it('should require all notification fields', () => {
+    it('should require all notification fields when flagNotifyOutcomePush is true', () => {
       const requiredFields = [
         'notificationRetries',
         'notificationAppName',
@@ -103,7 +105,7 @@ describe('step2Schema', () => {
       });
     });
 
-    it('should require JWT auth checkbox', () => {
+    it('should require enableJwtAuth checkbox when flagNotifyOutcomePush is true', () => {
       const data = { ...baseNotificationData, enableJwtAuth: false };
       const result = step2Schema(t).safeParse(data);
       expect(result.success).toBe(false);
@@ -124,9 +126,9 @@ describe('step2Schema', () => {
   describe('Edge Cases', () => {
     it('should pass validation when notifications are disabled', () => {
       const data = {
-        isSpontaneousPaymentEnabled: false,
-        paymentMethod: PaymentMethodOption.FREE, // <-- add this required field
-        enablePaymentNotifications: 'false'
+        flagSpontaneous: false,
+        paymentMethod: PaymentMethodOption.FREE,
+        flagNotifyOutcomePush: 'false'
         // no notification fields needed
       };
 
@@ -136,9 +138,9 @@ describe('step2Schema', () => {
 
     it('should ignore payment method validation when spontaneous payment disabled', () => {
       const data = {
-        isSpontaneousPaymentEnabled: false,
+        flagSpontaneous: false,
         paymentMethod: PaymentMethodOption.AMOUNT
-        // Missing fixedAmount
+        // Missing amountCents but should pass because flagSpontaneous is false
       };
 
       const result = step2Schema(t).safeParse(data);

--- a/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/schema.test.ts
+++ b/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/schema.test.ts
@@ -40,7 +40,7 @@ describe('step2Schema', () => {
       expect(result.success).toBe(false);
       expect(result.error?.issues[0]).toMatchObject({
         path: ['customFieldsSchema'],
-        message: 'debtTypeCreateEC.behaviour.spontaneous.file.required'
+        message: 'debtTypeOrgCreate.behaviour.spontaneous.file.required'
       });
     });
 

--- a/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/schema.ts
+++ b/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/schema.ts
@@ -3,7 +3,6 @@ import { TFunction } from 'i18next';
 import { PaymentMethodOption } from './components/PaymentMethodSelector';
 import { requireField, validateUrl } from '../../../../utils/schema';
 
-// Main schema
 export const step2Schema = (t: TFunction) => {
   const baseSchema = z.object({
     flagSpontaneous: z.boolean().default(false),

--- a/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/schema.ts
+++ b/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/schema.ts
@@ -6,16 +6,16 @@ import { requireField, validateUrl } from '../../../../utils/schema';
 // Main schema
 export const step2Schema = (t: TFunction) => {
   const baseSchema = z.object({
-    isSpontaneousPaymentEnabled: z.boolean().default(false),
-    isDueDateRequired: z.boolean().optional().default(false),
+    flagSpontaneous: z.boolean().default(false),
+    flagMandatoryDueDate: z.boolean().optional().default(false),
     isAnonymousFiscalCode: z.boolean().optional().default(false),
 
     paymentMethod: z.nativeEnum(PaymentMethodOption),
-    fixedAmount: z.coerce.number().optional(),
-    customFieldsSchema: z.any().optional(),
+    amountCents: z.coerce.number().optional(),
+    xsdDefinitionRef: z.any().optional(),
     externalPaymentUrl: z.string().optional(),
 
-    enablePaymentNotifications: z.enum(['true', 'false']).default('false'),
+    flagNotifyOutcomePush: z.enum(['true', 'false']).default('false'),
 
     notificationRetries: z.coerce.number().optional(),
     notificationAppName: z.string().optional(),
@@ -44,25 +44,25 @@ const validateSpontaneousPayment = (
   ctx: z.RefinementCtx,
   t: TFunction
 ) => {
-  if (!data.isSpontaneousPaymentEnabled) return;
+  if (!data.flagSpontaneous) return;
 
   switch (data.paymentMethod) {
     case PaymentMethodOption.AMOUNT:
-      if (!data.fixedAmount) {
+      if (!data.amountCents) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: t('commons.validation.amountRequired'),
-          path: ['fixedAmount']
+          path: ['amountCents']
         });
       }
       break;
 
     case PaymentMethodOption.CUSTOM:
-      if (!data.customFieldsSchema) {
+      if (!data.xsdDefinitionRef) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: t('debtTypeCreateEC.behaviour.spontaneous.file.required'),
-          path: ['customFieldsSchema']
+          message: t('debtTypeOrgCreate.behaviour.spontaneous.file.required'),
+          path: ['xsdDefinitionRef']
         });
       }
       break;
@@ -81,7 +81,7 @@ const validateNotifications = (
   ctx: z.RefinementCtx,
   t: TFunction
 ) => {
-  if (data.enablePaymentNotifications !== 'true') return;
+  if (data.flagNotifyOutcomePush !== 'true') return;
 
   // Validate required fields
   const requiredFields = [

--- a/src/routes/DebtTypeOrgCreate/steps/Step3Accounting.test.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step3Accounting.test.tsx
@@ -28,31 +28,31 @@ describe('Step3Accounting', () => {
 
     // Check main titles and subtitles
     expect(
-      screen.getByText('debtTypeCreateEC.accounting.title')
+      screen.getByText('debtTypeOrgCreate.accounting.title')
     ).toBeInTheDocument();
     expect(
-      screen.getByText('debtTypeCreateEC.accounting.subtitle')
+      screen.getByText('debtTypeOrgCreate.accounting.subtitle')
     ).toBeInTheDocument();
     expect(
-      screen.getByText('debtTypeCreateEC.accounting.alertMessage')
+      screen.getByText('debtTypeOrgCreate.accounting.alertMessage')
     ).toBeInTheDocument();
 
     // Check for section titles
     expect(
-      screen.getByText('debtTypeCreateEC.accounting.section.creditInfo')
+      screen.getByText('debtTypeOrgCreate.accounting.section.creditInfo')
     ).toBeInTheDocument();
     expect(
-      screen.getByText('debtTypeCreateEC.accounting.section.budgetInfo')
+      screen.getByText('debtTypeOrgCreate.accounting.section.budgetInfo')
     ).toBeInTheDocument();
 
     // Check for all input fields by label
     [
-      'debtTypeCreateEC.accounting.postalIban',
-      'debtTypeCreateEC.accounting.pspIban',
-      'debtTypeCreateEC.accounting.postalAccount',
-      'debtTypeCreateEC.accounting.postalAccountHolder',
-      'debtTypeCreateEC.accounting.defaultBudgetStructure',
-      'debtTypeCreateEC.accounting.entitySector'
+      'debtTypeOrgCreate.accounting.postalIban',
+      'debtTypeOrgCreate.accounting.pspIban',
+      'debtTypeOrgCreate.accounting.postalAccount',
+      'debtTypeOrgCreate.accounting.postalAccountHolder',
+      'debtTypeOrgCreate.accounting.defaultBudgetStructure',
+      'debtTypeOrgCreate.accounting.entitySector'
     ].forEach((label) => {
       expect(screen.getByRole('textbox', { name: label })).toBeInTheDocument();
     });
@@ -85,17 +85,17 @@ describe('Step3Accounting', () => {
     );
 
     fillField(
-      'debtTypeCreateEC.accounting.postalIban',
+      'debtTypeOrgCreate.accounting.postalIban',
       'CH9300762011623852957'
     );
-    fillField('debtTypeCreateEC.accounting.pspIban', 'CH9300762011623852958');
-    fillField('debtTypeCreateEC.accounting.postalAccount', '123456789');
-    fillField('debtTypeCreateEC.accounting.postalAccountHolder', 'John Doe');
+    fillField('debtTypeOrgCreate.accounting.pspIban', 'CH9300762011623852958');
+    fillField('debtTypeOrgCreate.accounting.postalAccount', '123456789');
+    fillField('debtTypeOrgCreate.accounting.postalAccountHolder', 'John Doe');
     fillField(
-      'debtTypeCreateEC.accounting.defaultBudgetStructure',
+      'debtTypeOrgCreate.accounting.defaultBudgetStructure',
       'Budget structure text'
     );
-    fillField('debtTypeCreateEC.accounting.entitySector', 'Public Sector');
+    fillField('debtTypeOrgCreate.accounting.entitySector', 'Public Sector');
 
     const nextButton = screen.getByRole('button', { name: 'commons.continue' });
     fireEvent.click(nextButton);

--- a/src/routes/DebtTypeOrgCreate/steps/Step3Accounting.test.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step3Accounting.test.tsx
@@ -103,11 +103,11 @@ describe('Step3Accounting', () => {
     await waitFor(() => {
       expect(mockSetData).toHaveBeenCalledWith({
         postalIban: 'CH9300762011623852957',
-        pspIban: 'CH9300762011623852958',
-        postalAccount: '123456789',
-        postalAccountHolder: 'John Doe',
-        defaultBudgetStructure: 'Budget structure text',
-        entitySector: 'Public Sector'
+        iban: 'CH9300762011623852958',
+        postalAccountCode: '123456789',
+        holderPostalCc: 'John Doe',
+        balance: 'Budget structure text',
+        orgSector: 'Public Sector'
       });
       expect(mockOnNext).toHaveBeenCalledTimes(1);
     });
@@ -129,13 +129,145 @@ describe('Step3Accounting', () => {
     await waitFor(() => {
       expect(mockSetData).toHaveBeenCalledWith({
         postalIban: undefined,
-        pspIban: undefined,
-        postalAccount: undefined,
-        postalAccountHolder: undefined,
-        defaultBudgetStructure: undefined,
-        entitySector: undefined
+        iban: undefined,
+        postalAccountCode: undefined,
+        holderPostalCc: undefined,
+        balance: undefined,
+        orgSector: undefined
       });
       expect(mockOnNext).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('shows validation error for invalid postalIban and prevents submission', async () => {
+    render(
+      <Step3Accounting
+        setData={mockSetData}
+        onNext={mockOnNext}
+        onBack={mockOnBack}
+      />
+    );
+
+    // Enter invalid postalIban
+    fillField('debtTypeOrgCreate.accounting.postalIban', 'INVALID_IBAN');
+
+    // Submit form
+    const nextButton = screen.getByRole('button', { name: 'commons.continue' });
+    fireEvent.click(nextButton);
+
+    // Wait for validation error message to appear
+    await waitFor(() => {
+      expect(
+        screen.getByText('commons.validation.invalidIban')
+      ).toBeInTheDocument();
+    });
+
+    // Submission should not happen
+    expect(mockSetData).not.toHaveBeenCalled();
+    expect(mockOnNext).not.toHaveBeenCalled();
+  });
+
+  it('shows validation error for invalid iban and prevents submission', async () => {
+    render(
+      <Step3Accounting
+        setData={mockSetData}
+        onNext={mockOnNext}
+        onBack={mockOnBack}
+      />
+    );
+
+    // Enter invalid iban
+    fillField('debtTypeOrgCreate.accounting.pspIban', '123');
+
+    // Submit form
+    const nextButton = screen.getByRole('button', { name: 'commons.continue' });
+    fireEvent.click(nextButton);
+
+    // Wait for validation error message to appear
+    await waitFor(() => {
+      expect(
+        screen.getByText('commons.validation.invalidIban')
+      ).toBeInTheDocument();
+    });
+
+    // Submission should not happen
+    expect(mockSetData).not.toHaveBeenCalled();
+    expect(mockOnNext).not.toHaveBeenCalled();
+  });
+
+  it('disables iban field when postalIban is filled', async () => {
+    render(
+      <Step3Accounting
+        setData={mockSetData}
+        onNext={mockOnNext}
+        onBack={mockOnBack}
+      />
+    );
+
+    const postalIbanInput = screen.getByRole('textbox', {
+      name: 'debtTypeOrgCreate.accounting.postalIban'
+    });
+    const ibanInput = screen.getByRole('textbox', {
+      name: 'debtTypeOrgCreate.accounting.pspIban'
+    });
+
+    // Initially both enabled
+    expect(postalIbanInput).toBeEnabled();
+    expect(ibanInput).toBeEnabled();
+
+    // Fill postalIban
+    fireEvent.change(postalIbanInput, {
+      target: { value: 'CH9300762011623852957' }
+    });
+
+    // iban input should become disabled
+    await waitFor(() => {
+      expect(ibanInput).toBeDisabled();
+    });
+
+    // Clear postalIban
+    fireEvent.change(postalIbanInput, { target: { value: '' } });
+
+    // iban input should become enabled again
+    await waitFor(() => {
+      expect(ibanInput).toBeEnabled();
+    });
+  });
+
+  it('disables postalIban field when iban is filled', async () => {
+    render(
+      <Step3Accounting
+        setData={mockSetData}
+        onNext={mockOnNext}
+        onBack={mockOnBack}
+      />
+    );
+
+    const postalIbanInput = screen.getByRole('textbox', {
+      name: 'debtTypeOrgCreate.accounting.postalIban'
+    });
+    const ibanInput = screen.getByRole('textbox', {
+      name: 'debtTypeOrgCreate.accounting.pspIban'
+    });
+
+    // Initially both enabled
+    expect(postalIbanInput).toBeEnabled();
+    expect(ibanInput).toBeEnabled();
+
+    // Fill iban
+    fireEvent.change(ibanInput, { target: { value: 'CH9300762011623852957' } });
+
+    // postalIban input should become disabled
+    await waitFor(() => {
+      expect(postalIbanInput).toBeDisabled();
+    });
+
+    // Clear iban
+    fireEvent.change(ibanInput, { target: { value: '' } });
+
+    // postalIban input should become enabled again
+    await waitFor(() => {
+      expect(postalIbanInput).toBeEnabled();
     });
   });
 });

--- a/src/routes/DebtTypeOrgCreate/steps/Step3Accounting.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step3Accounting.tsx
@@ -8,14 +8,16 @@ import SectionBox from '../../../components/Wizard/SectionBox';
 import WizardStepWrapper from '../../../components/Wizard/WizardStepWrapper';
 import { FormComponent } from '../../../components/FormComponent';
 import WizardStepButtons from '../../../components/Wizard/WizardStepButtons';
+import { isValidIBAN } from '../../../utils/fieldValidation';
+import { TFunction } from 'i18next';
 
 export type Step3Data = {
   postalIban?: string;
-  pspIban?: string;
-  postalAccount?: string;
-  postalAccountHolder?: string;
-  defaultBudgetStructure?: string;
-  entitySector?: string;
+  iban?: string;
+  postalAccountCode?: string;
+  holderPostalCc?: string;
+  balance?: string;
+  orgSector?: string;
 };
 
 export type Step3Props = {
@@ -24,24 +26,33 @@ export type Step3Props = {
   onBack: () => void;
 };
 
-const validationSchema = () =>
+const validationSchema = (t: TFunction) =>
   z.object({
-    postalIban: z.string().optional(),
-    pspIban: z.string().optional(),
-    postalAccount: z.string().optional(),
-    postalAccountHolder: z.string().optional(),
-    defaultBudgetStructure: z.string().optional(),
-    entitySector: z.string().optional()
+    postalIban: z
+      .literal(undefined)
+      .or(z.literal(''))
+      .or(z.string().refine(isValidIBAN, t('commons.validation.invalidIban'))),
+    iban: z
+      .literal(undefined)
+      .or(z.literal(''))
+      .or(z.string().refine(isValidIBAN, t('commons.validation.invalidIban'))),
+
+    postalAccountCode: z.string().optional(),
+    holderPostalCc: z.string().optional(),
+    balance: z.string().optional(),
+    orgSector: z.string().optional()
   });
 
 export const Step3Accounting = ({ setData, onNext, onBack }: Step3Props) => {
   const { t } = useTranslation();
-  const schema = validationSchema();
-  const form = useForm<Step3Data>({
+  const schema = validationSchema(t);
+  const { control, handleSubmit, watch } = useForm<Step3Data>({
     resolver: zodResolver(schema),
     mode: 'onTouched'
   });
-  const { control, handleSubmit } = form;
+
+  const postalIban = watch('postalIban');
+  const iban = watch('iban');
 
   const onSubmit = async (values: Step3Data) => {
     setData(values);
@@ -51,56 +62,58 @@ export const Step3Accounting = ({ setData, onNext, onBack }: Step3Props) => {
   return (
     <form aria-label="form">
       <WizardStepWrapper
-        title={t('debtTypeCreateEC.accounting.title')}
-        subtitle={t('debtTypeCreateEC.accounting.subtitle')}
-        alertMessage={t('debtTypeCreateEC.accounting.alertMessage')}
+        title={t('debtTypeOrgCreate.accounting.title')}
+        subtitle={t('debtTypeOrgCreate.accounting.subtitle')}
+        alertMessage={t('debtTypeOrgCreate.accounting.alertMessage')}
       >
         <SectionBox
-          title={t('debtTypeCreateEC.accounting.section.creditInfo')}
+          title={t('debtTypeOrgCreate.accounting.section.creditInfo')}
           adornment={<AccountBalanceIcon />}
         >
           <FormComponent.ControlledTextField
             name="postalIban"
             control={control}
-            label={t('debtTypeCreateEC.accounting.postalIban')}
+            label={t('debtTypeOrgCreate.accounting.postalIban')}
+            disabled={!!iban}
             required={false}
           />
           <FormComponent.ControlledTextField
-            name="pspIban"
+            name="iban"
             control={control}
-            label={t('debtTypeCreateEC.accounting.pspIban')}
+            label={t('debtTypeOrgCreate.accounting.pspIban')}
+            disabled={!!postalIban}
             required={false}
           />
           <FormComponent.ControlledTextField
-            name="postalAccount"
+            name="postalAccountCode"
             control={control}
-            label={t('debtTypeCreateEC.accounting.postalAccount')}
+            label={t('debtTypeOrgCreate.accounting.postalAccount')}
             required={false}
           />
           <FormComponent.ControlledTextField
-            name="postalAccountHolder"
+            name="holderPostalCc"
             control={control}
-            label={t('debtTypeCreateEC.accounting.postalAccountHolder')}
+            label={t('debtTypeOrgCreate.accounting.postalAccountHolder')}
             required={false}
           />
         </SectionBox>
         <SectionBox
-          title={t('debtTypeCreateEC.accounting.section.budgetInfo')}
+          title={t('debtTypeOrgCreate.accounting.section.budgetInfo')}
           adornment={<BookIcon />}
         >
           <FormComponent.ControlledTextField
-            name="defaultBudgetStructure"
+            name="balance"
             control={control}
-            label={t('debtTypeCreateEC.accounting.defaultBudgetStructure')}
+            label={t('debtTypeOrgCreate.accounting.defaultBudgetStructure')}
             multiline
             InputLabelProps={{ shrink: true }}
             rows={4}
             required={false}
           />
           <FormComponent.ControlledTextField
-            name="entitySector"
+            name="orgSector"
             control={control}
-            label={t('debtTypeCreateEC.accounting.entitySector')}
+            label={t('debtTypeOrgCreate.accounting.entitySector')}
             required={false}
           />
         </SectionBox>

--- a/src/routes/DebtTypeOrgCreate/steps/Step4Notifications.test.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step4Notifications.test.tsx
@@ -166,7 +166,7 @@ describe('Step4Notifications', () => {
     expect(mockSetData).not.toHaveBeenCalled();
     expect(mockOnNext).not.toHaveBeenCalled();
 
-    // Fill serviceApiKey only
+    // Fill serviceId only
     const apiKeyInput = screen.getByRole('textbox', {
       name: 'debtTypeOrgCreate.notifications.serviceApiKey.label'
     });
@@ -193,10 +193,10 @@ describe('Step4Notifications', () => {
 
     await waitFor(() => {
       expect(mockSetData).toHaveBeenCalledWith({
-        enableNotifications: true,
-        serviceApiKey: 'apikey123',
-        messageSubject: 'Subject',
-        messageBody: 'Body text'
+        flagNotifyIo: true,
+        serviceId: 'apikey123',
+        ioTemplateSubject: 'Subject',
+        ioTemplateMessage: 'Body text'
       });
       expect(mockOnNext).toHaveBeenCalledTimes(1);
     });
@@ -217,10 +217,10 @@ describe('Step4Notifications', () => {
 
     await waitFor(() => {
       expect(mockSetData).toHaveBeenCalledWith({
-        enableNotifications: false,
-        serviceApiKey: '',
-        messageSubject: '',
-        messageBody: ''
+        flagNotifyIo: false,
+        serviceId: '',
+        ioTemplateSubject: '',
+        ioTemplateMessage: ''
       });
       expect(mockOnNext).toHaveBeenCalledTimes(1);
     });

--- a/src/routes/DebtTypeOrgCreate/steps/Step4Notifications.test.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step4Notifications.test.tsx
@@ -27,25 +27,25 @@ describe('Step4Notifications', () => {
 
     // Check for main titles and alert message (translation keys)
     expect(
-      screen.getByText('debtTypeCreateEC.notifications.title')
+      screen.getByText('debtTypeOrgCreate.notifications.title')
     ).toBeInTheDocument();
     expect(
-      screen.getByText('debtTypeCreateEC.notifications.subtitle')
+      screen.getByText('debtTypeOrgCreate.notifications.subtitle')
     ).toBeInTheDocument();
     expect(
-      screen.getByText('debtTypeCreateEC.notifications.alertMessage')
+      screen.getByText('debtTypeOrgCreate.notifications.alertMessage')
     ).toBeInTheDocument();
 
     // Check for enableNotifications switch
     expect(
       screen.getByRole('checkbox', {
-        name: 'debtTypeCreateEC.notifications.enableNotifications'
+        name: 'debtTypeOrgCreate.notifications.enableNotifications'
       })
     ).toBeInTheDocument();
 
     // The notification section should NOT be visible initially
     expect(
-      screen.queryByText('debtTypeCreateEC.notifications.section.message')
+      screen.queryByText('debtTypeOrgCreate.notifications.section.message')
     ).not.toBeInTheDocument();
   });
 
@@ -59,7 +59,7 @@ describe('Step4Notifications', () => {
     );
 
     const switchInput = screen.getByRole('checkbox', {
-      name: 'debtTypeCreateEC.notifications.enableNotifications'
+      name: 'debtTypeOrgCreate.notifications.enableNotifications'
     });
 
     // Toggle switch on
@@ -67,14 +67,14 @@ describe('Step4Notifications', () => {
 
     // The notification section should appear
     expect(
-      screen.getByText('debtTypeCreateEC.notifications.section.message')
+      screen.getByText('debtTypeOrgCreate.notifications.section.message')
     ).toBeInTheDocument();
 
     // Check presence of required fields
     [
-      'debtTypeCreateEC.notifications.serviceApiKey.label',
-      'debtTypeCreateEC.notifications.messageSubject.label',
-      'debtTypeCreateEC.notifications.messageBody.label'
+      'debtTypeOrgCreate.notifications.serviceApiKey.label',
+      'debtTypeOrgCreate.notifications.messageSubject.label',
+      'debtTypeOrgCreate.notifications.messageBody.label'
     ].forEach((label) => {
       expect(screen.getByRole('textbox', { name: label })).toBeInTheDocument();
     });
@@ -96,15 +96,15 @@ describe('Step4Notifications', () => {
     );
 
     const switchInput = screen.getByRole('checkbox', {
-      name: 'debtTypeCreateEC.notifications.enableNotifications'
+      name: 'debtTypeOrgCreate.notifications.enableNotifications'
     });
     fireEvent.click(switchInput);
 
     const subjectInput = screen.getByRole('textbox', {
-      name: 'debtTypeCreateEC.notifications.messageSubject.label'
+      name: 'debtTypeOrgCreate.notifications.messageSubject.label'
     });
     const bodyInput = screen.getByRole('textbox', {
-      name: 'debtTypeCreateEC.notifications.messageBody.label'
+      name: 'debtTypeOrgCreate.notifications.messageBody.label'
     });
     const previewButton = screen.getByRole('button', {
       name: 'debtTypeCreate.settings.preview'
@@ -154,7 +154,7 @@ describe('Step4Notifications', () => {
 
     // Enable notifications
     const switchInput = screen.getByRole('checkbox', {
-      name: 'debtTypeCreateEC.notifications.enableNotifications'
+      name: 'debtTypeOrgCreate.notifications.enableNotifications'
     });
     fireEvent.click(switchInput);
 
@@ -168,7 +168,7 @@ describe('Step4Notifications', () => {
 
     // Fill serviceApiKey only
     const apiKeyInput = screen.getByRole('textbox', {
-      name: 'debtTypeCreateEC.notifications.serviceApiKey.label'
+      name: 'debtTypeOrgCreate.notifications.serviceApiKey.label'
     });
     fireEvent.change(apiKeyInput, { target: { value: 'apikey123' } });
 
@@ -180,10 +180,10 @@ describe('Step4Notifications', () => {
 
     // Fill subject and body
     const subjectInput = screen.getByRole('textbox', {
-      name: 'debtTypeCreateEC.notifications.messageSubject.label'
+      name: 'debtTypeOrgCreate.notifications.messageSubject.label'
     });
     const bodyInput = screen.getByRole('textbox', {
-      name: 'debtTypeCreateEC.notifications.messageBody.label'
+      name: 'debtTypeOrgCreate.notifications.messageBody.label'
     });
     fireEvent.change(subjectInput, { target: { value: 'Subject' } });
     fireEvent.change(bodyInput, { target: { value: 'Body text' } });

--- a/src/routes/DebtTypeOrgCreate/steps/Step4Notifications.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step4Notifications.tsx
@@ -17,10 +17,10 @@ import { MarkdownPreview } from '../../DebtTypeCreate/components/MarkdownPreview
 import Link from '@mui/material/Link';
 
 export type Step4Data = {
-  enableNotifications?: boolean;
-  serviceApiKey?: string;
-  messageSubject?: string;
-  messageBody?: string;
+  flagNotifyIo?: boolean;
+  serviceId?: string;
+  ioTemplateSubject?: string;
+  ioTemplateMessage?: string;
 };
 
 export type Step4Props = {
@@ -32,22 +32,22 @@ export type Step4Props = {
 const validationSchema = (t: TFunction) =>
   z
     .object({
-      enableNotifications: z.boolean().optional().default(false),
+      flagNotifyIo: z.boolean().optional().default(false),
       serviceApiKey: z.string().optional(),
-      messageSubject: z.string().optional(),
-      messageBody: z.string().optional()
+      ioTemplateSubject: z.string().optional(),
+      ioTemplateMessage: z.string().optional()
     })
-    .refine((data) => !data.enableNotifications || data.serviceApiKey, {
-      message: t('debtTypeCreateEC.notifications.serviceApiKey.required'),
+    .refine((data) => !data.flagNotifyIo || data.serviceApiKey, {
+      message: t('debtTypeOrgCreate.notifications.serviceApiKey.required'),
       path: ['serviceApiKey']
     })
-    .refine((data) => !data.enableNotifications || data.messageSubject, {
-      message: t('debtTypeCreateEC.notifications.messageSubject.required'),
-      path: ['messageSubject']
+    .refine((data) => !data.flagNotifyIo || data.ioTemplateSubject, {
+      message: t('debtTypeOrgCreate.notifications.messageSubject.required'),
+      path: ['ioTemplateSubject']
     })
-    .refine((data) => !data.enableNotifications || data.messageBody, {
-      message: t('debtTypeCreateEC.notifications.messageBody.required'),
-      path: ['messageBody']
+    .refine((data) => !data.flagNotifyIo || data.ioTemplateMessage, {
+      message: t('debtTypeOrgCreate.notifications.messageBody.required'),
+      path: ['ioTemplateMessage']
     });
 
 export const Step4Notifications = ({ setData, onNext, onBack }: Step4Props) => {
@@ -57,17 +57,17 @@ export const Step4Notifications = ({ setData, onNext, onBack }: Step4Props) => {
   const form = useForm<Step4Data>({
     resolver: zodResolver(schema),
     defaultValues: {
-      enableNotifications: false,
-      serviceApiKey: '',
-      messageSubject: '',
-      messageBody: ''
+      flagNotifyIo: false,
+      serviceId: '',
+      ioTemplateSubject: '',
+      ioTemplateMessage: ''
     },
     mode: 'onTouched'
   });
   const { control, handleSubmit, watch } = form;
-  const enableNotifications = watch('enableNotifications');
-  const messageSubject = watch('messageSubject');
-  const messageBody = watch('messageBody');
+  const flagNotifyIo = watch('flagNotifyIo');
+  const ioTemplateSubject = watch('ioTemplateSubject');
+  const ioTemplateMessage = watch('ioTemplateMessage');
 
   const onSubmit = async (values: Step4Data) => {
     setData(values);
@@ -77,46 +77,46 @@ export const Step4Notifications = ({ setData, onNext, onBack }: Step4Props) => {
   return (
     <form aria-label="form">
       <WizardStepWrapper
-        title={t('debtTypeCreateEC.notifications.title')}
-        subtitle={t('debtTypeCreateEC.notifications.subtitle')}
-        alertMessage={t('debtTypeCreateEC.notifications.alertMessage')}
+        title={t('debtTypeOrgCreate.notifications.title')}
+        subtitle={t('debtTypeOrgCreate.notifications.subtitle')}
+        alertMessage={t('debtTypeOrgCreate.notifications.alertMessage')}
       >
         <FormComponent.ControlledSwitch
-          label={t('debtTypeCreateEC.notifications.enableNotifications')}
-          name="enableNotifications"
+          label={t('debtTypeOrgCreate.notifications.enableNotifications')}
+          name="flagNotifyIo"
           control={control}
         />
-        {enableNotifications && (
+        {flagNotifyIo && (
           <SectionBox
-            title={t('debtTypeCreateEC.notifications.section.message')}
+            title={t('debtTypeOrgCreate.notifications.section.message')}
             adornment={<MessageIcon />}
           >
             <Stack gap={3}>
               <Stack gap={0.5}>
                 <FormComponent.ControlledTextField
-                  name="serviceApiKey"
+                  name="serviceId"
                   control={control}
                   label={t(
-                    'debtTypeCreateEC.notifications.serviceApiKey.label'
+                    'debtTypeOrgCreate.notifications.serviceApiKey.label'
                   )}
                   required
                 />
                 <Typography variant="caption" ml={2}>
-                  {t('debtTypeCreateEC.notifications.serviceApiKey.caption')}
+                  {t('debtTypeOrgCreate.notifications.serviceApiKey.caption')}
                 </Typography>
               </Stack>
               <Stack gap={0.5}>
                 <FormComponent.ControlledTextField
-                  name="messageSubject"
+                  name="ioTemplateSubject"
                   control={control}
                   label={t(
-                    'debtTypeCreateEC.notifications.messageSubject.label'
+                    'debtTypeOrgCreate.notifications.messageSubject.label'
                   )}
                   required
                 />
                 <Typography variant="caption" component="span" ml={2}>
                   <Trans
-                    i18nKey="debtTypeCreateEC.notifications.messageSubject.caption"
+                    i18nKey="debtTypeOrgCreate.notifications.messageSubject.caption"
                     components={[
                       <Link
                         key="link"
@@ -131,16 +131,16 @@ export const Step4Notifications = ({ setData, onNext, onBack }: Step4Props) => {
               </Stack>
               <Stack gap={0.5}>
                 <FormComponent.ControlledTextField
-                  name="messageBody"
+                  name="ioTemplateMessage"
                   control={control}
-                  label={t('debtTypeCreateEC.notifications.messageBody.label')}
+                  label={t('debtTypeOrgCreate.notifications.messageBody.label')}
                   multiline
                   rows={4}
                   required
                 />
                 <Typography variant="caption" component="span" ml={2}>
                   <Trans
-                    i18nKey="debtTypeCreateEC.notifications.messageBody.caption"
+                    i18nKey="debtTypeOrgCreate.notifications.messageBody.caption"
                     components={[
                       <Link
                         key="link"
@@ -162,7 +162,7 @@ export const Step4Notifications = ({ setData, onNext, onBack }: Step4Props) => {
               <Button
                 variant="text"
                 onClick={() => setOpen(true)}
-                disabled={!messageSubject || !messageBody}
+                disabled={!ioTemplateSubject || !ioTemplateMessage}
                 sx={{ px: 0 }}
               >
                 <PreviewIcon sx={{ mr: 1 }} />
@@ -174,8 +174,8 @@ export const Step4Notifications = ({ setData, onNext, onBack }: Step4Props) => {
       </WizardStepWrapper>
       <WizardStepButtons onBack={onBack} onNext={handleSubmit(onSubmit)} />
       <MarkdownPreview
-        title={messageSubject || ''}
-        message={messageBody || ''}
+        title={ioTemplateSubject || ''}
+        message={ioTemplateMessage || ''}
         open={open}
         onClose={() => setOpen(false)}
       />

--- a/src/routes/DebtTypeOrgCreate/steps/Step4Notifications.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step4Notifications.tsx
@@ -33,13 +33,13 @@ const validationSchema = (t: TFunction) =>
   z
     .object({
       flagNotifyIo: z.boolean().optional().default(false),
-      serviceApiKey: z.string().optional(),
+      serviceId: z.string().optional(),
       ioTemplateSubject: z.string().optional(),
       ioTemplateMessage: z.string().optional()
     })
-    .refine((data) => !data.flagNotifyIo || data.serviceApiKey, {
+    .refine((data) => !data.flagNotifyIo || data.serviceId, {
       message: t('debtTypeOrgCreate.notifications.serviceApiKey.required'),
-      path: ['serviceApiKey']
+      path: ['serviceId']
     })
     .refine((data) => !data.flagNotifyIo || data.ioTemplateSubject, {
       message: t('debtTypeOrgCreate.notifications.messageSubject.required'),

--- a/src/routes/DebtTypeOrgCreate/steps/Step5Operators.test.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step5Operators.test.tsx
@@ -1,11 +1,12 @@
 import { vi } from 'vitest';
-import { Step5Operators, OperatorSelection } from './Step5Operators';
+import { Step5Operators } from './Step5Operators';
 import {
   render,
   screen,
   fireEvent,
   waitFor
 } from '../../../__tests__/renderers';
+import { OperatorsSelection } from '../../../../generated/data-contracts';
 
 describe('Step5Operators', () => {
   const mockSetData = vi.fn();
@@ -80,17 +81,12 @@ describe('Step5Operators', () => {
       />
     );
 
-    const radioAll = screen.getByRole('radio', {
-      name: 'debtTypeOrgCreate.operators.options.all'
-    });
     const radioNone = screen.getByRole('radio', {
       name: 'debtTypeOrgCreate.operators.options.none'
     });
 
-    // Select NONE
     fireEvent.click(radioNone);
 
-    expect(radioAll).not.toBeChecked();
     expect(radioNone).toBeChecked();
   });
 
@@ -125,7 +121,7 @@ describe('Step5Operators', () => {
 
     await waitFor(() => {
       expect(mockSetData).toHaveBeenCalledWith({
-        operatorSelection: OperatorSelection.ALL
+        operatorsSelection: OperatorsSelection.ALL
       });
       expect(mockOnNext).toHaveBeenCalledTimes(1);
     });
@@ -150,16 +146,21 @@ describe('Step5Operators', () => {
 
     await waitFor(() => {
       expect(mockSetData).toHaveBeenCalledWith({
-        operatorSelection: OperatorSelection.NONE
+        operatorsSelection: OperatorsSelection.NONE
       });
       expect(mockOnNext).toHaveBeenCalledTimes(1);
     });
   });
 
-  it('shows validation error if operatorSelection is unset (edge case)', async () => {
-    // This is a theoretical case, since the radio is always set by default,
-    // but we can simulate it by rendering with no default value.
-    // You might need to adjust the component to allow this for testing.
+  // Optional: Edge case test for validation error if no selection (usually not possible with radios)
+  it('does not submit if operatorsSelection is unset (edge case)', async () => {
+    // This is a theoretical case because radios always have a selection,
+    // but you can simulate by rendering with no default value if needed.
+
+    // For demonstration, assume you can render with no default and clear selection:
+    // You would need to modify the component to allow this for testing.
+
+    // Here, just check that submission without selection doesn't call onNext:
     render(
       <Step5Operators
         setData={mockSetData}
@@ -168,18 +169,13 @@ describe('Step5Operators', () => {
       />
     );
 
-    // Uncheck both radios (simulate no selection)
-    const radioAll = screen.getByRole('radio', {
-      name: 'debtTypeOrgCreate.operators.options.all'
-    });
-    fireEvent.click(radioAll); // Already checked, so this might not uncheck
-    // In actual HTML, one radio is always checked, so this is just for completeness
-
+    // Attempt to submit without changing selection (default is ALL)
     const nextButton = screen.getByRole('button', { name: 'commons.continue' });
     fireEvent.click(nextButton);
 
-    // Should not submit, but since default is always set, this is just a placeholder
-    expect(mockSetData).not.toHaveBeenCalled();
-    expect(mockOnNext).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockSetData).toHaveBeenCalled();
+      expect(mockOnNext).toHaveBeenCalled();
+    });
   });
 });

--- a/src/routes/DebtTypeOrgCreate/steps/Step5Operators.test.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step5Operators.test.tsx
@@ -27,26 +27,26 @@ describe('Step5Operators', () => {
 
     // Main titles
     expect(
-      screen.getByText('debtTypeCreateEC.operators.title')
+      screen.getByText('debtTypeOrgCreate.operators.title')
     ).toBeInTheDocument();
     expect(
-      screen.getByText('debtTypeCreateEC.operators.subtitle')
+      screen.getByText('debtTypeOrgCreate.operators.subtitle')
     ).toBeInTheDocument();
 
     // Section title
     expect(
-      screen.getByText('debtTypeCreateEC.operators.section.operatorEntities')
+      screen.getByText('debtTypeOrgCreate.operators.section.operatorEntities')
     ).toBeInTheDocument();
 
     // Radio options
     expect(
       screen.getByRole('radio', {
-        name: 'debtTypeCreateEC.operators.options.all'
+        name: 'debtTypeOrgCreate.operators.options.all'
       })
     ).toBeInTheDocument();
     expect(
       screen.getByRole('radio', {
-        name: 'debtTypeCreateEC.operators.options.none'
+        name: 'debtTypeOrgCreate.operators.options.none'
       })
     ).toBeInTheDocument();
   });
@@ -61,10 +61,10 @@ describe('Step5Operators', () => {
     );
 
     const radioAll = screen.getByRole('radio', {
-      name: 'debtTypeCreateEC.operators.options.all'
+      name: 'debtTypeOrgCreate.operators.options.all'
     });
     const radioNone = screen.getByRole('radio', {
-      name: 'debtTypeCreateEC.operators.options.none'
+      name: 'debtTypeOrgCreate.operators.options.none'
     });
 
     expect(radioAll).toBeChecked();
@@ -81,10 +81,10 @@ describe('Step5Operators', () => {
     );
 
     const radioAll = screen.getByRole('radio', {
-      name: 'debtTypeCreateEC.operators.options.all'
+      name: 'debtTypeOrgCreate.operators.options.all'
     });
     const radioNone = screen.getByRole('radio', {
-      name: 'debtTypeCreateEC.operators.options.none'
+      name: 'debtTypeOrgCreate.operators.options.none'
     });
 
     // Select NONE
@@ -141,7 +141,7 @@ describe('Step5Operators', () => {
     );
 
     const radioNone = screen.getByRole('radio', {
-      name: 'debtTypeCreateEC.operators.options.none'
+      name: 'debtTypeOrgCreate.operators.options.none'
     });
     fireEvent.click(radioNone);
 
@@ -170,7 +170,7 @@ describe('Step5Operators', () => {
 
     // Uncheck both radios (simulate no selection)
     const radioAll = screen.getByRole('radio', {
-      name: 'debtTypeCreateEC.operators.options.all'
+      name: 'debtTypeOrgCreate.operators.options.all'
     });
     fireEvent.click(radioAll); // Already checked, so this might not uncheck
     // In actual HTML, one radio is always checked, so this is just for completeness

--- a/src/routes/DebtTypeOrgCreate/steps/Step5Operators.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step5Operators.tsx
@@ -8,14 +8,10 @@ import SectionBox from '../../../components/Wizard/SectionBox';
 import WizardStepWrapper from '../../../components/Wizard/WizardStepWrapper';
 import { FormComponent } from '../../../components/FormComponent';
 import WizardStepButtons from '../../../components/Wizard/WizardStepButtons';
-
-export enum OperatorSelection {
-  ALL = 'ALL',
-  NONE = 'NONE'
-}
+import { OperatorsSelection } from '../../../../generated/data-contracts';
 
 export type Step5Data = {
-  operatorSelection: OperatorSelection;
+  operatorsSelection: OperatorsSelection;
 };
 
 export type Step5Props = {
@@ -26,8 +22,10 @@ export type Step5Props = {
 
 const validationSchema = (t: TFunction) =>
   z.object({
-    operatorSelection: z.nativeEnum(OperatorSelection, {
-      required_error: t('debtTypeCreateEC.operators.operatorSelection.required')
+    operatorsSelection: z.nativeEnum(OperatorsSelection, {
+      required_error: t(
+        'debtTypeOrgCreate.operators.operatorSelection.required'
+      )
     })
   });
 
@@ -37,7 +35,7 @@ export const Step5Operators = ({ setData, onNext, onBack }: Step5Props) => {
   const form = useForm<Step5Data>({
     resolver: zodResolver(schema),
     defaultValues: {
-      operatorSelection: OperatorSelection.ALL
+      operatorsSelection: OperatorsSelection.ALL
     },
     mode: 'onTouched'
   });
@@ -51,24 +49,24 @@ export const Step5Operators = ({ setData, onNext, onBack }: Step5Props) => {
   return (
     <form aria-label="form">
       <WizardStepWrapper
-        title={t('debtTypeCreateEC.operators.title')}
-        subtitle={t('debtTypeCreateEC.operators.subtitle')}
+        title={t('debtTypeOrgCreate.operators.title')}
+        subtitle={t('debtTypeOrgCreate.operators.subtitle')}
       >
         <SectionBox
-          title={t('debtTypeCreateEC.operators.section.operatorEntities')}
+          title={t('debtTypeOrgCreate.operators.section.operatorEntities')}
           adornment={<PeopleIcon />}
         >
           <FormComponent.ControlledRadioGroup
-            name="operatorSelection"
+            name="operatorsSelection"
             control={control}
             options={[
               {
-                value: OperatorSelection.ALL,
-                label: t('debtTypeCreateEC.operators.options.all')
+                value: OperatorsSelection.ALL,
+                label: t('debtTypeOrgCreate.operators.options.all')
               },
               {
-                value: OperatorSelection.NONE,
-                label: t('debtTypeCreateEC.operators.options.none')
+                value: OperatorsSelection.NONE,
+                label: t('debtTypeOrgCreate.operators.options.none')
               }
             ]}
           />

--- a/src/routes/DebtTypesCreated/DebtTypesCreated.test.tsx
+++ b/src/routes/DebtTypesCreated/DebtTypesCreated.test.tsx
@@ -57,7 +57,7 @@ describe('DebtTypesCreated', () => {
     const createButton = screen.getByText('Create New Debt Type');
     fireEvent.click(createButton);
 
-    expect(mockNavigate).toHaveBeenCalledWith(PageRoutes.DEBT_TYPE_CREATE_EC);
+    expect(mockNavigate).toHaveBeenCalledWith(PageRoutes.DEBT_TYPE_ORG_CREATE);
   });
 
   it('does not render tabs', () => {

--- a/src/routes/DebtTypesCreated/DebtTypesCreated.tsx
+++ b/src/routes/DebtTypesCreated/DebtTypesCreated.tsx
@@ -136,7 +136,7 @@ export const DebtTypesCreated = () => {
           {
             icon: <Add />,
             buttonText: t('debtTypesCreated.callToAction'),
-            onActionClick: () => navigate(PageRoutes.DEBT_TYPE_CREATE_EC)
+            onActionClick: () => navigate(PageRoutes.DEBT_TYPE_ORG_CREATE)
           }
         ]}
         description={t(

--- a/src/routes/debtTypes.tsx
+++ b/src/routes/debtTypes.tsx
@@ -8,7 +8,7 @@ import { DebtTypeCreateSuccess } from './DebtTypeCreate/DebtTypeCreateSuccess';
 import { DebtTypeCatalogEdit } from './DebtTypeCatalogEdit';
 import { DebtTypeCatalogEditSuccess } from './DebtTypeCatalogEdit/DebtTypeCatalogEditSuccess';
 import DebtTypesCreated from './DebtTypesCreated/DebtTypesCreated';
-import { DebtTypeCreateEC } from './DebtTypeCreateEC';
+import { DebtTypeOrgCreate } from './DebtTypeOrgCreate';
 
 const deployPath = config.deployPath;
 
@@ -74,9 +74,9 @@ export const debtTypesRoutes = [
         } as RouteHandleObject
       },
       {
-        id: 'DEBT_TYPE_CREATE_EC',
+        id: 'DEBT_TYPE_ORG_CREATE',
         path: 'dashboard/new',
-        element: <DebtTypeCreateEC />,
+        element: <DebtTypeOrgCreate />,
         handle: {
           backButton: true,
           backButtonText: 'commons.exit',

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -306,7 +306,8 @@
       "urlRequired": "L'URL è obbligatorio",
       "invalidUrl": "Formato URL non valido",
       "fieldRequired": "Campo obbligatorio",
-      "checkboxRequired": "Questa conferma è obbligatoria"
+      "checkboxRequired": "Questa conferma è obbligatoria",
+      "invalidIban": "Formato IBAN non valido"
     }
   },
   "conservation": {
@@ -679,7 +680,7 @@
     "description": "La trovi nella sezione Catalogo Tipi dovuti, dove puoi modificarlo in qualsiasi momento.",
     "title": "Il tipo dovuto '{{paymentObject}}' è stato creato!"
   },
-  "debtTypeCreateEC": {
+  "debtTypeOrgCreate": {
     "title": "Imposta nuovo Tipo dovuto",
     "description": "Compila i campi e configura un nuovo Tipo dovuto per il tuo ente.",
     "configuration": {
@@ -696,12 +697,14 @@
         "subtitle": "Aggiungi i dati che caratterizzano questo Tipo dovuto all'interno del tuo ente."
       },
       "code": {
-        "label": "Codice Sistema Gestionale"
+        "label": "Codice Sistema Gestionale",
+        "required": "Il Codice Sistema Gestionale é obbligatorio"
       },
       "description": {
         "label": "Descrizione",
         "maxCharacters": "La descrizione del Tipo dovuto deve avere al massimo 100 caratteri",
-        "caption": "Ti aiuterà a riconoscere velocemente il dovuto nel caso in cui esistano due versioni dello stesso tipo dovuto."
+        "caption": "Ti aiuterà a riconoscere velocemente il dovuto nel caso in cui esistano due versioni dello stesso tipo dovuto.",
+        "required": "La descrizione del Tipo dovuto é obbligatorio"
       },
       "selection": {
         "title": "Intermediario del Pagamento",


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
    - api fields mapping
    - removes operatorSelection section
    - fixes types and schema
    - adds iban validation
    - getDebtPoperatorSelection
    - adds getDebtPositionTypesByOrganizationId
    - adds useDebtPositionTypesByOrg
    - fixes naming & hierarchy TypeEc -> TypeOrg
    - adds debtPositionTypeOrg
    - unit tests
   
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This PR connects the static create page to the new create api, enabling admins to create new DebtPositonTypesOrg.
Also fixes some logic and validation issues on the static page.

NB: not all fields are handled by the api at the moment and will be added in the future, in particular in Step2 notifications and actualization fields

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- unit tests
- visual testing

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
