### PR TITLE
fix: [P4ADEV-3010] Generic Pages titles fix

### DIFF
--- a/src/routes/UtilityPages/genericError.tsx
+++ b/src/routes/UtilityPages/genericError.tsx
@@ -44,7 +44,12 @@ export const GenericErrorPage = () => {
             sx={{ fontSize: 60, color: theme.palette.error.dark }}
           />
         }
-        title={String(t(pageConfig?.title, i18nParams))}
+        title={String(
+          t(pageConfig?.title, {
+            ...i18nParams,
+            interpolation: { escapeValue: false }
+          })
+        )}
         description={t(pageConfig?.description)}
         buttonConfig={buttonConfig}
       />

--- a/src/routes/UtilityPages/success.tsx
+++ b/src/routes/UtilityPages/success.tsx
@@ -43,7 +43,12 @@ export const SuccessPage = () => {
             sx={{ fontSize: 60, color: theme.palette.secondary.main }}
           />
         }
-        title={String(t(pageConfig?.title, i18nParams))}
+        title={String(
+          t(pageConfig?.title, {
+            ...i18nParams,
+            interpolation: { escapeValue: false }
+          })
+        )}
         description={t(pageConfig?.description)}
         buttonConfig={buttonConfig}
       />


### PR DESCRIPTION
This FIX intends to render the Title field in "utility pages" without escaping special chars.

#### List of Changes
- Add interpolation options to i18n params 

#### Motivation and Context
Render the title more "human friendly"

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
