### PR TITLE
feat: [P4ADEV-2806]  notice detail print single notice

### DIFF
--- a/src/api/debtPositions.ts
+++ b/src/api/debtPositions.ts
@@ -8,6 +8,7 @@ import {
 } from '../../generated/zod-schema';
 import { AxiosError } from 'axios';
 import { DebtPositionDTO } from '../../generated/data-contracts';
+import { extractFilename } from '../utils/formatters';
 
 type DebtPositionViewParams = Parameters<
   typeof utils.apiClient.bff.getDebtPositionViews
@@ -175,6 +176,36 @@ const createDebtPosition = (
     onError
   });
 
+/**
+ * Downloads the payment notice for a specific installment
+ * @param organizationId Organization ID
+ * @param debtPositionId Debt position ID
+ * @param iuv IUV code of the installment
+ * @returns Promise with file data and filename or null in case of error
+ */
+const downloadPaymentNotice = async (
+  organizationId: number,
+  debtPositionId: number,
+  iuv: string
+): Promise<{ data: Blob; fileName: string } | null> => {
+  try {
+    const response = await utils.apiClient.bff.getPaymentNotice(
+      organizationId,
+      debtPositionId,
+      { iuv },
+      { format: 'blob' }
+    );
+
+    const contentDisposition = response.headers['content-disposition'] || '';
+    const fileName = extractFilename(contentDisposition) || `notice-${iuv}.pdf`;
+
+    return { data: response.data, fileName };
+  } catch (error) {
+    console.error('Error downloading payment notice:', error);
+    return null;
+  }
+};
+
 export default {
   getDebtPositionViews,
   getInstallments,
@@ -182,5 +213,6 @@ export default {
   getDebtPositionDetail,
   deleteDebtPositionType,
   deleteDebtPosition,
-  createDebtPosition
+  createDebtPosition,
+  downloadPaymentNotice
 };

--- a/src/components/DebtPositionsInstallmentDetail/DebtPositionsInstallmentDetail.test.tsx
+++ b/src/components/DebtPositionsInstallmentDetail/DebtPositionsInstallmentDetail.test.tsx
@@ -4,6 +4,17 @@ import { DebtPositionsInstallmentDetail } from './DebtPositionsInstallmentDetail
 import debtPositions from '../../api/debtPositions';
 import { useLocation, useParams } from 'react-router-dom';
 import { setOrganizationId } from '../../store/OrganizationIdStore';
+import { downloadBlob } from '../../utils/download';
+import utils from '../../utils';
+import { STATE } from '../../store/types';
+import { InstallmentStatus } from '../../../generated/apiClient';
+import React from 'react';
+
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn()
+}));
 
 vi.mock('react-router-dom', () => ({
   useNavigate: vi.fn(),
@@ -18,23 +29,42 @@ vi.mock('react-router-dom', () => ({
 }));
 
 vi.mock('../../api/debtPositions', () => ({
-  default: { getInstallmentDetail: vi.fn() }
+  default: {
+    getInstallmentDetail: vi.fn(),
+    downloadPaymentNotice: vi.fn()
+  }
 }));
+
+vi.mock('../../utils/download', () => ({
+  downloadBlob: vi.fn()
+}));
+
+vi.mock('../../utils', () => ({
+  default: {
+    notify: {
+      emit: vi.fn()
+    }
+  }
+}));
+
+const mockOrganizationId = 123;
 
 vi.mock('../../store/GlobalStore', () => ({
   useStore: vi.fn(() => ({
-    state: { ORGANIZATION_ID: 3, customBreadcrumbsItems: [] }
+    state: {
+      [STATE.ORGANIZATION_ID]: mockOrganizationId,
+      customBreadcrumbsItems: []
+    }
   })),
   StoreProvider: ({ children }: React.PropsWithChildren<object>) => children
 }));
 
 describe('DebtPositionsInstallmentDetail', () => {
-  const mockOrganizationId = 123;
   const mockUseParams = vi.mocked(useParams);
   const mockPaidInstallment = {
     installmentId: 288,
     paymentOptionId: 301,
-    status: 'PAID',
+    status: InstallmentStatus.PAID,
     debtor: {
       entityType: 'F',
       fiscalCode: 'RSSMRA92A12B123A',
@@ -50,12 +80,13 @@ describe('DebtPositionsInstallmentDetail', () => {
     iur: '987654321098765',
     debtPositionTypeOrgDescription: 'Test for Create Debt Position',
     debtPositionDescription: 'Debt Position Description',
-    debtPositionId: 239
+    debtPositionId: 239,
+    iuv: '302000000000000001'
   };
 
   const mockUnpaidInstallment = {
     ...mockPaidInstallment,
-    status: 'UNPAID',
+    status: InstallmentStatus.UNPAID,
     paymentDateTime: undefined,
     payer: undefined,
     pspCompanyName: undefined,
@@ -131,5 +162,137 @@ describe('DebtPositionsInstallmentDetail', () => {
 
     fireEvent.click(showMore);
     expect(drawerTitle).toBeVisible();
+  });
+
+  it('downloads PDF when download button is clicked for UNPAID installment', async () => {
+    const mockBlob = new Blob(['test content'], { type: 'application/pdf' });
+    const mockFileName = 'notice-302000000000000001.pdf';
+
+    (
+      debtPositions.downloadPaymentNotice as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({
+      data: mockBlob,
+      fileName: mockFileName
+    });
+
+    (
+      debtPositions.getInstallmentDetail as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValue({ data: mockUnpaidInstallment });
+
+    render(<DebtPositionsInstallmentDetail />);
+
+    const downloadButton = screen.getByText('commons.downloadInstallment');
+    expect(downloadButton).toBeInTheDocument();
+
+    fireEvent.click(downloadButton);
+
+    expect(debtPositions.downloadPaymentNotice).toHaveBeenCalledWith(
+      mockOrganizationId,
+      mockUnpaidInstallment.debtPositionId,
+      mockUnpaidInstallment.iuv
+    );
+
+    await vi.waitFor(() => {
+      expect(downloadBlob).toHaveBeenCalledWith(mockBlob, mockFileName);
+    });
+  });
+
+  it('shows dialog when trying to download PAID installment', async () => {
+    render(<DebtPositionsInstallmentDetail />);
+
+    const downloadButton = screen.getByText('commons.downloadInstallment');
+    expect(downloadButton).toBeInTheDocument();
+
+    fireEvent.click(downloadButton);
+
+    expect(
+      screen.getByText('debtPositionInstallmentDetail.dialogDownload.title')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('debtPositionInstallmentDetail.dialogDownload.message')
+    ).toBeInTheDocument();
+
+    expect(debtPositions.downloadPaymentNotice).not.toHaveBeenCalled();
+  });
+
+  it('closes dialog when clicking cancel button', async () => {
+    vi.mock('../GenericDialog/GenericDialog', () => ({
+      default: ({
+        onConfirm,
+        open,
+        title,
+        message,
+        confirmLabel
+      }: {
+        onConfirm?: () => void;
+        open: boolean;
+        title: string;
+        message?: string;
+        confirmLabel?: string;
+      }) => {
+        if (open) {
+          return (
+            <div role="dialog">
+              <div>{title}</div>
+              {message && <div>{message}</div>}
+              <button onClick={onConfirm}>{confirmLabel}</button>
+            </div>
+          );
+        }
+        return null;
+      }
+    }));
+
+    render(<DebtPositionsInstallmentDetail />);
+
+    const downloadButton = screen.getByText('commons.downloadInstallment');
+    fireEvent.click(downloadButton);
+
+    expect(
+      screen.getByText('debtPositionInstallmentDetail.dialogDownload.title')
+    ).toBeInTheDocument();
+
+    const closeButton = screen.getByText('commons.close');
+    fireEvent.click(closeButton);
+  });
+
+  it('shows error notification when download fails', async () => {
+    (
+      debtPositions.getInstallmentDetail as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValue({ data: mockUnpaidInstallment });
+
+    (
+      debtPositions.downloadPaymentNotice as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue(null);
+
+    render(<DebtPositionsInstallmentDetail />);
+
+    const downloadButton = screen.getByText('commons.downloadInstallment');
+    fireEvent.click(downloadButton);
+
+    await vi.waitFor(() => {
+      expect(utils.notify.emit).toHaveBeenCalledWith(
+        'commons.files.downloadFailed',
+        'error'
+      );
+    });
+  });
+
+  it('shows error notification when IUV is missing', async () => {
+    const installmentWithoutIuv = { ...mockPaidInstallment, iuv: undefined };
+    (
+      debtPositions.getInstallmentDetail as unknown as ReturnType<typeof vi.fn>
+    ).mockReturnValue({ data: installmentWithoutIuv });
+
+    render(<DebtPositionsInstallmentDetail />);
+
+    const downloadButton = screen.getByText('commons.downloadInstallment');
+    fireEvent.click(downloadButton);
+
+    expect(utils.notify.emit).toHaveBeenCalledWith(
+      'commons.files.missingIuv',
+      'error'
+    );
+    expect(debtPositions.downloadPaymentNotice).not.toHaveBeenCalled();
   });
 });

--- a/src/components/DebtPositionsInstallmentDetail/DebtPositionsInstallmentDetail.tsx
+++ b/src/components/DebtPositionsInstallmentDetail/DebtPositionsInstallmentDetail.tsx
@@ -323,8 +323,8 @@ export const DebtPositionsInstallmentDetail = () => {
         open={openDeleteDialog}
         title={t('debtPositionInstallmentDetail.dialogDownload.title')}
         message={t('debtPositionInstallmentDetail.dialogDownload.message')}
-        cancelLabel={t('commons.close')}
-        onClose={() => setOpenDeleteDialog(false)}
+        confirmLabel={t('commons.close')}
+        onConfirm={() => setOpenDeleteDialog(false)}
       />
     </>
   );

--- a/src/components/DebtPositionsInstallmentDetail/DebtPositionsInstallmentDetail.tsx
+++ b/src/components/DebtPositionsInstallmentDetail/DebtPositionsInstallmentDetail.tsx
@@ -22,6 +22,9 @@ import { BredcrumbItem } from '../Breadcrumbs/Breadcrumbs';
 import { InstallmentDetailDrawer } from './InstallmentDetailDrawer';
 import { Timeline } from '../Timeline';
 import { setAppState } from '../../store/AppStateStore';
+import { downloadBlob } from '../../utils/download';
+import utils from '../../utils';
+import GenericDialog from '../GenericDialog/GenericDialog';
 
 export const DebtPositionsInstallmentDetail = () => {
   const { t } = useTranslation();
@@ -34,6 +37,7 @@ export const DebtPositionsInstallmentDetail = () => {
   } = useLocation();
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [timelineOpen, setTimelineOpen] = useState(false);
+  const [openDeleteDialog, setOpenDeleteDialog] = useState(false);
 
   const toggleDrawer = () => {
     setDrawerOpen((prev) => !prev);
@@ -51,6 +55,38 @@ export const DebtPositionsInstallmentDetail = () => {
     organizationId,
     installmentId
   );
+  const statusInstallment = installment?.status;
+
+  const handleDownloadInstallment = async () => {
+    if (!installment?.iuv || !installment.debtPositionId) {
+      utils.notify.emit(t('commons.files.missingIuv'), 'error');
+      return;
+    }
+
+    if (statusInstallment !== InstallmentStatus.UNPAID) {
+      setOpenDeleteDialog(true);
+      return;
+    }
+
+    try {
+      const result = await debtPositions.downloadPaymentNotice(
+        organizationId,
+        installment.debtPositionId,
+        installment.iuv
+      );
+
+      if (!result) {
+        utils.notify.emit(t('commons.files.downloadFailed'), 'error');
+        return;
+      }
+
+      const { data, fileName } = result;
+      downloadBlob(data, fileName);
+    } catch (error) {
+      console.error(t('commons.files.downloadFailed'), error);
+      utils.notify.emit(t('commons.files.downloadFailed'), 'error');
+    }
+  };
 
   const getFiscalCodeValue = (
     fiscalCode?: string,
@@ -179,7 +215,7 @@ export const DebtPositionsInstallmentDetail = () => {
             icon: <Download />,
             variant: 'contained',
             buttonText: t('commons.downloadInstallment'),
-            onActionClick: () => console.log('download')
+            onActionClick: handleDownloadInstallment
           }
         ]}
       />
@@ -282,6 +318,14 @@ export const DebtPositionsInstallmentDetail = () => {
           last
         />
       </Timeline.Drawer>
+      <GenericDialog
+        data-testid="confirm-delete-dialog"
+        open={openDeleteDialog}
+        title={t('debtPositionInstallmentDetail.dialogDownload.title')}
+        message={t('debtPositionInstallmentDetail.dialogDownload.message')}
+        cancelLabel={t('commons.close')}
+        onClose={() => setOpenDeleteDialog(false)}
+      />
     </>
   );
 };

--- a/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizardCompleted.tsx
+++ b/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizardCompleted.tsx
@@ -94,7 +94,22 @@ function DebtPositionCreateWizardCompleted() {
             isDraft ? translationParams : undefined
           )}
         </Typography>
+      </Box>
 
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 2
+        }}
+      >
+        <Button
+          role="button"
+          variant="outlined"
+          onClick={() => navigate(`${deployPath}/debt-positions/`)}
+        >
+          {t(translationKeys.backToStart)}
+        </Button>
         {isDraft && (
           <Button
             role="button"
@@ -105,13 +120,6 @@ function DebtPositionCreateWizardCompleted() {
           </Button>
         )}
       </Box>
-      <Button
-        role="button"
-        variant="naked"
-        onClick={() => navigate(`${deployPath}/debt-positions/`)}
-      >
-        {t(translationKeys.backToStart)}
-      </Button>
     </Box>
   );
 }

--- a/src/routes/DebtPositionDetail/DebtPositionDetail.tsx
+++ b/src/routes/DebtPositionDetail/DebtPositionDetail.tsx
@@ -347,16 +347,16 @@ const DebtPositionDetail = () => {
         anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
       >
         <>
-          <MenuItem onClick={handleDelete}>
-            <Delete fontSize="small" sx={{ mr: 1, color: 'error.main' }} />
-            {t('commons.delete')}
-          </MenuItem>
           {showEditOption && (
             <MenuItem onClick={() => console.log('edit')}>
               <Edit fontSize="small" sx={{ mr: 1, color: 'primary.main' }} />
               {t('debtPositionDetail.edit')}
             </MenuItem>
           )}
+          <MenuItem onClick={handleDelete}>
+            <Delete fontSize="small" sx={{ mr: 1, color: 'error.main' }} />
+            {t('commons.delete')}
+          </MenuItem>
         </>
       </Menu>
 

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -88,7 +88,9 @@
       "size": "Dimensione File",
       "upload": "Carica il file",
       "uploadDate": "Data Caricamento",
-      "uploadInProgress": "Caricamento in corso..."
+      "uploadInProgress": "Caricamento in corso...",
+      "downloadFailed": "Errore durante il download.",
+      "missingIuv": "Manca il codice IUV o l'ID della posizione debitoria"
     },
     "filters": {
       "accountingDate": {
@@ -553,6 +555,10 @@
     }
   },
   "debtPositionInstallmentDetail": {
+    "dialogDownload": {
+      "title": "L'avviso non può essere scaricato.",
+      "message": "Siamo spiacenti, questo file non può essere scaricato. Possono essere scaricati solo gli avvisi non pagati."
+    },
     "drawer": {
       "info": "Ci sono presenti altri beneficiari diversi al tuo ente.",
       "title": "Beneficiari"
@@ -583,7 +589,7 @@
   "debtPositionsImportThankYouPage": {
     "description": "Troverai il flusso caricato nella sezione Flussi importati"
   },
-   "debtTypeDetail": {
+  "debtTypeDetail": {
     "description": "Ecco i dettagli del Tipo dovuto",
     "debtMainConfiguration": {
       "title": "Configurazione generale",
@@ -591,7 +597,7 @@
     },
     "accounting": {
       "description": "Parametri per la gestione delle entrate."
-    }, 
+    },
     "messages": {
       "description": "Notifiche digitale ai cittadini.",
       "IOApp": "App IO",


### PR DESCRIPTION
This PR implements the functionality to download a single installment PDF.
The download button is available on the debt position detail page.

#### List of Changes

-Implemented API integration for PDF download
-Added logic to handle single installment PDF download
-Minor design fixes/edits on the detail page


#### How Has This Been Tested?

-visual testing
-unit tests


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
