### PR TITLE
feat: [P4ADEV-2916] using mutation to get a loader on waiting time

### DIFF
--- a/src/api/debtPositions.ts
+++ b/src/api/debtPositions.ts
@@ -182,34 +182,33 @@ const createDebtPosition = (
   });
 
 /**
- * Downloads the payment notice for a specific installment
+ * returns a File and a filename for the payment notice of a specific installment
  * @param organizationId Organization ID
  * @param debtPositionId Debt position ID
  * @param iuv IUV code of the installment
  * @returns Promise with file data and filename or null in case of error
  */
-const downloadPaymentNotice = async (
+const downloadPaymentNotice = (
   organizationId: number,
   debtPositionId: number,
   iuv: string
-): Promise<{ data: Blob; fileName: string } | null> => {
-  try {
-    const response = await utils.apiClient.bff.getPaymentNotice(
-      organizationId,
-      debtPositionId,
-      { iuv },
-      { format: 'blob' }
-    );
+) =>
+  useMutation({
+    mutationKey: ['downloadPaymentNotice', organizationId, debtPositionId, iuv],
+    mutationFn: async () => {
+      const response = await utils.apiClient.bff.getPaymentNotice(
+        organizationId,
+        debtPositionId,
+        { iuv },
+        { format: 'blob' }
+      );
+      const contentDisposition = response.headers['content-disposition'] || '';
+      const fileName =
+        extractFilename(contentDisposition) || `notice-${iuv}.pdf`;
 
-    const contentDisposition = response.headers['content-disposition'] || '';
-    const fileName = extractFilename(contentDisposition) || `notice-${iuv}.pdf`;
-
-    return { data: response.data, fileName };
-  } catch (error) {
-    console.error('Error downloading payment notice:', error);
-    return null;
-  }
-};
+      return { data: response.data, fileName };
+    }
+  });
 
 /**
  * Downloads a ZIP file containing all unpaid/unpayable installment notices for a debt position

--- a/src/api/debtPositions.ts
+++ b/src/api/debtPositions.ts
@@ -181,13 +181,7 @@ const createDebtPosition = (
     onError
   });
 
-/**
- * returns a File and a filename for the payment notice of a specific installment
- * @param organizationId Organization ID
- * @param debtPositionId Debt position ID
- * @param iuv IUV code of the installment
- * @returns a mutation to download the payment notice file
- */
+/** returns a mutation to download the payment notice file */
 const getPaymentNoticeFile = (
   organizationId: number,
   debtPositionId: number,
@@ -210,34 +204,24 @@ const getPaymentNoticeFile = (
     }
   });
 
-/**
- * Downloads a ZIP file containing all unpaid/unpayable installment notices for a debt position
- * @param organizationId Organization ID
- * @param debtPositionId Debt position ID
- * @returns Promise with file data and filename or null in case of error
- */
-const downloadDebtPositionZip = async (
-  organizationId: number,
-  debtPositionId: number
-): Promise<{ data: Blob; fileName: string } | null> => {
-  try {
-    const response = await utils.apiClient.bff.getUnpaidPaymentNoticeZip(
-      organizationId,
-      debtPositionId,
-      { format: 'blob' }
-    );
+/** returns a mutation to get export blob file of unpaid/unpayable installment notices for a debt position */
+const getDebtPositionZipFile = (organizationId: number) =>
+  useMutation({
+    mutationKey: ['getDebtPositionZipFile', organizationId],
+    mutationFn: async (debtPositionId: number) => {
+      const response = await utils.apiClient.bff.getUnpaidPaymentNoticeZip(
+        organizationId,
+        debtPositionId,
+        { format: 'blob' }
+      );
+      const contentDisposition = response.headers['content-disposition'] || '';
+      const fileName =
+        extractFilename(contentDisposition) ||
+        `debt-position-${debtPositionId}.zip`;
 
-    const contentDisposition = response.headers['content-disposition'] || '';
-    const fileName =
-      extractFilename(contentDisposition) ||
-      `debt-position-${debtPositionId}.zip`;
-
-    return { data: response.data, fileName };
-  } catch (error) {
-    console.error('Error downloading debt position ZIP:', error);
-    return null;
-  }
-};
+      return { data: response.data, fileName };
+    }
+  });
 
 export default {
   getDebtPositionViews,
@@ -249,5 +233,5 @@ export default {
   deleteDebtPosition,
   createDebtPosition,
   getPaymentNoticeFile,
-  downloadDebtPositionZip
+  getDebtPositionZipFile
 };

--- a/src/api/debtPositions.ts
+++ b/src/api/debtPositions.ts
@@ -186,15 +186,15 @@ const createDebtPosition = (
  * @param organizationId Organization ID
  * @param debtPositionId Debt position ID
  * @param iuv IUV code of the installment
- * @returns Promise with file data and filename or null in case of error
+ * @returns a mutation to download the payment notice file
  */
-const downloadPaymentNotice = (
+const getPaymentNoticeFile = (
   organizationId: number,
   debtPositionId: number,
   iuv: string
 ) =>
   useMutation({
-    mutationKey: ['downloadPaymentNotice', organizationId, debtPositionId, iuv],
+    mutationKey: ['getPaymentNoticeFile', organizationId, debtPositionId, iuv],
     mutationFn: async () => {
       const response = await utils.apiClient.bff.getPaymentNotice(
         organizationId,
@@ -248,6 +248,6 @@ export default {
   deleteDebtPositionTypeOrgs,
   deleteDebtPosition,
   createDebtPosition,
-  downloadPaymentNotice,
+  getPaymentNoticeFile,
   downloadDebtPositionZip
 };

--- a/src/api/exportFiles.test.ts
+++ b/src/api/exportFiles.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
-import { renderHook, waitFor } from '../__tests__/renderers';
-import { downloadExportFile, getExportFiles } from './exportFiles';
+import { act, renderHook, waitFor } from '../__tests__/renderers';
+import { getExportFile, getExportFiles } from './exportFiles';
 import utils from '../utils';
 import { AxiosResponse } from 'axios';
 import {
@@ -142,7 +142,12 @@ describe('downloadExportFile', () => {
       }
     } as unknown as AxiosResponse);
 
-    const result = await downloadExportFile(123, 456);
+    const { result } = renderHook(() => getExportFile(123));
+
+    await act(async () => {
+      const response = await result.current.mutateAsync(456);
+      expect(response).toEqual({ data: mockFileData, fileName: mockFileName });
+    });
 
     expect(mockDownloadExportFile).toHaveBeenCalledWith(123, 456, {
       format: 'blob'
@@ -150,10 +155,6 @@ describe('downloadExportFile', () => {
     expect(mockExtractFilename).toHaveBeenCalledWith(
       `attachment; filename="${mockFileName}"`
     );
-    expect(result).toEqual({
-      data: mockFileData,
-      fileName: mockFileName
-    });
   });
 
   it('uses default filename when content-disposition header is missing', async () => {
@@ -166,12 +167,12 @@ describe('downloadExportFile', () => {
 
     mockExtractFilename.mockReturnValueOnce(null);
 
-    const result = await downloadExportFile(123, 456);
+    const { result } = renderHook(() => getExportFile(123));
 
-    expect(mockExtractFilename).toHaveBeenCalledWith('');
-    expect(result).toEqual({
-      data: mockFileData,
-      fileName: 'file-456'
+    await act(async () => {
+      const response = await result.current.mutateAsync(456);
+      expect(response).toEqual({ data: mockFileData, fileName: 'file-456' });
     });
+    expect(mockExtractFilename).toHaveBeenCalledWith('');
   });
 });

--- a/src/api/exportFiles.ts
+++ b/src/api/exportFiles.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import utils from '../utils';
 import {
   ExportFileStatus,
@@ -47,25 +47,24 @@ export const getExportFiles = (
   });
 };
 
-export const downloadExportFile = async (
-  organizationId: number,
-  exportFileId: number
-): Promise<{ data: Blob; fileName: string } | null> => {
-  try {
-    const response =
-      await utils.fileshareClient.organization.downloadExportFile(
-        organizationId,
-        exportFileId,
-        { format: 'blob' }
-      );
-
-    const contentDisposition = response.headers['content-disposition'] || '';
-    const fileName =
-      extractFilename(contentDisposition) || `file-${exportFileId}`;
-
-    return { data: response.data, fileName };
-  } catch (error) {
-    console.error('Error downloading export file:', error);
-    return null;
-  }
-};
+/**
+ * returns File and filename for a given export file ID.
+ * @param organizationId ID of the organization to which the export file belongs
+ * @returns a mutation
+ */
+export const getExportFile = (organizationId: number) =>
+  useMutation({
+    mutationKey: ['downloadExportFile', organizationId],
+    mutationFn: async (exportFileId: number) => {
+      const response =
+        await utils.fileshareClient.organization.downloadExportFile(
+          organizationId,
+          exportFileId,
+          { format: 'blob' }
+        );
+      const contentDisposition = response.headers['content-disposition'] || '';
+      const fileName =
+        extractFilename(contentDisposition) || `file-${exportFileId}`;
+      return { data: response.data, fileName };
+    }
+  });

--- a/src/api/exportFiles.ts
+++ b/src/api/exportFiles.ts
@@ -47,11 +47,7 @@ export const getExportFiles = (
   });
 };
 
-/**
- * returns File and filename for a given export file ID.
- * @param organizationId ID of the organization to which the export file belongs
- * @returns a mutation
- */
+/** returns a mutation to get export blob file */
 export const getExportFile = (organizationId: number) =>
   useMutation({
     mutationKey: ['downloadExportFile', organizationId],

--- a/src/api/exportFiles.ts
+++ b/src/api/exportFiles.ts
@@ -50,7 +50,7 @@ export const getExportFiles = (
 /** returns a mutation to get export blob file */
 export const getExportFile = (organizationId: number) =>
   useMutation({
-    mutationKey: ['downloadExportFile', organizationId],
+    mutationKey: ['getExportFile', organizationId],
     mutationFn: async (exportFileId: number) => {
       const response =
         await utils.fileshareClient.organization.downloadExportFile(

--- a/src/api/ingestionFlowFiles.test.ts
+++ b/src/api/ingestionFlowFiles.test.ts
@@ -1,7 +1,7 @@
 import utils from '../utils';
 import { act, renderHook } from '../__tests__/renderers';
 import {
-  downloadIngestionFlowFile,
+  getIngestionFlowFile,
   uploadIngestionFlowFile
 } from './ingestionFlowFiles';
 import {
@@ -115,18 +115,20 @@ describe('downloadIngestionFlowFile', () => {
       }
     } as unknown as AxiosResponse);
 
-    const result = await downloadIngestionFlowFile(123, 456);
+    const { result } = renderHook(() => getIngestionFlowFile(123));
+
+    await act(async () => {
+      const response = await result.current.mutateAsync(456);
+      expect(response).toEqual({ data: mockFileData, fileName: mockFileName });
+    });
 
     expect(mockDownloadIngestionFlowFile).toHaveBeenCalledWith(123, 456, {
       format: 'blob'
     });
+
     expect(mockExtractFilename).toHaveBeenCalledWith(
       `attachment; filename="${mockFileName}"`
     );
-    expect(result).toEqual({
-      data: mockFileData,
-      fileName: mockFileName
-    });
   });
 
   it('uses default filename when content-disposition header is missing', async () => {
@@ -138,13 +140,13 @@ describe('downloadIngestionFlowFile', () => {
     } as unknown as AxiosResponse);
 
     mockExtractFilename.mockReturnValueOnce(null);
+    const { result } = renderHook(() => getIngestionFlowFile(123));
 
-    const result = await downloadIngestionFlowFile(123, 456);
+    await act(async () => {
+      const response = await result.current.mutateAsync(456);
+      expect(response).toEqual({ data: mockFileData, fileName: 'file-456' });
+    });
 
     expect(mockExtractFilename).toHaveBeenCalledWith('');
-    expect(result).toEqual({
-      data: mockFileData,
-      fileName: 'file-456'
-    });
   });
 });

--- a/src/api/ingestionFlowFiles.ts
+++ b/src/api/ingestionFlowFiles.ts
@@ -75,30 +75,26 @@ export const uploadIngestionFlowFile = ({
     }
   });
 
-export const downloadIngestionFlowFile = async (
-  organizationId: number,
-  ingestionFlowFileId: number
-): Promise<{ data: Blob; fileName: string } | null> => {
-  try {
-    const response =
-      await utils.fileshareClient.organization.downloadIngestionFlowFile(
-        organizationId,
-        ingestionFlowFileId,
-        { format: 'blob' }
-      );
+/** returns a mutation to get the ingestion flow blob file */
+export const getIngestionFlowFile = (organizationId: number) =>
+  useMutation({
+    mutationKey: ['getIngestionFlowFile', organizationId],
+    mutationFn: async (ingestionFlowFileId: number) => {
+      const response =
+        await utils.fileshareClient.organization.downloadIngestionFlowFile(
+          organizationId,
+          ingestionFlowFileId,
+          { format: 'blob' }
+        );
+      const contentDisposition = response.headers['content-disposition'] || '';
+      const fileName =
+        extractFilename(contentDisposition) || `file-${ingestionFlowFileId}`;
 
-    const contentDisposition = response.headers['content-disposition'] || '';
-    const fileName =
-      extractFilename(contentDisposition) || `file-${ingestionFlowFileId}`;
+      return { data: response.data, fileName };
+    }
+  });
 
-    return { data: response.data, fileName };
-  } catch (error) {
-    console.error('Error downloading ingestion flow file:', error);
-    return null;
-  }
-};
-
-/** return a mutation to get the ingestion flow error blob file */
+/** returns a mutation to get the ingestion flow error blob file */
 export const getIngestionFlowFileError = (organizationId: number) =>
   useMutation({
     mutationKey: ['downloadIngestionFlowFileError', organizationId],

--- a/src/components/ClassificationsOverview/ClassificationsOverview.test.tsx
+++ b/src/components/ClassificationsOverview/ClassificationsOverview.test.tsx
@@ -12,6 +12,7 @@ vi.mock('react-router-dom', async (importOriginal) => ({
 
 vi.mock('../../api/exportFiles', () => ({
   getExportFiles: vi.fn().mockReturnValue({ data: { content: [] } }),
+  getExportFile: vi.fn(),
   ExportFileStatus: {
     COMPLETED: 'COMPLETED'
   },

--- a/src/components/Conservation/Conservation.test.tsx
+++ b/src/components/Conservation/Conservation.test.tsx
@@ -12,6 +12,7 @@ vi.mock('react-router-dom', async (importOriginal) => ({
 
 vi.mock('../../api/exportFiles', () => ({
   getExportFiles: vi.fn().mockReturnValue({ data: { content: [] } }),
+  getExportFile: vi.fn(),
   ExportFileStatus: {
     COMPLETED: 'COMPLETED'
   },

--- a/src/components/DebtPositionsImportOverview/DebtPositionsImportOverview.test.tsx
+++ b/src/components/DebtPositionsImportOverview/DebtPositionsImportOverview.test.tsx
@@ -12,6 +12,7 @@ vi.mock('react-router-dom', async (importOriginal) => ({
 vi.mock('../../api/ingestionFlowFiles', () => ({
   getIngestionFlowFiles: vi.fn().mockReturnValue({ data: { content: [] } }),
   getIngestionFlowFileError: vi.fn(),
+  getIngestionFlowFile: vi.fn(),
   IngestionFlowFileType: {
     RECEIPT: 'RECEIPT',
     RECEIPT_PAGOPA: 'RECEIPT_PAGOPA',

--- a/src/components/DebtPositionsInstallmentDetail/DebtPositionsInstallmentDetail.test.tsx
+++ b/src/components/DebtPositionsInstallmentDetail/DebtPositionsInstallmentDetail.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { fireEvent, render, screen } from '../../__tests__/renderers';
 import { vi, describe, it, expect, beforeEach, Mock } from 'vitest';
 import { DebtPositionsInstallmentDetail } from './DebtPositionsInstallmentDetail';
@@ -32,7 +33,7 @@ vi.mock('react-router-dom', () => ({
 vi.mock('../../api/debtPositions', () => ({
   default: {
     getInstallmentDetail: vi.fn(),
-    downloadPaymentNotice: vi.fn()
+    getPaymentNoticeFile: vi.fn()
   }
 }));
 
@@ -62,6 +63,9 @@ vi.mock('../../store/GlobalStore', () => ({
 
 describe('DebtPositionsInstallmentDetail', () => {
   const mockUseParams = vi.mocked(useParams);
+  const mockBlob = new Blob(['test content'], { type: 'application/pdf' });
+  const mockFileName = 'notice-302000000000000001.pdf';
+  const mutateMock = vi.fn();
   const mockPaidInstallment = {
     installmentId: 288,
     paymentOptionId: 301,
@@ -166,19 +170,16 @@ describe('DebtPositionsInstallmentDetail', () => {
   });
 
   it('downloads PDF when download button is clicked for UNPAID installment', async () => {
-    const mockBlob = new Blob(['test content'], { type: 'application/pdf' });
-    const mockFileName = 'notice-302000000000000001.pdf';
+    vi.mocked(debtPositions.getPaymentNoticeFile).mockReturnValue({
+      mutateAsync: mutateMock.mockReturnValue({
+        data: mockBlob,
+        fileName: mockFileName
+      })
+    } as any);
 
-    (
-      debtPositions.downloadPaymentNotice as unknown as ReturnType<typeof vi.fn>
-    ).mockResolvedValue({
-      data: mockBlob,
-      fileName: mockFileName
-    });
-
-    (
-      debtPositions.getInstallmentDetail as unknown as ReturnType<typeof vi.fn>
-    ).mockReturnValue({ data: mockUnpaidInstallment });
+    vi.mocked(debtPositions.getInstallmentDetail).mockReturnValue({
+      data: mockUnpaidInstallment
+    } as any);
 
     render(<DebtPositionsInstallmentDetail />);
 
@@ -187,7 +188,7 @@ describe('DebtPositionsInstallmentDetail', () => {
 
     fireEvent.click(downloadButton);
 
-    expect(debtPositions.downloadPaymentNotice).toHaveBeenCalledWith(
+    expect(debtPositions.getPaymentNoticeFile).toHaveBeenCalledWith(
       mockOrganizationId,
       mockUnpaidInstallment.debtPositionId,
       mockUnpaidInstallment.iuv
@@ -201,6 +202,13 @@ describe('DebtPositionsInstallmentDetail', () => {
   it('shows dialog when trying to download PAID installment', async () => {
     render(<DebtPositionsInstallmentDetail />);
 
+    vi.mocked(debtPositions.getPaymentNoticeFile).mockReturnValue({
+      mutateAsync: mutateMock.mockReturnValue({
+        data: mockBlob,
+        fileName: mockFileName
+      })
+    } as any);
+
     const downloadButton = screen.getByText('commons.downloadInstallment');
     expect(downloadButton).toBeInTheDocument();
 
@@ -213,7 +221,7 @@ describe('DebtPositionsInstallmentDetail', () => {
       screen.getByText('debtPositionInstallmentDetail.dialogDownload.message')
     ).toBeInTheDocument();
 
-    expect(debtPositions.downloadPaymentNotice).not.toHaveBeenCalled();
+    expect(mutateMock).not.toHaveBeenCalled();
   });
 
   it('closes dialog when clicking cancel button', async () => {
@@ -263,7 +271,7 @@ describe('DebtPositionsInstallmentDetail', () => {
     ).mockReturnValue({ data: mockUnpaidInstallment });
 
     (
-      debtPositions.downloadPaymentNotice as unknown as ReturnType<typeof vi.fn>
+      debtPositions.getPaymentNoticeFile as unknown as ReturnType<typeof vi.fn>
     ).mockResolvedValue(null);
 
     render(<DebtPositionsInstallmentDetail />);
@@ -285,6 +293,13 @@ describe('DebtPositionsInstallmentDetail', () => {
       debtPositions.getInstallmentDetail as unknown as ReturnType<typeof vi.fn>
     ).mockReturnValue({ data: installmentWithoutIuv });
 
+    vi.mocked(debtPositions.getPaymentNoticeFile).mockReturnValue({
+      mutateAsync: mutateMock.mockReturnValue({
+        data: mockBlob,
+        fileName: mockFileName
+      })
+    } as any);
+
     render(<DebtPositionsInstallmentDetail />);
 
     const downloadButton = screen.getByText('commons.downloadInstallment');
@@ -294,6 +309,6 @@ describe('DebtPositionsInstallmentDetail', () => {
       'commons.files.missingIuv',
       'error'
     );
-    expect(debtPositions.downloadPaymentNotice).not.toHaveBeenCalled();
+    expect(mutateMock).not.toHaveBeenCalled();
   });
 });

--- a/src/components/DebtPositionsInstallmentDetail/DebtPositionsInstallmentDetail.tsx
+++ b/src/components/DebtPositionsInstallmentDetail/DebtPositionsInstallmentDetail.tsx
@@ -57,33 +57,25 @@ export const DebtPositionsInstallmentDetail = () => {
   );
   const statusInstallment = installment?.status;
 
+  const downloadMutation = debtPositions.downloadPaymentNotice(
+    organizationId,
+    installment?.debtPositionId || 0,
+    installment?.iuv || ''
+  );
+
   const handleDownloadInstallment = async () => {
-    if (!installment?.iuv || !installment.debtPositionId) {
-      utils.notify.emit(t('commons.files.missingIuv'), 'error');
-      return;
-    }
-
-    if (statusInstallment !== InstallmentStatus.UNPAID) {
-      setOpenDeleteDialog(true);
-      return;
-    }
-
     try {
-      const result = await debtPositions.downloadPaymentNotice(
-        organizationId,
-        installment.debtPositionId,
-        installment.iuv
-      );
-
-      if (!result) {
-        utils.notify.emit(t('commons.files.downloadFailed'), 'error');
-        return;
+      if (!installment?.iuv || !installment.debtPositionId) {
+        return utils.notify.emit(t('commons.files.missingIuv'), 'error');
       }
-
+      if (statusInstallment !== InstallmentStatus.UNPAID) {
+        return setOpenDeleteDialog(true);
+      }
+      const result = await downloadMutation.mutateAsync();
       const { data, fileName } = result;
       downloadBlob(data, fileName);
     } catch (error) {
-      console.error(t('commons.files.downloadFailed'), error);
+      console.error(error);
       utils.notify.emit(t('commons.files.downloadFailed'), 'error');
     }
   };

--- a/src/components/DebtPositionsInstallmentDetail/DebtPositionsInstallmentDetail.tsx
+++ b/src/components/DebtPositionsInstallmentDetail/DebtPositionsInstallmentDetail.tsx
@@ -57,7 +57,7 @@ export const DebtPositionsInstallmentDetail = () => {
   );
   const statusInstallment = installment?.status;
 
-  const downloadMutation = debtPositions.downloadPaymentNotice(
+  const downloadMutation = debtPositions.getPaymentNoticeFile(
     organizationId,
     installment?.debtPositionId || 0,
     installment?.iuv || ''

--- a/src/components/ExportFlowOverview/ExportFlowOverview.test.tsx
+++ b/src/components/ExportFlowOverview/ExportFlowOverview.test.tsx
@@ -1,6 +1,7 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { useNavigate, generatePath } from 'react-router-dom';
-import { downloadExportFile, getExportFiles } from '../../api/exportFiles';
+import { getExportFiles, getExportFile } from '../../api/exportFiles';
 import { fireEvent, render, waitFor, screen } from '../../__tests__/renderers';
 import { setOrganizationId } from '../../store/OrganizationIdStore';
 import { PageRoutes } from '../../App';
@@ -14,20 +15,17 @@ vi.mock('react-router-dom', async (importOriginal) => ({
   generatePath: vi.fn()
 }));
 
-vi.mock('../../api/exportFiles', () => ({
-  getExportFiles: vi
-    .fn()
-    .mockReturnValue({ data: { content: [] }, isLoading: false })
-}));
-
+const mutateAsyncMock = vi.fn();
 vi.mock('../../api/exportFiles', () => ({
   getExportFiles: vi
     .fn()
     .mockReturnValue({ data: { content: [] }, isLoading: false }),
-  downloadExportFile: vi.fn().mockResolvedValue({
-    data: new Blob(['test data']),
-    fileName: 'test_file.zip'
-  })
+  getExportFile: vi.fn().mockImplementation(() => ({
+    mutateAsync: mutateAsyncMock.mockReturnValue({
+      data: new Blob(['test data']),
+      fileName: 'test_file.zip'
+    })
+  }))
 }));
 
 vi.mock('../../utils/download', () => ({
@@ -174,7 +172,7 @@ describe('ExportFlowOverview', () => {
     fireEvent.click(downloadButtons[0]);
 
     await waitFor(() => {
-      expect(downloadExportFile).toHaveBeenCalledWith(123, expect.any(Number));
+      expect(mutateAsyncMock).toHaveBeenCalledWith(expect.any(Number));
     });
 
     await waitFor(() => {
@@ -343,14 +341,14 @@ describe('ExportFlowOverview', () => {
     expect(screen.queryByText('commons.noFlows')).toBeNull();
   });
 
-  it('handles null/undefined download result', async () => {
-    (
-      downloadExportFile as unknown as ReturnType<typeof vi.fn>
-    ).mockResolvedValueOnce(null);
+  it('handles error download result', async () => {
+    vi.mocked(getExportFile).mockReturnValue({
+      mutateAsync: mutateAsyncMock.mockRejectedValue(
+        new Error('Download failed')
+      )
+    } as any);
 
-    const consoleSpy = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => undefined);
+    const consoleSpy = vi.spyOn(console, 'error');
 
     render(
       <ExportFlowOverview
@@ -364,7 +362,8 @@ describe('ExportFlowOverview', () => {
     fireEvent.click(downloadButtons[0]);
 
     await waitFor(() => {
-      expect(consoleSpy).toHaveBeenCalledWith('Failed to download file');
+      expect(console.error).toHaveBeenCalled();
+      expect(downloadBlob).not.toHaveBeenCalled();
     });
 
     consoleSpy.mockRestore();

--- a/src/components/ExportFlowOverview/ExportFlowOverview.tsx
+++ b/src/components/ExportFlowOverview/ExportFlowOverview.tsx
@@ -18,11 +18,12 @@ import {
   ExportFileStatus,
   ExportFileTypeEnum
 } from '../../../generated/apiClient';
-import { downloadExportFile, getExportFiles } from '../../api/exportFiles';
+import { getExportFile, getExportFiles } from '../../api/exportFiles';
 import { useExportFlowFilters } from '../../hooks/useExportFlowFilters';
 import { downloadBlob } from '../../utils/download';
 import EmptyDataGrid from '../EmptyDataGrid/EmptyDataGrid';
 import { formatDateTime } from '../../utils/formatters';
+import utils from '../../utils';
 
 export type ExportFlowOverviewProps = {
   routingCategory: string;
@@ -64,17 +65,17 @@ const ExportFlowOverview = ({
   const { data, isLoading } = getExportFiles(organizationId, appliedFilters);
   const isEmptyData = !data?.content || data.content.length === 0;
 
+  const getFile = getExportFile(organizationId);
+
   const handleDownloadFile = async (exportFileId: number) => {
-    const result = await downloadExportFile(organizationId, exportFileId);
-
-    //TODO: handle error
-    if (!result) {
-      console.error('Failed to download file');
-      return;
+    try {
+      const result = await getFile.mutateAsync(exportFileId);
+      const { data, fileName } = result;
+      downloadBlob(data, fileName);
+    } catch (error) {
+      console.error(error);
+      utils.notify.emit(t('commons.files.downloadFailed'));
     }
-
-    const { data, fileName } = result;
-    downloadBlob(data, fileName);
   };
 
   const handleExportFlow = () => {

--- a/src/components/ImportFlowOverview/ImportFlowOverview.test.tsx
+++ b/src/components/ImportFlowOverview/ImportFlowOverview.test.tsx
@@ -1,8 +1,8 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { useNavigate, generatePath } from 'react-router-dom';
 import {
-  downloadIngestionFlowFile,
-  getIngestionFlowFiles
+  getIngestionFlowFiles,
+  getIngestionFlowFile
 } from '../../api/ingestionFlowFiles';
 import { downloadBlob } from '../../utils/download';
 import { fireEvent, render, waitFor, screen } from '../../__tests__/renderers';
@@ -20,6 +20,7 @@ vi.mock('react-router-dom', async (importOriginal) => ({
 vi.mock('../../api/ingestionFlowFiles', () => ({
   getIngestionFlowFiles: vi.fn().mockReturnValue({ data: { content: [] } }),
   getIngestionFlowFileError: vi.fn(),
+  getIngestionFlowFile: vi.fn(),
   IngestionFlowFileType: {
     RECEIPT: 'RECEIPT',
     RECEIPT_PAGOPA: 'RECEIPT_PAGOPA',
@@ -30,8 +31,7 @@ vi.mock('../../api/ingestionFlowFiles', () => ({
     TREASURY_XLS: 'TREASURY_XLS',
     TREASURY_POSTE: 'TREASURY_POSTE',
     DP_INSTALLMENTS: 'DP_INSTALLMENTS'
-  },
-  downloadIngestionFlowFile: vi.fn()
+  }
 }));
 
 vi.mock('../../utils/download', () => ({
@@ -820,17 +820,15 @@ describe('TelematicReceiptImportFlowOverview', () => {
   });
 
   it('calls downloadIngestionFlowFile and downloadBlob when download button is clicked', async () => {
-    const mockDownloadIngestionFlowFile = vi.fn().mockResolvedValue({
-      data: new Blob(['test content']),
-      fileName: 'test-file.csv'
-    });
-    const mockDownloadBlob = vi.fn();
+    const mockMutateAsync = vi.fn();
 
-    (downloadIngestionFlowFile as ReturnType<typeof vi.fn>).mockImplementation(
-      mockDownloadIngestionFlowFile
-    );
-    (downloadBlob as ReturnType<typeof vi.fn>).mockImplementation(
-      mockDownloadBlob
+    (getIngestionFlowFile as ReturnType<typeof vi.fn>).mockImplementation(
+      () => ({
+        mutateAsync: mockMutateAsync.mockResolvedValue({
+          data: new Blob(['test content']),
+          fileName: 'test-file.csv'
+        })
+      })
     );
 
     const { container } = render(
@@ -862,13 +860,12 @@ describe('TelematicReceiptImportFlowOverview', () => {
 
     fireEvent.click(downloadButton!);
 
-    expect(mockDownloadIngestionFlowFile).toHaveBeenCalledWith(
-      123,
+    expect(mockMutateAsync).toHaveBeenCalledWith(
       uploadedRow!.ingestionFlowFileId
     );
 
     await waitFor(() => {
-      expect(mockDownloadBlob).toHaveBeenCalledWith(
+      expect(downloadBlob).toHaveBeenCalledWith(
         expect.any(Blob),
         'test-file.csv'
       );
@@ -877,17 +874,15 @@ describe('TelematicReceiptImportFlowOverview', () => {
   });
 
   it('calls downloadIngestionFlowFile and downloadBlob when menu download option is clicked', async () => {
-    const mockDownloadIngestionFlowFile = vi.fn().mockResolvedValue({
-      data: new Blob(['test content']),
-      fileName: 'test-file.csv'
-    });
-    const mockDownloadBlob = vi.fn();
+    const mockMutateAsync = vi.fn();
 
-    (downloadIngestionFlowFile as ReturnType<typeof vi.fn>).mockImplementation(
-      mockDownloadIngestionFlowFile
-    );
-    (downloadBlob as ReturnType<typeof vi.fn>).mockImplementation(
-      mockDownloadBlob
+    (getIngestionFlowFile as ReturnType<typeof vi.fn>).mockImplementation(
+      () => ({
+        mutateAsync: mockMutateAsync.mockResolvedValue({
+          data: new Blob(['test content']),
+          fileName: 'test-file.csv'
+        })
+      })
     );
 
     render(
@@ -927,13 +922,12 @@ describe('TelematicReceiptImportFlowOverview', () => {
         fireEvent.click(downloadMenuItem);
       });
 
-      expect(mockDownloadIngestionFlowFile).toHaveBeenCalledWith(
-        123,
+      expect(mockMutateAsync).toHaveBeenCalledWith(
         completedRow.ingestionFlowFileId
       );
 
       await waitFor(() => {
-        expect(mockDownloadBlob).toHaveBeenCalledWith(
+        expect(downloadBlob).toHaveBeenCalledWith(
           expect.any(Blob),
           'test-file.csv'
         );

--- a/src/components/ImportFlowOverview/ImportFlowOverview.tsx
+++ b/src/components/ImportFlowOverview/ImportFlowOverview.tsx
@@ -19,7 +19,7 @@ import {
   STATE_COLORS
 } from '../../models/Filters';
 import {
-  downloadIngestionFlowFile,
+  getIngestionFlowFile,
   getIngestionFlowFileError,
   getIngestionFlowFiles
 } from '../../api/ingestionFlowFiles';
@@ -76,17 +76,17 @@ const ImportFlowOverview = ({
   const getIngestionFlowFileErrorMutation =
     getIngestionFlowFileError(organizationId);
 
+  const getIngestionFlowFileMutation = getIngestionFlowFile(organizationId);
+
   const handleDownloadFile = async (ingestionFlowFileId: number) => {
-    const result = await downloadIngestionFlowFile(
-      organizationId,
-      ingestionFlowFileId
-    );
-
-    if (!result)
-      return utils.notify.emit(t('FileUploaderFlowImport.error.flowFile'));
-
-    const { data, fileName } = result;
-    downloadBlob(data, fileName);
+    try {
+      const { data, fileName } =
+        await getIngestionFlowFileMutation.mutateAsync(ingestionFlowFileId);
+      downloadBlob(data, fileName);
+    } catch (error) {
+      console.error(error);
+      utils.notify.emit(t('FileUploaderFlowImport.error.errorFlowFile'));
+    }
   };
 
   const handleDownloadFileError = async (ingestionFlowFileId: number) => {

--- a/src/components/ReportingImportFlowOverview/ReportingImportFlowOverview.test.tsx
+++ b/src/components/ReportingImportFlowOverview/ReportingImportFlowOverview.test.tsx
@@ -13,6 +13,7 @@ vi.mock('react-router-dom', async (importOriginal) => ({
 vi.mock('../../api/ingestionFlowFiles', () => ({
   getIngestionFlowFiles: vi.fn().mockReturnValue({ data: { content: [] } }),
   getIngestionFlowFileError: vi.fn(),
+  getIngestionFlowFile: vi.fn(),
   IngestionFlowFileType: {
     RECEIPT: 'RECEIPT',
     RECEIPT_PAGOPA: 'RECEIPT_PAGOPA',

--- a/src/components/TelematicReceiptFlowExportOverview/TelematicReceiptFlowExportOverview.test.tsx
+++ b/src/components/TelematicReceiptFlowExportOverview/TelematicReceiptFlowExportOverview.test.tsx
@@ -12,6 +12,7 @@ vi.mock('react-router-dom', async (importOriginal) => ({
 
 vi.mock('../../api/exportFiles', () => ({
   getExportFiles: vi.fn().mockReturnValue({ data: { content: [] } }),
+  getExportFile: vi.fn(),
   ExportFileStatus: {
     COMPLETED: 'COMPLETED'
   },

--- a/src/components/TelematicReceiptImportFlowOverview/TelematicReceiptImportFlowOverview.test.tsx
+++ b/src/components/TelematicReceiptImportFlowOverview/TelematicReceiptImportFlowOverview.test.tsx
@@ -13,6 +13,7 @@ vi.mock('react-router-dom', async (importOriginal) => ({
 vi.mock('../../api/ingestionFlowFiles', () => ({
   getIngestionFlowFiles: vi.fn().mockReturnValue({ data: { content: [] } }),
   getIngestionFlowFileError: vi.fn(),
+  getIngestionFlowFile: vi.fn(),
   IngestionFlowFileType: {
     RECEIPT: 'RECEIPT',
     RECEIPT_PAGOPA: 'RECEIPT_PAGOPA',

--- a/src/components/TreasuryImportFlowOverview/TreasuryImportFlowOverview.test.tsx
+++ b/src/components/TreasuryImportFlowOverview/TreasuryImportFlowOverview.test.tsx
@@ -13,6 +13,7 @@ vi.mock('react-router-dom', async (importOriginal) => ({
 vi.mock('../../api/ingestionFlowFiles', () => ({
   getIngestionFlowFiles: vi.fn().mockReturnValue({ data: { content: [] } }),
   getIngestionFlowFileError: vi.fn(),
+  getIngestionFlowFile: vi.fn(),
   IngestionFlowFileType: {
     RECEIPT: 'RECEIPT',
     RECEIPT_PAGOPA: 'RECEIPT_PAGOPA',

--- a/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizardCompleted.test.tsx
+++ b/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizardCompleted.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   screen,
@@ -62,7 +63,7 @@ vi.mock('react-router', async () => {
 // Mock debtPositions API
 vi.mock('../../api/debtPositions', () => ({
   default: {
-    downloadDebtPositionZip: vi.fn()
+    getDebtPositionZipFile: vi.fn()
   }
 }));
 
@@ -210,14 +211,15 @@ describe('DebtPositionCreateWizardCompleted', () => {
       state: { description: 'Test Payment', debtPositionId: 123 }
     });
 
-    // Setup mock for downloadDebtPositionZip
-    const mockResult = {
-      data: new Blob(['test data'], { type: 'application/zip' }),
-      fileName: 'test-file.zip'
-    };
-    vi.mocked(debtPositions.downloadDebtPositionZip).mockResolvedValue(
-      mockResult
-    );
+    const mutateMock = vi.fn();
+
+    vi.mocked(debtPositions.getDebtPositionZipFile).mockReturnValue({
+      mutateAsync: mutateMock.mockReturnValue({
+        data: new Blob(['test data'], { type: 'application/zip' }),
+        fileName: 'test-file.zip'
+      })
+    } as any);
+    // Mock the downloadBlob functio
 
     customRender(<DebtPositionCreateWizardCompleted />);
 
@@ -228,10 +230,8 @@ describe('DebtPositionCreateWizardCompleted', () => {
     // Wait for the async function to complete
     await vi.waitFor(() => {
       // Verify that downloadDebtPositionZip was called with the correct arguments
-      expect(debtPositions.downloadDebtPositionZip).toHaveBeenCalledWith(
-        3,
-        123
-      );
+      expect(debtPositions.getDebtPositionZipFile).toHaveBeenCalledWith(3);
+      expect(mutateMock).toHaveBeenCalledWith(123);
     });
   });
 
@@ -241,10 +241,11 @@ describe('DebtPositionCreateWizardCompleted', () => {
       state: { description: 'Test Payment', debtPositionId: 123 }
     });
 
+    const mutateMock = vi.fn();
     // Setup mock for downloadDebtPositionZip to throw an error
-    vi.mocked(debtPositions.downloadDebtPositionZip).mockRejectedValue(
-      new Error('Download failed')
-    );
+    vi.mocked(debtPositions.getDebtPositionZipFile).mockReturnValue({
+      mutateAsync: mutateMock.mockRejectedValue(new Error('Download failed'))
+    } as any);
 
     customRender(<DebtPositionCreateWizardCompleted />);
 
@@ -255,10 +256,7 @@ describe('DebtPositionCreateWizardCompleted', () => {
     // Wait for the async function to complete
     await vi.waitFor(() => {
       // Verify that the error notification was emitted
-      expect(utils.notify.emit).toHaveBeenCalledWith(
-        'Download failed',
-        'error'
-      );
+      expect(utils.notify.emit).toHaveBeenCalledWith('Download failed');
     });
   });
 
@@ -300,10 +298,7 @@ describe('DebtPositionCreateWizardCompleted', () => {
     fireEvent.click(downloadButton);
 
     // Verify error notification was shown
-    expect(utils.notify.emit).toHaveBeenCalledWith(
-      'Missing debt position ID',
-      'error'
-    );
+    expect(utils.notify.emit).toHaveBeenCalledWith('Missing debt position ID');
   });
 
   it('handles case when download result is null', async () => {
@@ -313,7 +308,9 @@ describe('DebtPositionCreateWizardCompleted', () => {
     });
 
     // Setup mock for downloadDebtPositionZip to return null
-    vi.mocked(debtPositions.downloadDebtPositionZip).mockResolvedValue(null);
+    vi.mocked(debtPositions.getDebtPositionZipFile).mockReturnValue({
+      mutateAsync: vi.fn().mockReturnValue(null)
+    } as any);
 
     customRender(<DebtPositionCreateWizardCompleted />);
 
@@ -324,10 +321,7 @@ describe('DebtPositionCreateWizardCompleted', () => {
     // Wait for the async function to complete
     await vi.waitFor(() => {
       // Verify error notification was shown
-      expect(utils.notify.emit).toHaveBeenCalledWith(
-        'Download failed',
-        'error'
-      );
+      expect(utils.notify.emit).toHaveBeenCalledWith('Download failed');
     });
   });
 });

--- a/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizardCompleted.tsx
+++ b/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizardCompleted.tsx
@@ -47,28 +47,19 @@ function DebtPositionCreateWizardCompleted() {
     }
   }
 
-  const handleDownloadDebtPosition = async () => {
-    if (!debtPositionId) {
-      utils.notify.emit(t('commons.files.missingDebtPositionId'), 'error');
-      return;
-    }
+  const getDebtPositionZipFileMutation =
+    debtPositions.getDebtPositionZipFile(organizationId);
 
+  const handleDownloadDebtPosition = async () => {
     try {
-      const result = await debtPositions.downloadDebtPositionZip(
-        organizationId,
+      const result = await getDebtPositionZipFileMutation.mutateAsync(
         Number(debtPositionId)
       );
-
-      if (!result) {
-        utils.notify.emit(t('commons.files.downloadFailed'), 'error');
-        return;
-      }
-
       const { data, fileName } = result;
       downloadBlob(data, fileName);
     } catch (error) {
       console.error(t('commons.files.downloadFailed'), error);
-      utils.notify.emit(t('commons.files.downloadFailed'), 'error');
+      utils.notify.emit(t('commons.files.downloadFailed'));
     }
   };
 

--- a/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizardCompleted.tsx
+++ b/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizardCompleted.tsx
@@ -51,6 +51,10 @@ function DebtPositionCreateWizardCompleted() {
     debtPositions.getDebtPositionZipFile(organizationId);
 
   const handleDownloadDebtPosition = async () => {
+    if (!debtPositionId) {
+      return utils.notify.emit(t('commons.files.missingDebtPositionId'));
+    }
+
     try {
       const result = await getDebtPositionZipFileMutation.mutateAsync(
         Number(debtPositionId)

--- a/src/routes/DebtPositionDetail/DebtPositionDetail.test.tsx
+++ b/src/routes/DebtPositionDetail/DebtPositionDetail.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { screen, fireEvent } from '@testing-library/react';
 import { render } from '../../__tests__/renderers';
 import DebtPositionDetail from './DebtPositionDetail';

--- a/src/routes/DebtPositionDetail/DebtPositionDetail.test.tsx
+++ b/src/routes/DebtPositionDetail/DebtPositionDetail.test.tsx
@@ -104,18 +104,22 @@ vi.mock('../../store/GlobalStore', () => ({
   StoreProvider: ({ children }: React.PropsWithChildren<object>) => children
 }));
 
-const mockMutate = vi.fn();
+const mockResult = {
+  data: new Blob(['test data'], { type: 'application/zip' }),
+  fileName: 'test-file.zip'
+};
+const mockMutate = vi.fn().mockReturnValue(mockResult);
+const deleteMockMutate = vi.fn();
 
 vi.mock('../../api/debtPositions', () => ({
   default: {
     getDebtPositionDetail: vi.fn(),
     deleteDebtPosition: vi.fn().mockImplementation(() => ({
-      mutate: mockMutate,
-      isLoading: false,
-      isError: false,
-      isSuccess: false
+      mutate: deleteMockMutate
     })),
-    downloadDebtPositionZip: vi.fn()
+    getDebtPositionZipFile: vi.fn().mockImplementation(() => ({
+      mutateAsync: mockMutate
+    }))
   }
 }));
 
@@ -315,16 +319,8 @@ describe('DebtPositionDetail Component', () => {
     }
   });
 
-  it('calls downloadDebtPositionZip when download button is clicked and status is UNPAID', async () => {
+  it('calls getDebtPositionZipFile mutation when download button is clicked and status is UNPAID', async () => {
     mockDebtPositionDetail.status = DebtPositionStatus.UNPAID;
-    const mockResult = {
-      data: new Blob(['test data'], { type: 'application/zip' }),
-      fileName: 'test-file.zip'
-    };
-
-    vi.mocked(debtPositions.downloadDebtPositionZip).mockResolvedValue(
-      mockResult
-    );
 
     render(<DebtPositionDetail />);
 
@@ -337,10 +333,7 @@ describe('DebtPositionDetail Component', () => {
       fireEvent.click(downloadButton);
 
       await vi.waitFor(() => {
-        const firstCall = vi.mocked(debtPositions.downloadDebtPositionZip).mock
-          .calls[0];
-        expect(firstCall).toBeTruthy();
-        expect(firstCall[1]).toBe(10);
+        expect(mockMutate).toHaveBeenCalledWith(10);
         expect(utils.downloadBlob).toHaveBeenCalledWith(
           mockResult.data,
           mockResult.fileName
@@ -349,16 +342,8 @@ describe('DebtPositionDetail Component', () => {
     }
   });
 
-  it('calls downloadDebtPositionZip when download button is clicked and status is PARTIALLY_PAID', async () => {
+  it('calls getDebtPositionZipFile mutation function when download button is clicked and status is PARTIALLY_PAID', async () => {
     mockDebtPositionDetail.status = DebtPositionStatus.PARTIALLY_PAID;
-    const mockResult = {
-      data: new Blob(['test data'], { type: 'application/zip' }),
-      fileName: 'test-file.zip'
-    };
-
-    vi.mocked(debtPositions.downloadDebtPositionZip).mockResolvedValue(
-      mockResult
-    );
 
     render(<DebtPositionDetail />);
 
@@ -371,10 +356,7 @@ describe('DebtPositionDetail Component', () => {
       fireEvent.click(downloadButton);
 
       await vi.waitFor(() => {
-        const firstCall = vi.mocked(debtPositions.downloadDebtPositionZip).mock
-          .calls[0];
-        expect(firstCall).toBeTruthy();
-        expect(firstCall[1]).toBe(10);
+        expect(mockMutate).toHaveBeenCalledWith(10);
         expect(utils.downloadBlob).toHaveBeenCalledWith(
           mockResult.data,
           mockResult.fileName
@@ -403,7 +385,7 @@ describe('DebtPositionDetail Component', () => {
             'Notices can only be downloaded for unpaid or partially paid debt positions'
           )
         ).toBeVisible();
-        expect(debtPositions.downloadDebtPositionZip).not.toHaveBeenCalled();
+        expect(mockMutate).not.toHaveBeenCalled();
       });
     }
   });
@@ -411,9 +393,9 @@ describe('DebtPositionDetail Component', () => {
   it('handles error when downloadDebtPositionZip fails', async () => {
     mockDebtPositionDetail.status = DebtPositionStatus.UNPAID;
 
-    vi.mocked(debtPositions.downloadDebtPositionZip).mockRejectedValue(
-      new Error('Download failed')
-    );
+    vi.mocked(debtPositions.getDebtPositionZipFile).mockReturnValue({
+      mutateAsync: mockMutate.mockRejectedValue(new Error('Download failed'))
+    } as any);
 
     render(<DebtPositionDetail />);
 
@@ -426,10 +408,7 @@ describe('DebtPositionDetail Component', () => {
       fireEvent.click(downloadButton);
 
       await vi.waitFor(() => {
-        const firstCall = vi.mocked(debtPositions.downloadDebtPositionZip).mock
-          .calls[0];
-        expect(firstCall).toBeTruthy();
-        expect(firstCall[1]).toBe(10);
+        expect(mockMutate).toHaveBeenCalledWith(10);
         expect(utils.downloadBlob).not.toHaveBeenCalled();
         expect(console.error).toHaveBeenCalled();
       });
@@ -539,7 +518,7 @@ describe('DebtPositionDetail Component', () => {
 
       // Verifica che la funzione di eliminazione sia stata chiamata
       await vi.waitFor(() => {
-        expect(mockMutate).toHaveBeenCalled();
+        expect(deleteMockMutate).toHaveBeenCalled();
       });
     }
   });
@@ -584,7 +563,7 @@ describe('DebtPositionDetail Component', () => {
       });
 
       // Verifica che la funzione di eliminazione NON sia stata chiamata
-      expect(mockMutate).not.toHaveBeenCalled();
+      expect(deleteMockMutate).not.toHaveBeenCalled();
     }
   });
 
@@ -633,7 +612,7 @@ describe('DebtPositionDetail Component', () => {
       });
 
       // Verifica che la funzione di eliminazione NON sia stata chiamata
-      expect(mockMutate).not.toHaveBeenCalled();
+      expect(deleteMockMutate).not.toHaveBeenCalled();
     }
   });
 });

--- a/src/routes/DebtPositionDetail/DebtPositionDetail.tsx
+++ b/src/routes/DebtPositionDetail/DebtPositionDetail.tsx
@@ -209,12 +209,10 @@ const DebtPositionDetail = () => {
     });
   };
 
-  const handleDownloadNotices = async () => {
-    if (!debtPositionId) {
-      utils.notify.emit(t('commons.files.missingDebtPositionId'), 'error');
-      return;
-    }
+  const getDebtPositionZipFileMutation =
+    debtPositions.getDebtPositionZipFile(organizationId);
 
+  const handleDownloadNotices = async () => {
     const DOWNLOADABLE_STATES = [
       DebtPositionStatus.UNPAID,
       DebtPositionStatus.PARTIALLY_PAID
@@ -229,21 +227,14 @@ const DebtPositionDetail = () => {
     }
 
     try {
-      const result = await debtPositions.downloadDebtPositionZip(
-        organizationId,
-        debtPositionId
-      );
-
-      if (!result) {
-        utils.notify.emit(t('commons.files.downloadFailed'), 'error');
-        return;
-      }
+      const result =
+        await getDebtPositionZipFileMutation.mutateAsync(debtPositionId);
 
       const { data, fileName } = result;
       downloadBlob(data, fileName);
     } catch (error) {
       console.error(t('commons.files.downloadFailed'), error);
-      utils.notify.emit(t('commons.files.downloadFailed'), 'error');
+      utils.notify.emit(t('commons.files.downloadFailed'));
     }
   };
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- refactor some services to use ReactQuery
- using mutation to take advantage of observation of the states of the request calls (such as isFetching, isMutating, isError, etc...)
- updating unit tests

<!--- Describe your changes in detail -->

#### Motivation and Context
This changes is useful because wrapping all requests with mutation or query (react Query) waiting times gives to the user a feedback about this wait in the form of a loader icon on an transparent overlay. This is particularly useful for the request of file downloads.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

- Tested simulating low communication times, trough developer dev tools, and observing the visual feedback in the form of a loader on a transparent overlay
- Tested trough unit tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
