### PR TITLE
feat: [P4ADEV-2900] Taxonomy section

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import AuthCallback from './routes/AuthCallback';
 import { postToken } from './api/token';
 import LoggedOut from './routes/UtilityPages/loggedout';
 import ErrorPage from './routes/UtilityPages/error';
+import { backofficeRoutes } from './routes/backoffice';
 
 const deployPath = config.deployPath;
 
@@ -83,7 +84,8 @@ const routesDef = [
       ...debtTypesRoutes,
       ...responsesRoutes,
       ...debtPositionsRoutes,
-      ...classificationsRoutes
+      ...classificationsRoutes,
+      ...backofficeRoutes
     ]
   }
 ];

--- a/src/api/taxonomy.test.ts
+++ b/src/api/taxonomy.test.ts
@@ -1,0 +1,62 @@
+import utils from '../utils';
+import { AxiosResponse } from 'axios';
+import { describe, expect, it, vi } from 'vitest';
+import { getTaxonomyDetail } from './taxonomy';
+import { renderHook, waitFor } from '../__tests__/renderers';
+
+vi.mock('./utils', () => {
+  const originalModule = vi.importActual('utils');
+  return {
+    ...originalModule,
+    apiClient: {
+      bff: {
+        getTaxonomyDetail: vi.fn()
+      }
+    }
+  };
+});
+
+describe('get Taxonomy Detail ', () => {
+  it('returns data correctly', async () => {
+    const dataMock = {
+      creationDate: '2025-02-20T09:23:17.977642',
+      updateDate: '2025-05-27T17:23:33.402746',
+      updateOperatorExternalId: 'WS_USER',
+      updateTraceId: 'ecc6c6bf5df88ea1c3500676734d173e',
+      taxonomyId: 705,
+      organizationType: '10',
+      organizationTypeDescription: "AUTORITA' AMMINISTRATIVE INDIPENDENTI",
+      macroAreaCode: '15',
+      macroAreaName: 'Autorità Idrica',
+      macroAreaDescription: 'Settore idrico',
+      serviceTypeCode: '100',
+      serviceType: 'tassa concorso',
+      serviceTypeDescription: 'tassa per la partecipazione ai concorsi',
+      collectionReason: 'TS',
+      startDateValidity: '2024-08-01T00:00:00.000000',
+      endDateOfValidity: '2080-01-01T00:00:00.000000',
+      taxonomyCode: '9/1004100TS/',
+      _links: {
+        self: {
+          href: 'http://:8080/crud/taxonomies/705'
+        },
+        taxonomy: {
+          href: 'http://:8080/crud/taxonomies/705'
+        }
+      }
+    };
+
+    const params = { taxonomyId: 705 };
+
+    const apiMock = vi
+      .spyOn(utils.apiClient.bff, 'getTaxonomyDetail')
+      .mockResolvedValue({ data: dataMock } as AxiosResponse);
+
+    const { result } = renderHook(() => getTaxonomyDetail(params.taxonomyId));
+
+    await waitFor(() => {
+      expect(apiMock).toHaveBeenCalledWith(params.taxonomyId);
+      expect(result.current.data).toEqual(dataMock);
+    });
+  });
+});

--- a/src/api/taxonomy.test.ts
+++ b/src/api/taxonomy.test.ts
@@ -1,8 +1,9 @@
 import utils from '../utils';
 import { AxiosResponse } from 'axios';
 import { describe, expect, it, vi } from 'vitest';
-import { getTaxonomyDetail } from './taxonomy';
+import { getTaxonomyDetail, synchronizeTaxonomy } from './taxonomy';
 import { renderHook, waitFor } from '../__tests__/renderers';
+import { Taxonomy, WorkflowCreatedDTO } from '../../generated/data-contracts';
 
 vi.mock('./utils', () => {
   const originalModule = vi.importActual('utils');
@@ -10,7 +11,8 @@ vi.mock('./utils', () => {
     ...originalModule,
     apiClient: {
       bff: {
-        getTaxonomyDetail: vi.fn()
+        getTaxonomyDetail: vi.fn(),
+        synchronizeTaxonomy: vi.fn()
       }
     }
   };
@@ -18,7 +20,7 @@ vi.mock('./utils', () => {
 
 describe('get Taxonomy Detail ', () => {
   it('returns data correctly', async () => {
-    const dataMock = {
+    const dataMock: Taxonomy = {
       creationDate: '2025-02-20T09:23:17.977642',
       updateDate: '2025-05-27T17:23:33.402746',
       updateOperatorExternalId: 'WS_USER',
@@ -60,3 +62,27 @@ describe('get Taxonomy Detail ', () => {
     });
   });
 });
+
+describe('synchronizeTaxonomy', () => {
+  it('should call synchronizeTaxonomy and return data', async () => {
+
+    const dataMock: WorkflowCreatedDTO = {
+      workflowId: "SynchronizeTaxonomyPagoPaFetchWF-ON-DEMAND",
+      runId: "01971768-1993-7287-8993-4218439ea77a"
+    };
+    const apiMock = vi
+      .spyOn(utils.apiClient.bff, 'synchronizeTaxonomy')
+      .mockResolvedValue({ data: dataMock } as AxiosResponse);
+
+    const { result } = renderHook(() => synchronizeTaxonomy());
+
+    await result.current.mutateAsync();
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(dataMock);
+    });
+
+    expect(result.current.data).toEqual(dataMock);
+    expect(apiMock).toHaveBeenCalled();
+  })
+})

--- a/src/api/taxonomy.ts
+++ b/src/api/taxonomy.ts
@@ -1,4 +1,4 @@
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useMutation, useQuery } from '@tanstack/react-query';
 import utils from '../utils';
 import { parseAndLog } from '../utils/loaders';
 import {
@@ -113,3 +113,15 @@ export const getTaxonomyDetail = (taxonomyId: number) =>
       return taxonomydetail;
     }
   });
+
+
+export const synchronizeTaxonomy = () =>
+  useMutation({
+    mutationKey: ['sync'],
+    mutationFn: async () => {
+      const { data } = await utils.apiClient.bff.synchronizeTaxonomy();
+      return data;
+    }
+  });
+
+

--- a/src/api/taxonomy.ts
+++ b/src/api/taxonomy.ts
@@ -6,7 +6,8 @@ import {
   taxonomyServiceTypeCodeDTOSchema,
   taxonomyCollectionReasonDTOSchema,
   taxonomyCodeDTOSchema,
-  taxonomyOrganizationTypeDTOSchema
+  taxonomyOrganizationTypeDTOSchema,
+  taxonomySchema
 } from '../../generated/zod-schema';
 
 export const getOrganizationsTypes = () =>
@@ -97,5 +98,18 @@ export const getTaxonomyCode = (query: TaxonomyCodeQuery) =>
         value: taxonomyCode,
         label: taxonomyCode
       }));
+    }
+  });
+
+export const getTaxonomyDetail = (taxonomyId: number) =>
+  useQuery({
+    queryKey: ['taxonomyId', taxonomyId],
+    queryFn: async () => {
+      const { data: taxonomydetail } =
+        await utils.apiClient.bff.getTaxonomyDetail(taxonomyId);
+      if (taxonomydetail) {
+        parseAndLog(taxonomySchema, taxonomydetail);
+      }
+      return taxonomydetail;
     }
   });

--- a/src/components/ActionCard/ActionCard.tsx
+++ b/src/components/ActionCard/ActionCard.tsx
@@ -1,22 +1,33 @@
-import { Box, Button, Divider, Grid, Typography } from '@mui/material';
+import {
+  Box,
+  Button,
+  ButtonProps,
+  Divider,
+  Grid,
+  Typography
+} from '@mui/material';
 import { ArrowForward } from '@mui/icons-material';
 
 type ActionCardProps = {
-  title: string;
-  description: string;
+  actionButtonVariant?: ButtonProps['variant'];
   actionLabel: string;
-  actionIcon: React.ReactNode;
-  linkLabel: string;
+  actionIcon?: React.ReactNode;
+  description: string;
+  footerText?: string;
+  linkLabel?: string;
+  title: string;
   onActionClick: () => void;
-  onLinkClick: () => void;
+  onLinkClick?: () => void;
 };
 
 const ActionCard = ({
-  title,
-  description,
   actionLabel,
   actionIcon,
+  actionButtonVariant = 'outlined',
+  description,
+  footerText,
   linkLabel,
+  title,
   onActionClick,
   onLinkClick
 }: ActionCardProps) => {
@@ -30,7 +41,7 @@ const ActionCard = ({
         width="100%"
         borderRadius={0.5}
         padding={3}
-        sx={{ backgroundColor: 'background.paper', mb: 3 }}
+        sx={{ backgroundColor: 'background.paper' }}
       >
         <Typography id="action-card-title" variant="h6" sx={{ mb: 1 }}>
           {title}
@@ -43,11 +54,11 @@ const ActionCard = ({
           {description}
         </Typography>
         <Grid container direction="column" justifyContent={'start'}>
-          <Grid item lg={12} mb={4}>
+          <Grid item lg={12}>
             <Button
               size="large"
               startIcon={actionIcon}
-              variant="outlined"
+              variant={actionButtonVariant}
               fullWidth={false}
               onClick={onActionClick}
             >
@@ -55,23 +66,38 @@ const ActionCard = ({
             </Button>
           </Grid>
 
-          <Divider
-            orientation="horizontal"
-            flexItem
-            sx={{ display: 'block' }}
-          />
+          {(footerText || linkLabel) && (
+            <Divider
+              orientation="horizontal"
+              flexItem
+              sx={{ display: 'block', my: 3 }}
+            />
+          )}
 
-          <Grid item lg={12} mt={2}>
-            <Button
-              size="large"
-              endIcon={<ArrowForward />}
-              variant="text"
-              fullWidth={false}
-              onClick={onLinkClick}
-            >
-              {linkLabel}
-            </Button>
-          </Grid>
+          {linkLabel && (
+            <Grid item lg={12}>
+              <Button
+                size="large"
+                endIcon={<ArrowForward />}
+                variant="text"
+                fullWidth={false}
+                onClick={onLinkClick}
+                sx={{ py: 1 }}
+              >
+                {linkLabel}
+              </Button>
+            </Grid>
+          )}
+          {footerText && (
+            <Grid item lg={12}>
+              <Typography
+                variant="body2"
+                sx={{ color: 'text.secondary', mb: 2 }}
+              >
+                {footerText}
+              </Typography>
+            </Grid>
+          )}
         </Grid>
       </Box>
     </section>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -22,6 +22,7 @@ import AltRouteIcon from '@mui/icons-material/AltRoute';
 import DnsIcon from '@mui/icons-material/Dns';
 import PeopleIcon from '@mui/icons-material/People';
 import DashboardIcon from '@mui/icons-material/Dashboard';
+import SettingsIcon from '@mui/icons-material/Settings';
 import { sidebarStyles } from './sidebar.styles';
 import { PageRoutes } from '../../App';
 import { ISidebarMenuItem } from '../../models/SidebarMenuItem';
@@ -106,6 +107,18 @@ export const Sidebar: React.FC = () => {
       icon: DnsIcon,
       route: '/debtpositions',
       end: true
+    });
+    additionalItems.push({
+      label: t('commons.routes.BACKOFFICE'),
+      icon: SettingsIcon,
+      end: false,
+      items: [
+        {
+          label: t('commons.routes.BACKOFFICE_TAXONOMY'),
+          route: PageRoutes.BACKOFFICE_TAXONOMY,
+          end: true
+        }
+      ]
     });
   }
 

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -65,7 +65,6 @@ export function Layout() {
     <>
       <Snackbar
         autoHideDuration={6000}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
         onClose={utils.notify.dismiss}
         open={utils.notify.status.isVisible.value}
       >

--- a/src/routes/Taxonomy/index.test.tsx
+++ b/src/routes/Taxonomy/index.test.tsx
@@ -1,0 +1,14 @@
+import { describe, it, vi } from 'vitest';
+import TaxonomyPage from '.';
+import { render } from '../../__tests__/renderers';
+
+vi.mock('react-router-dom', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useNavigate: vi.fn()
+}));
+
+describe('TaxonomyPage Page', () => {
+  it('renders TaxonomyPage without crashing', () => {
+    render(<TaxonomyPage />);
+  });
+});

--- a/src/routes/Taxonomy/index.tsx
+++ b/src/routes/Taxonomy/index.tsx
@@ -3,9 +3,26 @@ import { useTranslation } from 'react-i18next';
 import TitleComponent from '../../components/TitleComponent/TitleComponent';
 import ActionCard from '../../components/ActionCard/ActionCard';
 import utils from '../../utils';
+import { synchronizeTaxonomy } from '../../api/taxonomy';
 
 export const TaxonomyPage = () => {
   const { t } = useTranslation();
+
+
+  const syncMutation = synchronizeTaxonomy();
+
+  const handleUpdateCTA = async () => {
+
+    try {
+      const result = await syncMutation.mutateAsync();
+      if (result) utils.notify.emit(t('taxonomyPage.APIUpdateOK'), 'info');
+    } catch (error) {
+      console.error(error);
+      utils.notify.emit(t('taxonomyPage.APIUpdateKO'), 'error');
+    }
+  }
+
+
 
   return (
     <>
@@ -23,9 +40,7 @@ export const TaxonomyPage = () => {
               actionLabel={t('taxonomyPage.APIUpdateCTA')}
               footerText={t('commons.lastUpdate')}
               actionButtonVariant="contained"
-              onActionClick={() =>
-                utils.notify.emit(t('taxonomyPage.APIUpdateOK'), 'info')
-              }
+              onActionClick={handleUpdateCTA}
             />
           </Grid>
         </Grid>

--- a/src/routes/Taxonomy/index.tsx
+++ b/src/routes/Taxonomy/index.tsx
@@ -1,0 +1,37 @@
+import { Grid } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import TitleComponent from '../../components/TitleComponent/TitleComponent';
+import ActionCard from '../../components/ActionCard/ActionCard';
+import utils from '../../utils';
+
+export const TaxonomyPage = () => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <TitleComponent title={t('commons.routes.BACKOFFICE_TAXONOMY_INDEX')} />
+      <Grid container direction="row">
+        <Grid container spacing={2}>
+          <Grid item xs={12} md={7}>
+            TASSONOMIA TO-DO
+          </Grid>
+
+          <Grid item xs={12} md={5}>
+            <ActionCard
+              title={t('taxonomyPage.APIUpdate')}
+              description={t('taxonomyPage.APIUpdateText')}
+              actionLabel={t('taxonomyPage.APIUpdateCTA')}
+              footerText={t('commons.lastUpdate')}
+              actionButtonVariant="contained"
+              onActionClick={() =>
+                utils.notify.emit(t('taxonomyPage.APIUpdateOK'), 'info')
+              }
+            />
+          </Grid>
+        </Grid>
+      </Grid>
+    </>
+  );
+};
+
+export default TaxonomyPage;

--- a/src/routes/TaxonomyDetail/index.test.tsx
+++ b/src/routes/TaxonomyDetail/index.test.tsx
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { TaxonomyDetailPage } from '.';
+import { render } from '../../__tests__/renderers';
+import { getTaxonomyDetail } from '../../api/taxonomy';
+
+vi.mock('../../api/taxonomy', () => ({
+  getTaxonomyDetail: vi.fn()
+}));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useParams: () => ({ taxonomyId: '705' }),
+    Navigate: vi.fn(({ to }) => <div>Navigate to {to}</div>),
+    useNavigate: () => vi.fn()
+  };
+});
+
+describe('Taxonomy Detail Page', () => {
+  const dataMock = {
+    creationDate: '2025-02-20T09:23:17.977642',
+    updateDate: '2025-05-27T17:23:33.402746',
+    updateOperatorExternalId: 'WS_USER',
+    updateTraceId: 'ecc6c6bf5df88ea1c3500676734d173e',
+    taxonomyId: 705,
+    organizationType: '10',
+    organizationTypeDescription: "AUTORITA' AMMINISTRATIVE INDIPENDENTI",
+    macroAreaCode: '15',
+    macroAreaName: 'Autorità Idrica',
+    macroAreaDescription: 'Settore idrico',
+    serviceTypeCode: '100',
+    serviceType: 'tassa concorso',
+    serviceTypeDescription: 'tassa per la partecipazione ai concorsi',
+    collectionReason: 'TS',
+    startDateValidity: '2024-08-01T00:00:00.000000',
+    endDateOfValidity: '2080-01-01T00:00:00.000000',
+    taxonomyCode: '9/1004100TS/',
+    _links: {
+      self: {
+        href: 'http://:8080/crud/taxonomies/705'
+      },
+      taxonomy: {
+        href: 'http://:8080/crud/taxonomies/705'
+      }
+    }
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    (getTaxonomyDetail as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: dataMock
+    });
+  });
+
+  it('renders Taxonomy Detail without crashing', () => {
+    render(<TaxonomyDetailPage />);
+
+    expect(screen.getByText(dataMock.taxonomyCode)).toBeInTheDocument();
+  });
+});

--- a/src/routes/TaxonomyDetail/index.tsx
+++ b/src/routes/TaxonomyDetail/index.tsx
@@ -1,0 +1,115 @@
+import { Grid } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+import TitleComponent from '../../components/TitleComponent/TitleComponent';
+import { getTaxonomyDetail } from '../../api/taxonomy';
+import DetailContainer, {
+  DetailData
+} from '../../components/DetailContainer/DetailContainer';
+import { useEffect } from 'react';
+import { formatDate } from '../../utils/formatters';
+
+export const TaxonomyDetailPage = () => {
+  const { t } = useTranslation();
+  const { taxonomyId } = useParams<{ taxonomyId: string }>();
+  const taxonomyInfo: Array<DetailData> = [];
+  const dateInfo: Array<DetailData> = [];
+
+  if (isNaN(Number(taxonomyId))) {
+    // TODO
+    // raise error
+    console.error('taxonomyId is not a number');
+  }
+
+  const { data } = getTaxonomyDetail(Number(taxonomyId));
+
+  useEffect(() => {
+    if (data) {
+      taxonomyInfo.push(
+        {
+          label: t('taxonomyPage.fields.organizationType'),
+          value: data.organizationType
+        },
+        {
+          label: t('taxonomyPage.fields.organizationTypeDescription'),
+          value: data.organizationTypeDescription
+        },
+        {
+          label: t('taxonomyPage.fields.macroAreaCode'),
+          value: data.macroAreaCode
+        },
+        {
+          label: t('taxonomyPage.fields.macroAreaName'),
+          value: data.macroAreaName
+        },
+        {
+          label: t('taxonomyPage.fields.serviceTypeCode'),
+          value: data.serviceTypeCode
+        },
+        {
+          label: t('taxonomyPage.fields.serviceType'),
+          value: data.serviceType
+        },
+        {
+          label: t('taxonomyPage.fields.serviceTypeDescription'),
+          value: data.serviceTypeDescription
+        },
+        {
+          label: t('taxonomyPage.fields.collectionReason'),
+          value: data.collectionReason
+        }
+      );
+      dateInfo.push(
+        {
+          label: t('taxonomyPage.fields.startDateValidity'),
+          value: formatDate(data.startDateValidity)
+        },
+        {
+          label: t('taxonomyPage.fields.endDateOfValidity'),
+          value: formatDate(data.endDateOfValidity)
+        }
+      );
+    }
+  }, [data]);
+
+  return (
+    <>
+      {data && (
+        <>
+          <TitleComponent title={data.taxonomyCode} />
+          <Grid container spacing={3} my={2}>
+            <Grid item md={6}>
+              <DetailContainer
+                sections={[
+                  {
+                    title: {
+                      label: t('taxonomyPage.taxonomyInfo'),
+                      variant: 'overline'
+                    },
+                    data: taxonomyInfo,
+                    inline: true
+                  }
+                ]}
+              />
+            </Grid>
+            <Grid item md={6}>
+              <DetailContainer
+                sections={[
+                  {
+                    title: {
+                      label: t('taxonomyPage.dateInfo'),
+                      variant: 'overline'
+                    },
+                    data: dateInfo
+                  }
+                ]}
+              />
+            </Grid>
+          </Grid>
+        </>
+      )}
+    </>
+  );
+};
+
+export default TaxonomyDetailPage;

--- a/src/routes/TaxonomyDetail/index.tsx
+++ b/src/routes/TaxonomyDetail/index.tsx
@@ -1,6 +1,6 @@
 import { Grid } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import TitleComponent from '../../components/TitleComponent/TitleComponent';
 import { getTaxonomyDetail } from '../../api/taxonomy';
 import DetailContainer, {
@@ -8,20 +8,24 @@ import DetailContainer, {
 } from '../../components/DetailContainer/DetailContainer';
 import { useEffect } from 'react';
 import { formatDate } from '../../utils/formatters';
+import { PageRoutes } from '../../App';
 
 export const TaxonomyDetailPage = () => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const { taxonomyId } = useParams<{ taxonomyId: string }>();
   const taxonomyInfo: Array<DetailData> = [];
   const dateInfo: Array<DetailData> = [];
 
   if (isNaN(Number(taxonomyId))) {
-    // TODO
-    // raise error
-    console.error('taxonomyId is not a number');
+    navigate(PageRoutes.RESPONSES_ERROR);
   }
 
-  const { data } = getTaxonomyDetail(Number(taxonomyId));
+  const { data, isError } = getTaxonomyDetail(Number(taxonomyId));
+
+  if (isError) {
+    navigate(PageRoutes.RESPONSES_ERROR);
+  }
 
   useEffect(() => {
     if (data) {

--- a/src/routes/backoffice.tsx
+++ b/src/routes/backoffice.tsx
@@ -4,6 +4,7 @@ import TaxonomyPage from './Taxonomy';
 import { RouteHandleObject } from '../models/Routes';
 import TaxonomyDetailPage from './TaxonomyDetail';
 import { Navigate } from 'react-router-dom';
+import { SuperAdminRouteGuard } from '../components/RouteGuard/RouteGuard';
 
 const deployPath = config.deployPath;
 
@@ -19,7 +20,7 @@ export const backofficeRoutes = [
       {
         id: 'BACKOFFICE_TAXONOMY',
         path: 'taxonomy/',
-        element: <Layout />,
+        element: <SuperAdminRouteGuard><Layout /></SuperAdminRouteGuard>,
         children: [
           {
             id: 'BACKOFFICE_TAXONOMY_INDEX',

--- a/src/routes/backoffice.tsx
+++ b/src/routes/backoffice.tsx
@@ -1,0 +1,45 @@
+import config from '../utils/config';
+import { Layout } from '../components/layout/Layout';
+import TaxonomyPage from './Taxonomy';
+import { RouteHandleObject } from '../models/Routes';
+import TaxonomyDetailPage from './TaxonomyDetail';
+import { Navigate } from 'react-router-dom';
+
+const deployPath = config.deployPath;
+
+export const backofficeRoutes = [
+  {
+    id: 'BACKOFFICE',
+    path: `${deployPath}/backoffice/`,
+    children: [
+      {
+        element: <Navigate replace to={`${deployPath}/`} />,
+        index: true
+      },
+      {
+        id: 'BACKOFFICE_TAXONOMY',
+        path: 'taxonomy/',
+        element: <Layout />,
+        children: [
+          {
+            id: 'BACKOFFICE_TAXONOMY_INDEX',
+            element: <TaxonomyPage />,
+            index: true,
+            handle: {
+              hideBreadcrumbs: true,
+              backButton: false
+            } as RouteHandleObject
+          },
+          {
+            id: 'BACKOFFICE_TAXONOMY_DETAIL',
+            path: ':taxonomyId',
+            element: <TaxonomyDetailPage />,
+            handle: {
+              backButton: true
+            } as RouteHandleObject
+          }
+        ]
+      }
+    ]
+  }
+];

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -174,6 +174,7 @@
     "iud": "IUD",
     "iur": "IUR",
     "iuv": "IUV",
+    "lastUpdate": "Ultimo aggiornamento",
     "macroarea": "Macroarea",
     "mandatoryDueDate": "Data di Scadenza Obbligatoria",
     "message": "Messaggio",
@@ -208,6 +209,10 @@
     "required": "Campo obbligatorio",
     "requiredFieldDescription": "* Indica un campo obbligatorio",
     "routes": {
+      "BACKOFFICE": "Backoffice",
+      "BACKOFFICE_TAXONOMY": "Tassonomia",
+      "BACKOFFICE_TAXONOMY_INDEX": "Tassonomia",
+      "BACKOFFICE_TAXONOMY_DETAIL": "Dettaglio",
       "CLASSIFICATIONS": "Classificazioni",
       "CLASSIFICATIONS_SEARCH_RESULTS": "Risultato ricerca",
       "CONSERVATION": "Conservazione",
@@ -596,33 +601,6 @@
   "debtPositionsImportThankYouPage": {
     "description": "Troverai il flusso caricato nella sezione Flussi importati"
   },
-  "debtTypeDetail": {
-    "description": "Ecco i dettagli del Tipo dovuto",
-    "debtMainConfiguration": {
-      "title": "Configurazione generale",
-      "description": "Definizione del Tipo dovuto"
-    },
-    "debtConfiguration": {
-      "externalPaymentUrl": "URL pagamento esterno",
-      "xsdAttachment": "Allegato XSD"
-    },
-    "accounting": {
-      "description": "Parametri per la gestione delle entrate."
-    },
-    "messages": {
-      "description": "Notifiche digitale ai cittadini.",
-      "IOApp": "App IO",
-      "sendMessage": "Invia messaggio",
-      "APIKey": "API Key"
-    },
-    "enabledOperators": {
-      "title": "Abilitazione agli operatori",
-      "description": "Operatori abilitati a questo Tipo Dovuto.",
-      "allOperatorsSelected": "Tutti gli operatori",
-      "selectedOperators": "Operatori selezionati",
-      "noSelectedOperators": "Senza operatori associati"
-    }
-  },
   "debtTypeCatalogDetail": {
     "IOAppMessageTemplate": "Template Messaggio su app IO",
     "additionalSettings": {
@@ -735,6 +713,33 @@
     "backToStart": "Torna alla sezione",
     "description": "La trovi nella sezione Catalogo Tipi dovuti, dove puoi modificarlo in qualsiasi momento.",
     "title": "Il tipo dovuto '{{paymentObject}}' è stato creato!"
+  },
+  "debtTypeDetail": {
+    "description": "Ecco i dettagli del Tipo dovuto",
+    "debtMainConfiguration": {
+      "title": "Configurazione generale",
+      "description": "Definizione del Tipo dovuto"
+    },
+    "debtConfiguration": {
+      "externalPaymentUrl": "URL pagamento esterno",
+      "xsdAttachment": "Allegato XSD"
+    },
+    "accounting": {
+      "description": "Parametri per la gestione delle entrate."
+    },
+    "messages": {
+      "description": "Notifiche digitale ai cittadini.",
+      "IOApp": "App IO",
+      "sendMessage": "Invia messaggio",
+      "APIKey": "API Key"
+    },
+    "enabledOperators": {
+      "title": "Abilitazione agli operatori",
+      "description": "Operatori abilitati a questo Tipo Dovuto.",
+      "allOperatorsSelected": "Tutti gli operatori",
+      "selectedOperators": "Operatori selezionati",
+      "noSelectedOperators": "Senza operatori associati"
+    }
   },
   "debtTypeOrgCreate": {
     "title": "Imposta nuovo Tipo dovuto",
@@ -984,6 +989,26 @@
     "searchRegulationId": "ID Regolamento",
     "searchReportingId": "ID Rendicontazione",
     "totalAmount": "Importo totale"
+  },
+  "taxonomyPage": {
+    "APIUpdate": "Aggiornamento API",
+    "APIUpdateText": "Aggiorna per verificare la presenza di nuove API di PagoPA.",
+    "APIUpdateCTA": "Aggiorna",
+    "APIUpdateOK": "Aggiornamento pianificato. Abbiamo ricevuto la richiesta è stata pianificata correttamente, sarà eseguita a breve dal sistema.",
+    "taxonomyInfo": "Informazioni sulla tassonomia",
+    "dateInfo": "Validità",
+    "fields": {
+      "organizationType": "Codice tipo organizzazione",
+      "organizationTypeDescription": "Tipo organizzazione",
+      "macroAreaCode": "Codice macroarea",
+      "macroAreaName": "Macroarea",
+      "serviceTypeCode": "Codice tipo servizio",
+      "collectionReason": "Motivo riscossione",
+      "startDateValidity": "Data inizio validità",
+      "endDateOfValidity": "Data fine validità",
+      "serviceType": "Tipo Servizio",
+      "serviceTypeDescription": "Descrizione tipo servizio"
+    }
   },
   "telematicReceiptDetail": {
     "title": "Dettaglio Ricevuta Telematica"

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -1004,6 +1004,7 @@
     "APIUpdateText": "Aggiorna per verificare la presenza di nuove API di PagoPA.",
     "APIUpdateCTA": "Aggiorna",
     "APIUpdateOK": "Aggiornamento pianificato. Abbiamo ricevuto la richiesta è stata pianificata correttamente, sarà eseguita a breve dal sistema.",
+    "APIUpdateKO": "Aggiornamento non riuscito. Il sistema non è stato in grado di pianificare l’aggiornamento.",
     "taxonomyInfo": "Informazioni sulla tassonomia",
     "dateInfo": "Validità",
     "fields": {


### PR DESCRIPTION
This PR add a main wrapper called "Backoffice" to some useful admin pages (only for superadmin).
The first part of this work is about "Taxonomy".

#### List of Changes
- add backoffice and taxonomy nav items to the sidebar
- add new routes for taxonomy main page and detail
- the first version of Taxonomy home as only the action card with the call of "sync procedure"
- add a detail page for a single voice of a taxonomy detail
- add tests

#### Motivation and Context
We have a new section to manage Taxonomy. This PR solves the JIRA tasks #P4ADEV-2900 and #P4ADEV-2903 

#### How Has This Been Tested?
- visual tests
- unit tests


#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
