### PR TITLE
fix: [P4ADEV-2859] add route to create button, update test

### DIFF
--- a/src/routes/DebtPositions/DebtPositionsResults.test.tsx
+++ b/src/routes/DebtPositions/DebtPositionsResults.test.tsx
@@ -1,10 +1,11 @@
 import { describe, expect, it, Mock, vi } from 'vitest';
-import { render, screen } from '../../__tests__/renderers';
-import { useLocation } from 'react-router-dom';
+import { render, screen, fireEvent } from '../../__tests__/renderers';
+import { useLocation, useNavigate } from 'react-router-dom';
 import FilterContainer from '../../components/FilterContainer/FilterContainer';
 import { SearchType } from '../../models/DebtPositions';
 import DebtPositionResults from './DebtPositionsResults';
 import { DebtPositionsDataGrid } from './components/DebtPositionsDataGrid';
+import { PageRoutes } from '../../App';
 
 // Mock dependencies
 vi.mock('react-i18next', () => ({
@@ -12,7 +13,11 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('react-router-dom', () => ({
-  useLocation: vi.fn()
+  useLocation: vi.fn(),
+  useNavigate: vi.fn(() => vi.fn()),
+  Navigate: vi.fn(),
+  generatePath: vi.fn((path) => path),
+  createBrowserRouter: vi.fn()
 }));
 
 vi.mock('../../hooks/useDebtPositionsSearch', () => ({
@@ -34,8 +39,34 @@ vi.mock('../../hooks/useDebtPositionsFilters', () => ({
   }))
 }));
 
+type ActionType = {
+  buttonText?: string;
+  onActionClick: () => void;
+};
+
 vi.mock('../../components/TitleComponent/TitleComponent', () => ({
-  default: vi.fn(({ title }) => <div>{title}</div>)
+  default: vi.fn(
+    ({
+      title,
+      callToAction
+    }: {
+      title: string;
+      callToAction?: Array<ActionType>;
+    }) => (
+      <div>
+        <div>{title}</div>
+        {callToAction?.map((action: ActionType, index: number) => (
+          <button
+            key={index}
+            onClick={action.onActionClick}
+            data-testid="action-button"
+          >
+            {action.buttonText}
+          </button>
+        ))}
+      </div>
+    )
+  )
 }));
 
 vi.mock('../../components/FilterContainer/FilterContainer', () => ({
@@ -114,6 +145,23 @@ describe('DebtPositionResults', () => {
         })
       }),
       expect.anything()
+    );
+  });
+
+  it('should navigate to create wizard when action button is clicked', () => {
+    const navigateMock = vi.fn();
+    (useLocation as Mock).mockReturnValue(
+      mockLocationState(SearchType.DEBT_POSITION)
+    );
+    (useNavigate as Mock).mockReturnValue(navigateMock);
+
+    render(<DebtPositionResults />);
+
+    const actionButton = screen.getByTestId('action-button');
+    fireEvent.click(actionButton);
+
+    expect(navigateMock).toHaveBeenCalledWith(
+      PageRoutes.DEBT_POSITION_CREATE_WIZARD
     );
   });
 });

--- a/src/routes/DebtPositions/DebtPositionsResults.tsx
+++ b/src/routes/DebtPositions/DebtPositionsResults.tsx
@@ -1,7 +1,7 @@
 import { Grid, Stack, useTheme } from '@mui/material';
 import { Add } from '@mui/icons-material';
 import { useTranslation } from 'react-i18next';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import FilterContainer from '../../components/FilterContainer/FilterContainer';
 import TitleComponent from '../../components/TitleComponent/TitleComponent';
 import { BaseFilterValues } from '../../models/Filters';
@@ -15,6 +15,7 @@ import {
   PagedDebtPositionView
 } from '../../../generated/apiClient';
 import debtPositions from '../../api/debtPositions';
+import { PageRoutes } from '../../App';
 
 export type LocationState = {
   searchType: SearchType;
@@ -28,6 +29,7 @@ export type DebtResultsProps = {
 export const DebtPositionResults = () => {
   const theme = useTheme();
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const {
     state: { filters: initialFilters, searchType }
   }: { state: LocationState } = useLocation();
@@ -63,7 +65,8 @@ export const DebtPositionResults = () => {
               searchType === SearchType.IUV
                 ? t('commons.createNewOne')
                 : t('commons.createNew'),
-            onActionClick: () => console.log('create button clicked')
+            onActionClick: () =>
+              navigate(PageRoutes.DEBT_POSITION_CREATE_WIZARD)
           }
         ]}
       />


### PR DESCRIPTION
This PR fixes the bug that prevented correct navigation when clicking the "Create" button in the Debt Position Results page.
Now, clicking the button correctly redirects the user to the first step of the wizard for creating a new debt position.


#### How Has This Been Tested?

-unit tests


#### Types of changes


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:


- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
