### PR TITLE
feat: [P4ADEV-2812] select operator in debtType "Ente Intermediato"

### DIFF
--- a/src/api/debtPositionTypeOrgOperators.test.ts
+++ b/src/api/debtPositionTypeOrgOperators.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
+import { renderHook, waitFor } from '../__tests__/renderers';
+import utils from '../utils';
+import { getDebtPositionTypeOrgOperators } from './debtPositionTypeOrgOperators';
+import { parseAndLog } from '../utils/loaders';
+import type { UseQueryOptions } from '@tanstack/react-query';
+import type { PagedDebtPositionTypeOrgOperatorDTO } from '../../generated/data-contracts';
+
+type OperatorQueryKey = [string, number, Record<string, unknown>];
+
+vi.mock('../utils', () => ({
+  default: {
+    apiClient: {
+      bff: {
+        getDebtPositionTypeOrgOperators: vi.fn()
+      }
+    }
+  }
+}));
+
+vi.mock('../utils/loaders', () => ({
+  parseAndLog: vi.fn()
+}));
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual<typeof import('@tanstack/react-query')>(
+    '@tanstack/react-query'
+  );
+
+  return {
+    ...actual,
+    useQuery: vi.fn(
+      (
+        options: UseQueryOptions<
+          PagedDebtPositionTypeOrgOperatorDTO,
+          Error,
+          PagedDebtPositionTypeOrgOperatorDTO,
+          OperatorQueryKey
+        >
+      ) => {
+        useQueryMock.lastOptions = options;
+        return actual.useQuery(options);
+      }
+    )
+  };
+});
+
+type QueryMock = {
+  lastOptions: UseQueryOptions<
+    PagedDebtPositionTypeOrgOperatorDTO,
+    Error,
+    PagedDebtPositionTypeOrgOperatorDTO,
+    OperatorQueryKey
+  > | null;
+};
+
+const useQueryMock: QueryMock = {
+  lastOptions: null
+};
+
+describe('getDebtPositionTypeOrgOperators', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useQueryMock.lastOptions = null;
+  });
+
+  it('should fetch and return operators with default parameters', async () => {
+    const mockData: PagedDebtPositionTypeOrgOperatorDTO = {
+      content: [
+        {
+          operatorId: 'op1',
+          firstName: 'John',
+          lastName: 'Doe',
+          mappedExternalUserId: 'ext1',
+          enabled: true
+        }
+      ],
+      totalPages: 1,
+      number: 0,
+      size: 10,
+      totalElements: 1
+    };
+
+    (
+      utils.apiClient.bff.getDebtPositionTypeOrgOperators as Mock
+    ).mockResolvedValue({
+      data: mockData
+    });
+
+    const { result } = renderHook(() =>
+      getDebtPositionTypeOrgOperators(3, { page: 0, size: 10 })
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockData);
+    expect(
+      utils.apiClient.bff.getDebtPositionTypeOrgOperators
+    ).toHaveBeenCalledWith(
+      3,
+      { page: 0, size: 10 },
+      expect.objectContaining({
+        paramsSerializer: {
+          indexes: null
+        }
+      })
+    );
+    expect(parseAndLog).toHaveBeenCalledWith(expect.anything(), mockData);
+  });
+
+  it('should handle sort parameters correctly', async () => {
+    const mockData: PagedDebtPositionTypeOrgOperatorDTO = {
+      content: [],
+      totalPages: 0,
+      number: 0,
+      size: 10,
+      totalElements: 0
+    };
+
+    (
+      utils.apiClient.bff.getDebtPositionTypeOrgOperators as Mock
+    ).mockResolvedValue({
+      data: mockData
+    });
+
+    const { result } = renderHook(() =>
+      getDebtPositionTypeOrgOperators(3, {
+        page: 0,
+        size: 10,
+        sort: ['operator,asc', 'firstName,desc']
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockData);
+    expect(
+      utils.apiClient.bff.getDebtPositionTypeOrgOperators
+    ).toHaveBeenCalledWith(
+      3,
+      {
+        page: 0,
+        size: 10,
+        sort: ['operator,asc', 'firstName,desc']
+      },
+      expect.objectContaining({
+        paramsSerializer: {
+          indexes: null
+        }
+      })
+    );
+  });
+
+  it('should handle debtPositionTypeOrgId parameter', async () => {
+    const mockData: PagedDebtPositionTypeOrgOperatorDTO = {
+      content: [],
+      totalPages: 0,
+      number: 0,
+      size: 10,
+      totalElements: 0
+    };
+
+    (
+      utils.apiClient.bff.getDebtPositionTypeOrgOperators as Mock
+    ).mockResolvedValue({
+      data: mockData
+    });
+
+    const { result } = renderHook(() =>
+      getDebtPositionTypeOrgOperators(3, {
+        debtPositionTypeOrgId: 123,
+        page: 0,
+        size: 10
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockData);
+    expect(
+      utils.apiClient.bff.getDebtPositionTypeOrgOperators
+    ).toHaveBeenCalledWith(
+      3,
+      {
+        debtPositionTypeOrgId: 123,
+        page: 0,
+        size: 10
+      },
+      expect.any(Object)
+    );
+  });
+
+  it('should handle errors correctly', async () => {
+    const error = new Error('API error');
+    (
+      utils.apiClient.bff.getDebtPositionTypeOrgOperators as Mock
+    ).mockRejectedValue(error);
+
+    renderHook(() => getDebtPositionTypeOrgOperators(3, { page: 0, size: 10 }));
+
+    expect(
+      utils.apiClient.bff.getDebtPositionTypeOrgOperators
+    ).toHaveBeenCalledWith(3, { page: 0, size: 10 }, expect.any(Object));
+
+    expect(
+      utils.apiClient.bff.getDebtPositionTypeOrgOperators
+    ).toHaveBeenCalled();
+  });
+
+  it('should use correct query key structure', async () => {
+    const mockData: PagedDebtPositionTypeOrgOperatorDTO = {
+      content: [],
+      totalPages: 0,
+      number: 0,
+      size: 10,
+      totalElements: 0
+    };
+
+    (
+      utils.apiClient.bff.getDebtPositionTypeOrgOperators as Mock
+    ).mockResolvedValue({
+      data: mockData
+    });
+
+    const queryParams = {
+      debtPositionTypeOrgId: 123,
+      page: 0,
+      size: 10,
+      sort: ['operator,asc']
+    };
+
+    renderHook(() => getDebtPositionTypeOrgOperators(3, queryParams));
+
+    expect(useQueryMock.lastOptions).toBeTruthy();
+    if (useQueryMock.lastOptions) {
+      expect(useQueryMock.lastOptions.queryKey).toEqual([
+        'getDebtPositionTypeOrgOperators',
+        3,
+        queryParams
+      ]);
+    }
+  });
+});

--- a/src/api/debtPositionTypeOrgOperators.ts
+++ b/src/api/debtPositionTypeOrgOperators.ts
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query';
+import utils from '../utils';
+import { parseAndLog } from '../utils/loaders';
+import { pagedDebtPositionTypeOrgOperatorDTOSchema } from '../../generated/zod-schema';
+
+export const getDebtPositionTypeOrgOperators = (
+  organizationId: number,
+  query: {
+    debtPositionTypeOrgId?: number;
+    page?: number;
+    size?: number;
+    sort?: Array<string>;
+  }
+) =>
+  useQuery({
+    queryKey: ['getDebtPositionTypeOrgOperators', organizationId, query],
+    queryFn: async () => {
+      const { data: response } =
+        await utils.apiClient.bff.getDebtPositionTypeOrgOperators(
+          organizationId,
+          query,
+          {
+            paramsSerializer: {
+              // repeat array params as query string
+              indexes: null
+            }
+          }
+        );
+
+      if (response) {
+        parseAndLog(pagedDebtPositionTypeOrgOperatorDTOSchema, response);
+      }
+
+      return response;
+    }
+  });

--- a/src/routes/DebtTypeOrgCreate/index.tsx
+++ b/src/routes/DebtTypeOrgCreate/index.tsx
@@ -59,7 +59,12 @@ export const DebtTypeOrgCreate = () => {
               ? await data.xsdDefinitionRef?.text()
               : undefined
         },
-        operatorsSelection: data.operatorsSelection
+        operatorsSelection: data.operatorsSelection,
+        ...(data.operatorsSelection === OperatorsSelection.SELECTED &&
+          data.enabledOperators &&
+          data.enabledOperators.length > 0 && {
+            enabledOperators: data.enabledOperators
+          })
       }
     };
   };

--- a/src/routes/DebtTypeOrgCreate/steps/Step5OperatorSelector/OperatorSelector.test.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step5OperatorSelector/OperatorSelector.test.tsx
@@ -1,0 +1,224 @@
+import { vi } from 'vitest';
+import OperatorSelector from './OperatorSelector';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor
+} from '../../../../__tests__/renderers';
+import { i18nTestSetup } from '../../../../__tests__/i18nTestSetup';
+import * as api from '../../../../api/debtPositionTypeOrgOperators';
+
+i18nTestSetup({
+  'commons.operator': 'Operatore',
+  'commons.deleteSelection': 'Cancella selezione',
+  'commons.selectedOperator': 'operatori selezionati'
+});
+
+const mockApiResponse = {
+  content: [
+    {
+      operatorId: 'op1',
+      mappedExternalUserId: 'ext1',
+      firstName: 'John',
+      lastName: 'Doe',
+      enabled: true
+    },
+    {
+      operatorId: 'op2',
+      mappedExternalUserId: 'ext2',
+      firstName: 'Jane',
+      lastName: 'Smith',
+      enabled: false
+    },
+    {
+      operatorId: 'op3',
+      mappedExternalUserId: null,
+      firstName: 'Bob',
+      lastName: 'Johnson',
+      enabled: true
+    }
+  ],
+  totalPages: 2,
+  number: 0,
+  size: 10
+};
+
+describe('OperatorSelector', () => {
+  vi.mock('../../../../api/debtPositionTypeOrgOperators', () => ({
+    getDebtPositionTypeOrgOperators: vi.fn(() => ({
+      data: mockApiResponse,
+      isLoading: false,
+      error: null
+    }))
+  }));
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the operator grid with correct data', async () => {
+    const onSelectionChangeMock = vi.fn();
+
+    render(
+      <OperatorSelector
+        organizationId={3}
+        onSelectionChange={onSelectionChangeMock}
+        enabledOperators={[]}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('John Doe')).toBeInTheDocument();
+      expect(screen.getByText('Jane Smith')).toBeInTheDocument();
+      expect(screen.getByText('Bob Johnson')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Operatore')).toBeInTheDocument();
+  });
+
+  it('handles selection changes correctly', async () => {
+    const onSelectionChangeMock = vi.fn();
+
+    render(
+      <OperatorSelector
+        organizationId={3}
+        onSelectionChange={onSelectionChangeMock}
+        enabledOperators={[]}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('John Doe')).toBeInTheDocument();
+    });
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[1]);
+
+    expect(onSelectionChangeMock).toHaveBeenCalledWith(['ext1']);
+  });
+
+  it('initializes with pre-selected operators', async () => {
+    const onSelectionChangeMock = vi.fn();
+
+    render(
+      <OperatorSelector
+        organizationId={3}
+        onSelectionChange={onSelectionChangeMock}
+        enabledOperators={['ext1']}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('John Doe')).toBeInTheDocument();
+    });
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes[1]).toBeChecked();
+  });
+
+  it('clears selection when clear button is clicked', async () => {
+    const onSelectionChangeMock = vi.fn();
+
+    render(
+      <OperatorSelector
+        organizationId={3}
+        onSelectionChange={onSelectionChangeMock}
+        enabledOperators={['ext1', 'ext2']}
+      />
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/\(2\) operatori selezionati/)
+      ).toBeInTheDocument();
+    });
+
+    const clearButton = screen.getByText('Cancella selezione');
+    fireEvent.click(clearButton);
+
+    expect(onSelectionChangeMock).toHaveBeenCalledWith([]);
+  });
+
+  it('handles pagination correctly', async () => {
+    const onSelectionChangeMock = vi.fn();
+    const getDebtPositionTypeOrgOperatorsSpy = vi.spyOn(
+      api,
+      'getDebtPositionTypeOrgOperators'
+    );
+
+    render(
+      <OperatorSelector
+        organizationId={3}
+        onSelectionChange={onSelectionChangeMock}
+        enabledOperators={[]}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('John Doe')).toBeInTheDocument();
+    });
+
+    const paginationButtons = screen.getAllByRole('button');
+    const page2Button = paginationButtons.find(
+      (button) => button.textContent === '2'
+    );
+    if (page2Button) {
+      fireEvent.click(page2Button);
+    }
+
+    expect(getDebtPositionTypeOrgOperatorsSpy).toHaveBeenCalledWith(
+      3,
+      expect.objectContaining({ page: 1, size: 10 })
+    );
+  });
+
+  it('handles sort model change correctly', async () => {
+    const onSelectionChangeMock = vi.fn();
+    const getDebtPositionTypeOrgOperatorsSpy = vi.spyOn(
+      api,
+      'getDebtPositionTypeOrgOperators'
+    );
+
+    render(
+      <OperatorSelector
+        organizationId={3}
+        onSelectionChange={onSelectionChangeMock}
+        enabledOperators={[]}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('John Doe')).toBeInTheDocument();
+    });
+
+    const columnHeader = screen.getByText('Operatore');
+    fireEvent.click(columnHeader);
+
+    expect(getDebtPositionTypeOrgOperatorsSpy).toHaveBeenCalled();
+  });
+
+  it('shows correct selection count in alert', async () => {
+    const onSelectionChangeMock = vi.fn();
+
+    render(
+      <OperatorSelector
+        organizationId={3}
+        onSelectionChange={onSelectionChangeMock}
+        enabledOperators={[]}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('John Doe')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText(/operatori selezionati/)).not.toBeInTheDocument();
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[1]);
+    fireEvent.click(checkboxes[2]);
+
+    expect(screen.getByText(/\(2\) operatori selezionati/)).toBeInTheDocument();
+  });
+});

--- a/src/routes/DebtTypeOrgCreate/steps/Step5OperatorSelector/OperatorSelector.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step5OperatorSelector/OperatorSelector.tsx
@@ -1,0 +1,168 @@
+import { Box, Button, Alert } from '@mui/material';
+import { theme } from '@pagopa/mui-italia';
+import CustomDataGrid from '../../../../components/DataGrid/CustomDataGrid';
+import {
+  GridColDef,
+  GridRowSelectionModel,
+  GridSortModel
+} from '@mui/x-data-grid';
+import { useTranslation } from 'react-i18next';
+import { CopyAll } from '@mui/icons-material';
+import { useState, useEffect, useMemo } from 'react';
+import { getDebtPositionTypeOrgOperators } from '../../../../api/debtPositionTypeOrgOperators';
+import { DebtPositionTypeOrgOperatorDTO } from '../../../../../generated/data-contracts';
+
+type OperatorData = {
+  id: string;
+  operator: string;
+  firstName?: string;
+  lastName?: string;
+  enabled?: boolean;
+  mappedExternalUserId?: string;
+};
+
+type OperatorSelectorProps = {
+  organizationId: number;
+  debtPositionTypeOrgId?: number;
+  onSelectionChange: (enabledOperators: Array<string>) => void;
+  enabledOperators: Array<string>;
+};
+
+const OperatorSelector = ({
+  organizationId,
+  debtPositionTypeOrgId,
+  onSelectionChange,
+  enabledOperators
+}: OperatorSelectorProps) => {
+  const { t } = useTranslation();
+  const [rowSelectionModel, setRowSelectionModel] =
+    useState<GridRowSelectionModel>(enabledOperators);
+
+  const [appliedFilters, setAppliedFilters] = useState({
+    page: 0,
+    size: 10
+  });
+  const [sortModel, setSortModel] = useState<GridSortModel>([]);
+
+  const sortArray = useMemo(() => {
+    if (sortModel.length === 0) return undefined;
+    return sortModel.map((sort) => `${sort.field},${sort.sort}`);
+  }, [sortModel]);
+
+  const { data: apiResponse } = getDebtPositionTypeOrgOperators(
+    organizationId,
+    {
+      debtPositionTypeOrgId,
+      page: appliedFilters.page,
+      size: appliedFilters.size,
+      ...(sortArray && { sort: sortArray })
+    }
+  );
+
+  const operators: Array<OperatorData> = useMemo(() => {
+    if (!apiResponse?.content) return [];
+
+    return apiResponse.content.map(
+      (operator: DebtPositionTypeOrgOperatorDTO) => ({
+        id: operator.mappedExternalUserId || operator.operatorId || '',
+        operator:
+          `${operator.firstName || ''} ${operator.lastName || ''}`.trim() ||
+          operator.mappedExternalUserId ||
+          operator.operatorId ||
+          'N/A',
+        firstName: operator.firstName,
+        lastName: operator.lastName,
+        enabled: operator.enabled,
+        mappedExternalUserId: operator.mappedExternalUserId,
+        operatorId: operator.operatorId
+      })
+    );
+  }, [apiResponse]);
+
+  useEffect(() => {
+    setRowSelectionModel(enabledOperators);
+  }, [enabledOperators]);
+
+  const handleSelectionChange = (newSelection: GridRowSelectionModel) => {
+    setRowSelectionModel(newSelection);
+    onSelectionChange(newSelection as Array<string>);
+  };
+
+  const handleClearSelection = () => {
+    setRowSelectionModel([]);
+    onSelectionChange([]);
+  };
+
+  const handleSortModelChange = (model: GridSortModel) => {
+    setSortModel(model);
+  };
+
+  const updatePagination = (params: { page?: number; size?: number }) => {
+    setAppliedFilters((prev) => ({
+      ...prev,
+      ...params
+    }));
+  };
+
+  const columns: Array<GridColDef> = [
+    {
+      field: 'operator',
+      headerName: t('commons.operator'),
+      flex: 1,
+      type: 'string',
+      sortable: true
+    }
+  ];
+
+  const selectedCount = rowSelectionModel.length;
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      {selectedCount > 0 && (
+        <Alert
+          severity="info"
+          variant="outlined"
+          sx={{ mb: 2 }}
+          action={
+            <Button size="large" onClick={handleClearSelection}>
+              <CopyAll />
+              {t('commons.deleteSelection')}
+            </Button>
+          }
+        >
+          ({selectedCount}) {t('commons.selectedOperator')}
+        </Alert>
+      )}
+
+      <Box sx={{ bgcolor: theme.palette.grey[200], padding: 2 }}>
+        <CustomDataGrid
+          rows={operators}
+          columns={columns}
+          getRowId={(row) => row.id}
+          disableColumnMenu
+          disableColumnResize
+          checkboxSelection
+          rowSelectionModel={rowSelectionModel}
+          hideFooterSelectedRowCount
+          onRowSelectionModelChange={handleSelectionChange}
+          sortModel={sortModel}
+          onSortModelChange={handleSortModelChange}
+          customPagination={{
+            totalPages: apiResponse?.totalPages || 0,
+            defaultPageOption: appliedFilters.size,
+            sizePageOptions: [5, 10, 15, 20],
+            onPageChange: (page) =>
+              updatePagination({
+                page: page - 1,
+                size: appliedFilters.size
+              }),
+            onPageSizeChange: (size) => updatePagination({ size, page: 0 }),
+            currentPage: appliedFilters.page + 1
+          }}
+        />
+      </Box>
+    </Box>
+  );
+};
+
+export default OperatorSelector;

--- a/src/routes/DebtTypeOrgCreate/steps/Step5Operators.test.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step5Operators.test.tsx
@@ -8,6 +8,36 @@ import {
 } from '../../../__tests__/renderers';
 import { OperatorsSelection } from '../../../../generated/data-contracts';
 
+const mockApiResponse = {
+  content: [
+    {
+      operatorId: 'op1',
+      mappedExternalUserId: 'ext1',
+      firstName: 'John',
+      lastName: 'Doe',
+      enabled: true
+    },
+    {
+      operatorId: 'op2',
+      mappedExternalUserId: 'ext2',
+      firstName: 'Jane',
+      lastName: 'Smith',
+      enabled: false
+    }
+  ],
+  totalPages: 1,
+  number: 0,
+  size: 10
+};
+
+vi.mock('../../../api/debtPositionTypeOrgOperators', () => ({
+  getDebtPositionTypeOrgOperators: vi.fn(() => ({
+    data: mockApiResponse,
+    isLoading: false,
+    error: null
+  }))
+}));
+
 describe('Step5Operators', () => {
   const mockSetData = vi.fn();
   const mockOnNext = vi.fn();
@@ -26,7 +56,6 @@ describe('Step5Operators', () => {
       />
     );
 
-    // Main titles
     expect(
       screen.getByText('debtTypeOrgCreate.operators.title')
     ).toBeInTheDocument();
@@ -34,15 +63,18 @@ describe('Step5Operators', () => {
       screen.getByText('debtTypeOrgCreate.operators.subtitle')
     ).toBeInTheDocument();
 
-    // Section title
     expect(
       screen.getByText('debtTypeOrgCreate.operators.section.operatorEntities')
     ).toBeInTheDocument();
 
-    // Radio options
     expect(
       screen.getByRole('radio', {
         name: 'debtTypeOrgCreate.operators.options.all'
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('radio', {
+        name: 'debtTypeOrgCreate.operators.options.selected'
       })
     ).toBeInTheDocument();
     expect(
@@ -121,7 +153,8 @@ describe('Step5Operators', () => {
 
     await waitFor(() => {
       expect(mockSetData).toHaveBeenCalledWith({
-        operatorsSelection: OperatorsSelection.ALL
+        operatorsSelection: OperatorsSelection.ALL,
+        enabledOperators: []
       });
       expect(mockOnNext).toHaveBeenCalledTimes(1);
     });
@@ -146,21 +179,14 @@ describe('Step5Operators', () => {
 
     await waitFor(() => {
       expect(mockSetData).toHaveBeenCalledWith({
-        operatorsSelection: OperatorsSelection.NONE
+        operatorsSelection: OperatorsSelection.NONE,
+        enabledOperators: []
       });
       expect(mockOnNext).toHaveBeenCalledTimes(1);
     });
   });
 
-  // Optional: Edge case test for validation error if no selection (usually not possible with radios)
-  it('does not submit if operatorsSelection is unset (edge case)', async () => {
-    // This is a theoretical case because radios always have a selection,
-    // but you can simulate by rendering with no default value if needed.
-
-    // For demonstration, assume you can render with no default and clear selection:
-    // You would need to modify the component to allow this for testing.
-
-    // Here, just check that submission without selection doesn't call onNext:
+  it('displays OperatorSelector when SELECTED option is chosen', async () => {
     render(
       <Step5Operators
         setData={mockSetData}
@@ -169,13 +195,47 @@ describe('Step5Operators', () => {
       />
     );
 
-    // Attempt to submit without changing selection (default is ALL)
+    const radioSelected = screen.getByRole('radio', {
+      name: 'debtTypeOrgCreate.operators.options.selected'
+    });
+    fireEvent.click(radioSelected);
+
+    await waitFor(() => {
+      expect(screen.getByText('John Doe')).toBeInTheDocument();
+      expect(screen.getByText('Jane Smith')).toBeInTheDocument();
+    });
+  });
+
+  it('submits form with selected operators when SELECTED option is chosen', async () => {
+    render(
+      <Step5Operators
+        setData={mockSetData}
+        onNext={mockOnNext}
+        onBack={mockOnBack}
+      />
+    );
+
+    const radioSelected = screen.getByRole('radio', {
+      name: 'debtTypeOrgCreate.operators.options.selected'
+    });
+    fireEvent.click(radioSelected);
+
+    await waitFor(() => {
+      expect(screen.getByText('John Doe')).toBeInTheDocument();
+    });
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[1]);
+
     const nextButton = screen.getByRole('button', { name: 'commons.continue' });
     fireEvent.click(nextButton);
 
     await waitFor(() => {
-      expect(mockSetData).toHaveBeenCalled();
-      expect(mockOnNext).toHaveBeenCalled();
+      expect(mockSetData).toHaveBeenCalledWith({
+        operatorsSelection: OperatorsSelection.SELECTED,
+        enabledOperators: ['ext1']
+      });
+      expect(mockOnNext).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/routes/DebtTypeOrgCreate/steps/Step5Operators.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step5Operators.tsx
@@ -8,10 +8,12 @@ import SectionBox from '../../../components/Wizard/SectionBox';
 import WizardStepWrapper from '../../../components/Wizard/WizardStepWrapper';
 import { FormComponent } from '../../../components/FormComponent';
 import WizardStepButtons from '../../../components/Wizard/WizardStepButtons';
+import OperatorSelector from './Step5OperatorSelector/OperatorSelector';
 import { OperatorsSelection } from '../../../../generated/data-contracts';
 
 export type Step5Data = {
   operatorsSelection: OperatorsSelection;
+  enabledOperators?: Array<string>;
 };
 
 export type Step5Props = {
@@ -23,10 +25,9 @@ export type Step5Props = {
 const validationSchema = (t: TFunction) =>
   z.object({
     operatorsSelection: z.nativeEnum(OperatorsSelection, {
-      required_error: t(
-        'debtTypeOrgCreate.operators.operatorSelection.required'
-      )
-    })
+      required_error: t('debtTypeCreateEC.operators.operatorSelection.required')
+    }),
+    enabledOperators: z.array(z.string()).optional()
   });
 
 export const Step5Operators = ({ setData, onNext, onBack }: Step5Props) => {
@@ -35,15 +36,22 @@ export const Step5Operators = ({ setData, onNext, onBack }: Step5Props) => {
   const form = useForm<Step5Data>({
     resolver: zodResolver(schema),
     defaultValues: {
-      operatorsSelection: OperatorsSelection.ALL
+      operatorsSelection: OperatorsSelection.ALL,
+      enabledOperators: []
     },
     mode: 'onTouched'
   });
-  const { control, handleSubmit } = form;
+  const { control, handleSubmit, watch, setValue } = form;
+
+  const operatorSelection = watch('operatorsSelection');
 
   const onSubmit = async (values: Step5Data) => {
     setData(values);
     onNext();
+  };
+
+  const handleOperatorSelectionChange = (enabledOperators: Array<string>) => {
+    setValue('enabledOperators', enabledOperators);
   };
 
   return (
@@ -65,11 +73,22 @@ export const Step5Operators = ({ setData, onNext, onBack }: Step5Props) => {
                 label: t('debtTypeOrgCreate.operators.options.all')
               },
               {
+                value: OperatorsSelection.SELECTED,
+                label: t('debtTypeOrgCreate.operators.options.selected')
+              },
+              {
                 value: OperatorsSelection.NONE,
                 label: t('debtTypeOrgCreate.operators.options.none')
               }
             ]}
           />
+          {operatorSelection === OperatorsSelection.SELECTED && (
+            <OperatorSelector
+              onSelectionChange={handleOperatorSelectionChange}
+              enabledOperators={watch('enabledOperators') || []}
+              organizationId={3}
+            />
+          )}
         </SectionBox>
       </WizardStepWrapper>
       <WizardStepButtons onBack={onBack} onNext={handleSubmit(onSubmit)} />

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -66,6 +66,7 @@
     "debtTypeName": "Nome del Tipo dovuto",
     "debtor": "Debitore",
     "delete": "Elimina",
+    "deleteSelection": "Cancella la selezione",
     "description": "Descrizione",
     "detail": "Dettaglio",
     "disabled": "Disabilitato",
@@ -256,7 +257,9 @@
     "searchIUF": "ID Rendicontazione",
     "searchIUV": "Cerca IUV",
     "searchName": "Cerca Nome",
+    "searchOperator": "Cerca operatore",
     "searchRegulationUniqueIdentifier": "ID Regolamento",
+    "selectedOperator": "Operatore selezionato",
     "serviceType": "Tipo Servizio",
     "showAllFlows": "Vedi tutti i flussi",
     "showDebtPositions": "Vedi Posizione debitoria",
@@ -862,7 +865,8 @@
       },
       "options": {
         "all": "Tutti gli operatori",
-        "none": "Senza operatori associati"
+        "none": "Senza operatori associati",
+        "selected": "Operatori selezionati"
       }
     },
     "stepper": {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Added datagrid for operator visualization
- Integrated API to retrieve operator list
- Managed operator parameter passing in POST requests to enable them for debtType

<!--- Describe your changes in detail -->

#### Motivation and Context
Added the datagrid to visualize and select operators to whom we want to give "visibility" of the debtType.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

- unit tests
- visual testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/43b8710c-055f-498e-b007-b94f3cfebb46)

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
