### PR TITLE
feat: [P4ADEV-3037]  edit pd wizard draft to unpaid

### DIFF
--- a/src/components/Wizard/WizardStepButtons.test.tsx
+++ b/src/components/Wizard/WizardStepButtons.test.tsx
@@ -208,4 +208,66 @@ describe('WizardStepButtons', () => {
     expect(screen.getByText('Salva bozza')).toBeInTheDocument();
     fireEvent.click(screen.getByText('Salva bozza'));
   });
+
+  it('renders Save Draft button with text variant when showSaveDraftIcon is true', () => {
+    const onNext = vi.fn();
+    const onBack = vi.fn();
+    const onSaveDraft = vi.fn();
+
+    render(
+      <WizardStepButtons
+        onNext={onNext}
+        onBack={onBack}
+        onSaveDraft={onSaveDraft}
+        showSaveDraft={true}
+        showSaveDraftIcon={true}
+      />
+    );
+
+    const saveDraftButton = screen.getByText('Salva bozza');
+    expect(saveDraftButton).toBeInTheDocument();
+    // Verifica che abbia la classe per il variant="text" (senza bordo)
+    expect(saveDraftButton.closest('button')).toHaveClass('MuiButton-text');
+  });
+
+  it('renders Save Draft button with outlined variant when showSaveDraftIcon is false', () => {
+    const onNext = vi.fn();
+    const onBack = vi.fn();
+    const onSaveDraft = vi.fn();
+
+    render(
+      <WizardStepButtons
+        onNext={onNext}
+        onBack={onBack}
+        onSaveDraft={onSaveDraft}
+        showSaveDraft={true}
+        showSaveDraftIcon={false}
+      />
+    );
+
+    const saveDraftButton = screen.getByText('Salva bozza');
+    expect(saveDraftButton).toBeInTheDocument();
+    // Verifica che abbia la classe per il variant="outlined" (con bordo)
+    expect(saveDraftButton.closest('button')).toHaveClass('MuiButton-outlined');
+  });
+
+  it('renders Save Draft button with default text variant when showSaveDraftIcon is not specified', () => {
+    const onNext = vi.fn();
+    const onBack = vi.fn();
+    const onSaveDraft = vi.fn();
+
+    render(
+      <WizardStepButtons
+        onNext={onNext}
+        onBack={onBack}
+        onSaveDraft={onSaveDraft}
+        showSaveDraft={true}
+      />
+    );
+
+    const saveDraftButton = screen.getByText('Salva bozza');
+    expect(saveDraftButton).toBeInTheDocument();
+    // Di default showSaveDraftIcon è true, quindi dovrebbe usare variant="text"
+    expect(saveDraftButton.closest('button')).toHaveClass('MuiButton-text');
+  });
 });

--- a/src/components/Wizard/WizardStepButtons.test.tsx
+++ b/src/components/Wizard/WizardStepButtons.test.tsx
@@ -226,7 +226,6 @@ describe('WizardStepButtons', () => {
 
     const saveDraftButton = screen.getByText('Salva bozza');
     expect(saveDraftButton).toBeInTheDocument();
-    // Verifica che abbia la classe per il variant="text" (senza bordo)
     expect(saveDraftButton.closest('button')).toHaveClass('MuiButton-text');
   });
 
@@ -247,7 +246,6 @@ describe('WizardStepButtons', () => {
 
     const saveDraftButton = screen.getByText('Salva bozza');
     expect(saveDraftButton).toBeInTheDocument();
-    // Verifica che abbia la classe per il variant="outlined" (con bordo)
     expect(saveDraftButton.closest('button')).toHaveClass('MuiButton-outlined');
   });
 
@@ -267,7 +265,6 @@ describe('WizardStepButtons', () => {
 
     const saveDraftButton = screen.getByText('Salva bozza');
     expect(saveDraftButton).toBeInTheDocument();
-    // Di default showSaveDraftIcon è true, quindi dovrebbe usare variant="text"
     expect(saveDraftButton.closest('button')).toHaveClass('MuiButton-text');
   });
 });

--- a/src/components/Wizard/WizardStepButtons.tsx
+++ b/src/components/Wizard/WizardStepButtons.tsx
@@ -46,7 +46,7 @@ const WizardStepButtons = ({
       <Box display="flex" gap={4}>
         {showSaveDraft && (
           <Button
-            variant="outlined"
+            variant={showSaveDraftIcon ? 'text' : 'outlined'}
             onClick={onSaveDraft}
             disabled={disableSaveDraft}
             startIcon={showSaveDraftIcon ? <Save /> : undefined}

--- a/src/components/Wizard/WizardStepButtons.tsx
+++ b/src/components/Wizard/WizardStepButtons.tsx
@@ -13,6 +13,7 @@ type Props = {
   backLabel?: string;
   showSaveDraft?: boolean;
   saveDraftLabel?: string;
+  showSaveDraftIcon?: boolean;
 };
 
 const WizardStepButtons = ({
@@ -25,7 +26,8 @@ const WizardStepButtons = ({
   nextLabel = 'commons.continue',
   backLabel = 'commons.back',
   showSaveDraft = false,
-  saveDraftLabel = 'commons.saveDraft'
+  saveDraftLabel = 'commons.saveDraft',
+  showSaveDraftIcon = true
 }: Props) => {
   const { t } = useTranslation();
 
@@ -44,10 +46,10 @@ const WizardStepButtons = ({
       <Box display="flex" gap={4}>
         {showSaveDraft && (
           <Button
-            variant="naked"
+            variant="outlined"
             onClick={onSaveDraft}
             disabled={disableSaveDraft}
-            startIcon={<Save />}
+            startIcon={showSaveDraftIcon ? <Save /> : undefined}
           >
             {t(saveDraftLabel)}
           </Button>

--- a/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizardCompleted.tsx
+++ b/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizardCompleted.tsx
@@ -23,12 +23,16 @@ function DebtPositionCreateWizardCompleted() {
     description = '',
     status,
     debtPositionId,
-    isEditing = false
+    isEditing = false,
+    wasPublished = false
   } = location.state || {};
   const isDraft = status === DebtPositionStatus.DRAFT;
 
   const getTitleTranslationKey = (): string => {
     if (isEditing) {
+      if (wasPublished) {
+        return 'debtPositionCreateWizardCompleted.title';
+      }
       return isDraft
         ? 'debtPositionCreateWizardCompleted.editDraft'
         : 'debtPositionCreateWizardCompleted.edit';
@@ -39,6 +43,9 @@ function DebtPositionCreateWizardCompleted() {
   };
 
   const getDescriptionTranslationKey = (): string => {
+    if (isEditing && wasPublished) {
+      return 'debtPositionCreateWizardCompleted.description';
+    }
     return isDraft
       ? 'debtPositionCreateWizardCompleted.descriptionDraft'
       : 'debtPositionCreateWizardCompleted.description';
@@ -157,7 +164,7 @@ function DebtPositionCreateWizardCompleted() {
         >
           {t(translationKeys.backToStart)}
         </Button>
-        {isDraft ? (
+        {isDraft && !wasPublished ? (
           <Button
             role="button"
             variant="contained"

--- a/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizardCompleted.tsx
+++ b/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizardCompleted.tsx
@@ -12,6 +12,90 @@ import debtPositions from '../../api/debtPositions';
 import utils from '../../utils';
 import { downloadBlob } from '../../utils/download';
 
+type DebtPositionCompletionState = {
+  readonly description?: string;
+  readonly status?: DebtPositionStatus;
+  readonly debtPositionId?: number;
+  readonly isEditing?: boolean;
+  readonly wasPublished?: boolean;
+};
+
+enum CompletionScenario {
+  CREATION_DRAFT = 'CREATION_DRAFT',
+  CREATION_PUBLISHED = 'CREATION_PUBLISHED',
+  EDIT_SAVED = 'EDIT_SAVED',
+  EDIT_PUBLISHED = 'EDIT_PUBLISHED'
+}
+
+type ScenarioConfig = {
+  readonly titleKey: string;
+  readonly descriptionKey: string;
+  readonly showDownload: boolean;
+  readonly showView: boolean;
+};
+
+const SCENARIO_CONFIG: Record<CompletionScenario, ScenarioConfig> = {
+  [CompletionScenario.CREATION_DRAFT]: {
+    titleKey: 'debtPositionCreateWizardCompleted.draft',
+    descriptionKey: 'debtPositionCreateWizardCompleted.descriptionDraft',
+    showDownload: false,
+    showView: true
+  },
+  [CompletionScenario.CREATION_PUBLISHED]: {
+    titleKey: 'debtPositionCreateWizardCompleted.title',
+    descriptionKey: 'debtPositionCreateWizardCompleted.description',
+    showDownload: true,
+    showView: false
+  },
+  [CompletionScenario.EDIT_SAVED]: {
+    titleKey: 'debtPositionCreateWizardCompleted.edit',
+    descriptionKey: 'debtPositionCreateWizardCompleted.description',
+    showDownload: false,
+    showView: true
+  },
+  [CompletionScenario.EDIT_PUBLISHED]: {
+    titleKey: 'debtPositionCreateWizardCompleted.title',
+    descriptionKey: 'debtPositionCreateWizardCompleted.description',
+    showDownload: true,
+    showView: false
+  }
+} as const;
+
+const getCompletionScenario = (
+  isEditing: boolean,
+  isDraft: boolean,
+  wasPublished: boolean
+): CompletionScenario => {
+  if (isEditing) {
+    return wasPublished
+      ? CompletionScenario.EDIT_PUBLISHED
+      : CompletionScenario.EDIT_SAVED;
+  }
+  return isDraft
+    ? CompletionScenario.CREATION_DRAFT
+    : CompletionScenario.CREATION_PUBLISHED;
+};
+
+// Type guard per validazione runtime
+const isValidCompletionState = (
+  state: unknown
+): state is DebtPositionCompletionState => {
+  if (!state || typeof state !== 'object') return false;
+
+  const s = state as Record<string, unknown>;
+
+  return (
+    (s.description === undefined || typeof s.description === 'string') &&
+    (s.status === undefined ||
+      Object.values(DebtPositionStatus).includes(
+        s.status as DebtPositionStatus
+      )) &&
+    (s.debtPositionId === undefined || typeof s.debtPositionId === 'number') &&
+    (s.isEditing === undefined || typeof s.isEditing === 'boolean') &&
+    (s.wasPublished === undefined || typeof s.wasPublished === 'boolean')
+  );
+};
+
 function DebtPositionCreateWizardCompleted() {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -19,41 +103,38 @@ function DebtPositionCreateWizardCompleted() {
   const deployPath = config.deployPath;
   const { state } = useStore();
   const organizationId = Number(state[STATE.ORGANIZATION_ID]);
+  const validatedState: DebtPositionCompletionState = isValidCompletionState(
+    location.state
+  )
+    ? location.state
+    : {
+        description: '',
+        status: undefined,
+        debtPositionId: undefined,
+        isEditing: false,
+        wasPublished: false
+      };
+
   const {
     description = '',
     status,
     debtPositionId,
     isEditing = false,
     wasPublished = false
-  } = location.state || {};
+  } = validatedState;
+
   const isDraft = status === DebtPositionStatus.DRAFT;
 
-  const getTitleTranslationKey = (): string => {
-    if (isEditing) {
-      if (wasPublished) {
-        return 'debtPositionCreateWizardCompleted.title';
-      }
-      return isDraft
-        ? 'debtPositionCreateWizardCompleted.editDraft'
-        : 'debtPositionCreateWizardCompleted.edit';
-    }
-    return isDraft
-      ? 'debtPositionCreateWizardCompleted.draft'
-      : 'debtPositionCreateWizardCompleted.title';
-  };
-
-  const getDescriptionTranslationKey = (): string => {
-    if (isEditing && wasPublished) {
-      return 'debtPositionCreateWizardCompleted.description';
-    }
-    return isDraft
-      ? 'debtPositionCreateWizardCompleted.descriptionDraft'
-      : 'debtPositionCreateWizardCompleted.description';
-  };
+  const currentScenario = getCompletionScenario(
+    isEditing,
+    isDraft,
+    wasPublished
+  );
+  const scenarioConfig = SCENARIO_CONFIG[currentScenario];
 
   const translationKeys = {
-    title: getTitleTranslationKey(),
-    description: getDescriptionTranslationKey(),
+    title: scenarioConfig.titleKey,
+    description: scenarioConfig.descriptionKey,
     viewDebtPosition: 'debtPositionCreateWizardCompleted.viewDebtPosition',
     backToStart: 'debtPositionCreateWizardCompleted.backToStart',
     downloadDebtPosition:
@@ -164,7 +245,7 @@ function DebtPositionCreateWizardCompleted() {
         >
           {t(translationKeys.backToStart)}
         </Button>
-        {isDraft && !wasPublished ? (
+        {scenarioConfig.showView ? (
           <Button
             role="button"
             variant="contained"

--- a/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizardCompleted.tsx
+++ b/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizardCompleted.tsx
@@ -76,7 +76,7 @@ const getCompletionScenario = (
     : CompletionScenario.CREATION_PUBLISHED;
 };
 
-// Type guard per validazione runtime
+// Type guard for runtime validation
 const isValidCompletionState = (
   state: unknown
 ): state is DebtPositionCompletionState => {

--- a/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizardCompleted.tsx
+++ b/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizardCompleted.tsx
@@ -67,7 +67,7 @@ const getCompletionScenario = (
   wasPublished: boolean
 ): CompletionScenario => {
   if (isEditing) {
-    return wasPublished
+    return wasPublished || !isDraft
       ? CompletionScenario.EDIT_PUBLISHED
       : CompletionScenario.EDIT_SAVED;
   }

--- a/src/routes/DebtPositionCreateWizard/components/Step/Step3.test.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step/Step3.test.tsx
@@ -43,7 +43,9 @@ vi.mock('react-i18next', () => ({
           'Multiple Beneficiaries',
         'debtPositionCreateWizard.step3.error.subtitle':
           'Error creating debt position',
-        'commons.create': 'Create'
+        'commons.create': 'Create',
+        'commons.save': 'Save',
+        'commons.saveDraft': 'Save Draft'
       };
       return translations[key] || key;
     }
@@ -70,7 +72,8 @@ vi.mock('../../../../store/GlobalStore', () => ({
 vi.mock('../../../../api/debtPositions', () => ({
   default: {
     createDebtPosition: vi.fn(),
-    manageDebtPositionInstallments: vi.fn()
+    manageDebtPositionInstallments: vi.fn(),
+    getDebtPositionDetail: vi.fn()
   }
 }));
 
@@ -220,6 +223,7 @@ describe('Step3 Component', () => {
   const mockOnBack = vi.fn();
   const mockCreateDebtPosition = vi.fn();
   const mockManageDebtPositionInstallments = vi.fn();
+  const mockGetDebtPositionDetail = vi.fn();
 
   const initialData: Step3Data = {
     paymentObject: { value: 'Test Payment', readonly: false },
@@ -270,6 +274,18 @@ describe('Step3 Component', () => {
       >
     ).mockReturnValue({
       mutate: mockManageDebtPositionInstallments
+    });
+
+    (
+      debtPositionsApi.getDebtPositionDetail as unknown as ReturnType<
+        typeof vi.fn
+      >
+    ).mockReturnValue({
+      data: null
+    });
+
+    mockGetDebtPositionDetail.mockReturnValue({
+      data: null
     });
   });
 
@@ -1267,5 +1283,746 @@ describe('Step3 Component', () => {
 
     expect(amountInput).toBeInTheDocument();
     expect(amountInput).toHaveValue('100,00');
+  });
+
+  describe('getSaveDraftHandler function', () => {
+    it('should return undefined for UNPAID/EXPIRED in edit mode (no save draft option)', () => {
+      render(
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: '/debt-position-edit',
+              state: { debtPositionId: 123 }
+            }
+          ]}
+        >
+          <Step3
+            data={initialData}
+            setData={mockSetData}
+            onNext={mockOnNext}
+            onBack={mockOnBack}
+            step1Data={mockStep1Data}
+            step2Data={mockStep2Data}
+            isEditing={true}
+          />
+        </MemoryRouter>
+      );
+
+      // In edit mode per UNPAID/EXPIRED, il save draft button non dovrebbe essere visibile
+      expect(screen.queryByTestId('save-draft-button')).not.toBeInTheDocument();
+    });
+
+    it('should show save draft button for DRAFT in edit mode', async () => {
+      // Mock per DRAFT debt position
+      (
+        debtPositionsApi.getDebtPositionDetail as unknown as ReturnType<
+          typeof vi.fn
+        >
+      ).mockReturnValue({
+        data: {
+          status: DebtPositionStatus.DRAFT,
+          paymentOptions: [{ paymentOptionId: 'payment-123' }]
+        }
+      });
+
+      render(
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: '/debt-position-edit',
+              state: { debtPositionId: 123 }
+            }
+          ]}
+        >
+          <Step3
+            data={initialData}
+            setData={mockSetData}
+            onNext={mockOnNext}
+            onBack={mockOnBack}
+            step1Data={mockStep1Data}
+            step2Data={mockStep2Data}
+            isEditing={true}
+          />
+        </MemoryRouter>
+      );
+
+      // Per DRAFT in edit dovrebbe mostrare il save draft button
+      await waitFor(() => {
+        expect(screen.getByTestId('save-draft-button')).toBeInTheDocument();
+      });
+    });
+
+    it('should show correct buttons for DRAFT in edit mode', async () => {
+      // Mock per DRAFT debt position
+      (
+        debtPositionsApi.getDebtPositionDetail as unknown as ReturnType<
+          typeof vi.fn
+        >
+      ).mockReturnValue({
+        data: {
+          status: DebtPositionStatus.DRAFT,
+          paymentOptions: [{ paymentOptionId: 'payment-123' }]
+        }
+      });
+
+      render(
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: '/debt-position-edit',
+              state: { debtPositionId: 123 }
+            }
+          ]}
+        >
+          <Step3
+            data={initialData}
+            setData={mockSetData}
+            onNext={mockOnNext}
+            onBack={mockOnBack}
+            step1Data={mockStep1Data}
+            step2Data={mockStep2Data}
+            isEditing={true}
+          />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('next-button')).toBeInTheDocument();
+        expect(screen.getByTestId('save-draft-button')).toBeInTheDocument();
+      });
+    });
+
+    it('should show save draft button in creation mode', async () => {
+      render(
+        <MemoryRouter>
+          <Step3
+            data={initialData}
+            setData={mockSetData}
+            onNext={mockOnNext}
+            onBack={mockOnBack}
+            step1Data={mockStep1Data}
+            step2Data={mockStep2Data}
+            isEditing={false}
+          />
+        </MemoryRouter>
+      );
+
+      expect(screen.getByTestId('save-draft-button')).toBeInTheDocument();
+      expect(screen.getByTestId('next-button')).toBeInTheDocument();
+    });
+  });
+
+  describe('Edit mode error handling', () => {
+    it('should handle missing paymentOptionId in edit mode', async () => {
+      (
+        debtPositionsApi.getDebtPositionDetail as unknown as ReturnType<
+          typeof vi.fn
+        >
+      ).mockReturnValue({
+        data: {
+          status: DebtPositionStatus.DRAFT,
+          paymentOptions: [{ paymentOptionId: null }]
+        }
+      });
+
+      render(
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: '/debt-position-edit',
+              state: { debtPositionId: 123 }
+            }
+          ]}
+        >
+          <Step3
+            data={initialData}
+            setData={mockSetData}
+            onNext={mockOnNext}
+            onBack={mockOnBack}
+            step1Data={mockStep1Data}
+            step2Data={mockStep2Data}
+            isEditing={true}
+          />
+        </MemoryRouter>
+      );
+
+      const nextButton = screen.getByTestId('next-button');
+      fireEvent.click(nextButton);
+
+      await waitFor(() => {
+        expect(mockManageDebtPositionInstallments).not.toHaveBeenCalled();
+      });
+    });
+
+    it('should handle invalid debtPositionId in edit mode', async () => {
+      (
+        debtPositionsApi.getDebtPositionDetail as unknown as ReturnType<
+          typeof vi.fn
+        >
+      ).mockReturnValue({
+        data: {
+          status: DebtPositionStatus.DRAFT,
+          paymentOptions: [{ paymentOptionId: 'payment-123' }]
+        }
+      });
+
+      render(
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: '/debt-position-edit',
+              state: { debtPositionId: 'invalid-id' }
+            }
+          ]}
+        >
+          <Step3
+            data={initialData}
+            setData={mockSetData}
+            onNext={mockOnNext}
+            onBack={mockOnBack}
+            step1Data={mockStep1Data}
+            step2Data={mockStep2Data}
+            isEditing={true}
+          />
+        </MemoryRouter>
+      );
+
+      const nextButton = screen.getByTestId('next-button');
+      fireEvent.click(nextButton);
+
+      await waitFor(() => {
+        expect(mockManageDebtPositionInstallments).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('Button labels and visibility', () => {
+    it('should show correct button labels for DRAFT in edit mode', async () => {
+      (
+        debtPositionsApi.getDebtPositionDetail as unknown as ReturnType<
+          typeof vi.fn
+        >
+      ).mockReturnValue({
+        data: {
+          status: DebtPositionStatus.DRAFT,
+          paymentOptions: [{ paymentOptionId: 'payment-123' }]
+        }
+      });
+
+      render(
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: '/debt-position-edit',
+              state: { debtPositionId: 123 }
+            }
+          ]}
+        >
+          <Step3
+            data={initialData}
+            setData={mockSetData}
+            onNext={mockOnNext}
+            onBack={mockOnBack}
+            step1Data={mockStep1Data}
+            step2Data={mockStep2Data}
+            isEditing={true}
+          />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        const nextButton = screen.getByTestId('next-button');
+        expect(nextButton).toHaveTextContent('commons.create'); // Should show translation key
+
+        const saveDraftButton = screen.getByTestId('save-draft-button');
+        expect(saveDraftButton).toHaveTextContent('Save Draft'); // Should show "Save Draft"
+      });
+    });
+
+    it('should show correct button labels for UNPAID in edit mode', async () => {
+      (
+        debtPositionsApi.getDebtPositionDetail as unknown as ReturnType<
+          typeof vi.fn
+        >
+      ).mockReturnValue({
+        data: {
+          status: DebtPositionStatus.UNPAID,
+          paymentOptions: [{ paymentOptionId: 'payment-123' }]
+        }
+      });
+
+      render(
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: '/debt-position-edit',
+              state: { debtPositionId: 123 }
+            }
+          ]}
+        >
+          <Step3
+            data={initialData}
+            setData={mockSetData}
+            onNext={mockOnNext}
+            onBack={mockOnBack}
+            step1Data={mockStep1Data}
+            step2Data={mockStep2Data}
+            isEditing={true}
+          />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        const nextButton = screen.getByTestId('next-button');
+        expect(nextButton).toHaveTextContent('commons.save'); // Should show "Save" for UNPAID in edit
+
+        // Save draft button should not be visible for UNPAID
+        expect(
+          screen.queryByTestId('save-draft-button')
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Form data population in edit mode', () => {
+    it('should populate form fields when editing with actual data', async () => {
+      const dataWithActualValues: Step3Data = {
+        paymentObject: { value: 'Existing Payment Object', readonly: false },
+        paymentOption: { value: DebtPositionTypeEnum.SINGLE, readonly: false },
+        amount: { value: '150.50', readonly: false },
+        dueDate: { value: '2025-12-01', readonly: false },
+        isMultibeneficiary: { value: true, readonly: false },
+        beneficiaries: [
+          {
+            entityName: 'Test Entity',
+            amount: '150.50',
+            taxCode: 'TEST123',
+            remittance: 'Test remittance',
+            iban: 'IT60X0542811101000000123456',
+            taxonomyCode: 'TEST'
+          }
+        ],
+        installments: [],
+        flagMandatoryDueDate: false
+      };
+
+      render(
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: '/debt-position-edit',
+              state: { debtPositionId: 123 }
+            }
+          ]}
+        >
+          <Step3
+            data={dataWithActualValues}
+            setData={mockSetData}
+            onNext={mockOnNext}
+            onBack={mockOnBack}
+            step1Data={mockStep1Data}
+            step2Data={mockStep2Data}
+            isEditing={true}
+          />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByDisplayValue('Existing Payment Object')
+        ).toBeInTheDocument();
+        expect(screen.getByDisplayValue('150,50')).toBeInTheDocument();
+      });
+    });
+
+    it('should not populate form fields when editing without actual data', async () => {
+      const dataWithEmptyValues: Step3Data = {
+        paymentObject: { value: '', readonly: false },
+        paymentOption: { value: DebtPositionTypeEnum.SINGLE, readonly: false },
+        amount: { value: '', readonly: false },
+        dueDate: { value: '', readonly: false },
+        isMultibeneficiary: { value: false, readonly: false },
+        beneficiaries: [],
+        installments: [],
+        flagMandatoryDueDate: false
+      };
+
+      render(
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: '/debt-position-edit',
+              state: { debtPositionId: 123 }
+            }
+          ]}
+        >
+          <Step3
+            data={dataWithEmptyValues}
+            setData={mockSetData}
+            onNext={mockOnNext}
+            onBack={mockOnBack}
+            step1Data={mockStep1Data}
+            step2Data={mockStep2Data}
+            isEditing={true}
+          />
+        </MemoryRouter>
+      );
+
+      // I campi dovrebbero rimanere vuoti
+      await waitFor(() => {
+        const paymentObjectInput = screen.getByRole('textbox', {
+          name: /Payment Object/i
+        });
+        expect(paymentObjectInput).toHaveValue('');
+      });
+    });
+
+    it('should populate form fields with installments data', async () => {
+      const dataWithInstallments: Step3Data = {
+        paymentObject: { value: 'Installment Payment', readonly: false },
+        paymentOption: {
+          value: DebtPositionTypeEnum.INSTALLMENTS,
+          readonly: false
+        },
+        amount: { value: '300.00', readonly: false },
+        dueDate: { value: '', readonly: false },
+        isMultibeneficiary: { value: false, readonly: false },
+        beneficiaries: [],
+        installments: [
+          {
+            amount: '100.00',
+            dueDate: '2025-06-01',
+            remittance: 'First installment',
+            isMultibeneficiary: false,
+            beneficiaries: []
+          },
+          {
+            amount: '200.00',
+            dueDate: '2025-07-01',
+            remittance: 'Second installment',
+            isMultibeneficiary: false,
+            beneficiaries: []
+          }
+        ],
+        flagMandatoryDueDate: false
+      };
+
+      render(
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: '/debt-position-edit',
+              state: { debtPositionId: 123 }
+            }
+          ]}
+        >
+          <Step3
+            data={dataWithInstallments}
+            setData={mockSetData}
+            onNext={mockOnNext}
+            onBack={mockOnBack}
+            step1Data={mockStep1Data}
+            step2Data={mockStep2Data}
+            isEditing={true}
+          />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('installment-field')).toBeInTheDocument();
+      });
+    });
+
+    it('should handle date value as string in dueDate field', async () => {
+      const dataWithStringDate: Step3Data = {
+        paymentObject: { value: 'Payment with string date', readonly: false },
+        paymentOption: { value: DebtPositionTypeEnum.SINGLE, readonly: false },
+        amount: { value: '100.00', readonly: false },
+        dueDate: { value: '2025-06-15', readonly: false }, // String date
+        isMultibeneficiary: { value: false, readonly: false },
+        beneficiaries: [],
+        installments: [],
+        flagMandatoryDueDate: false
+      };
+
+      render(
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: '/debt-position-edit',
+              state: { debtPositionId: 123 }
+            }
+          ]}
+        >
+          <Step3
+            data={dataWithStringDate}
+            setData={mockSetData}
+            onNext={mockOnNext}
+            onBack={mockOnBack}
+            step1Data={mockStep1Data}
+            step2Data={mockStep2Data}
+            isEditing={true}
+          />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        const datePicker = screen.getByTestId('date-picker-input');
+        expect(datePicker).toHaveValue('2025-06-15');
+      });
+    });
+  });
+
+  describe('Multi-beneficiary initialization logic', () => {
+    it('should initialize beneficiaries when multi-beneficiary is enabled and no beneficiaries exist', async () => {
+      render(
+        <MemoryRouter>
+          <Step3
+            data={{
+              ...initialData,
+              isMultibeneficiary: { value: false, readonly: false }
+            }}
+            setData={mockSetData}
+            onNext={mockOnNext}
+            onBack={mockOnBack}
+            step1Data={mockStep1Data}
+            step2Data={mockStep2Data}
+            isEditing={false}
+          />
+        </MemoryRouter>
+      );
+
+      const multiBeneficiarySwitch = screen.getByRole('checkbox', {
+        name: /Multiple Beneficiaries/i
+      });
+
+      fireEvent.click(multiBeneficiarySwitch);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('beneficiary-field')).toBeInTheDocument();
+      });
+    });
+
+    it('should not initialize beneficiaries when in editing mode with already set up data', async () => {
+      const dataWithExistingBeneficiaries: Step3Data = {
+        ...initialData,
+        isMultibeneficiary: { value: true, readonly: false },
+        beneficiaries: [
+          {
+            entityName: 'Existing Entity',
+            amount: '100.00',
+            taxCode: 'EXISTING123',
+            remittance: 'Existing remittance',
+            iban: 'IT60X0542811101000000123456',
+            taxonomyCode: 'EXISTING'
+          }
+        ]
+      };
+
+      render(
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: '/debt-position-edit',
+              state: { debtPositionId: 123 }
+            }
+          ]}
+        >
+          <Step3
+            data={dataWithExistingBeneficiaries}
+            setData={mockSetData}
+            onNext={mockOnNext}
+            onBack={mockOnBack}
+            step1Data={mockStep1Data}
+            step2Data={mockStep2Data}
+            isEditing={true}
+          />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('beneficiary-field')).toBeInTheDocument();
+      });
+    });
+
+    it('should clear beneficiaries when multi-beneficiary is disabled', async () => {
+      render(
+        <MemoryRouter>
+          <Step3
+            data={{
+              ...initialData,
+              isMultibeneficiary: { value: true, readonly: false }
+            }}
+            setData={mockSetData}
+            onNext={mockOnNext}
+            onBack={mockOnBack}
+            step1Data={mockStep1Data}
+            step2Data={mockStep2Data}
+            isEditing={false}
+          />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('beneficiary-field')).toBeInTheDocument();
+      });
+
+      const multiBeneficiarySwitch = screen.getByRole('checkbox', {
+        name: /Multiple Beneficiaries/i
+      });
+
+      fireEvent.click(multiBeneficiarySwitch);
+
+      await waitFor(() => {
+        expect(
+          screen.queryByTestId('beneficiary-field')
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Additional edge cases', () => {
+    it('should handle beneficiary validation failure correctly', async () => {
+      vi.spyOn(paymentUtility, 'validateMultiBeneficiary').mockReturnValue(
+        false
+      );
+
+      render(
+        <MemoryRouter>
+          <Step3
+            data={{
+              ...initialData,
+              isMultibeneficiary: { value: true, readonly: false }
+            }}
+            setData={mockSetData}
+            onNext={mockOnNext}
+            onBack={mockOnBack}
+            step1Data={mockStep1Data}
+            step2Data={mockStep2Data}
+            isEditing={false}
+          />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('beneficiary-field')).toBeInTheDocument();
+      });
+
+      const nextButton = screen.getByTestId('next-button');
+      fireEvent.click(nextButton);
+
+      await waitFor(() => {
+        expect(mockCreateDebtPosition).not.toHaveBeenCalled();
+      });
+    });
+
+    it('should handle form validation failure correctly', async () => {
+      render(
+        <MemoryRouter>
+          <Step3
+            data={{
+              ...initialData,
+              paymentObject: { value: '', readonly: false } // Empty required field
+            }}
+            setData={mockSetData}
+            onNext={mockOnNext}
+            onBack={mockOnBack}
+            step1Data={mockStep1Data}
+            step2Data={mockStep2Data}
+            isEditing={false}
+          />
+        </MemoryRouter>
+      );
+
+      const nextButton = screen.getByTestId('next-button');
+      fireEvent.click(nextButton);
+
+      await waitFor(() => {
+        expect(mockCreateDebtPosition).not.toHaveBeenCalled();
+      });
+    });
+
+    it('should handle installments modification correctly', async () => {
+      vi.spyOn(
+        installmentValidation,
+        'syncInstallmentBeneficiaries'
+      ).mockReturnValueOnce({
+        installments: [
+          {
+            amount: '100',
+            dueDate: '2025-07-15',
+            remittance: 'Modified payment',
+            isMultibeneficiary: false,
+            beneficiaries: []
+          }
+        ],
+        modified: true
+      });
+
+      vi.spyOn(
+        installmentValidation,
+        'validateInstallments'
+      ).mockReturnValueOnce({
+        hasInvalidBeneficiaries: false,
+        hasInvalidPaymentFields: false,
+        hasInvalidAmounts: false,
+        hasEmptyRemittance: false
+      });
+
+      render(
+        <MemoryRouter>
+          <Step3
+            data={{
+              ...initialData,
+              paymentOption: {
+                value: DebtPositionTypeEnum.INSTALLMENTS,
+                readonly: false
+              }
+            }}
+            setData={mockSetData}
+            onNext={mockOnNext}
+            onBack={mockOnBack}
+            step1Data={mockStep1Data}
+            step2Data={mockStep2Data}
+            isEditing={false}
+          />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('installment-field')).toBeInTheDocument();
+      });
+
+      const nextButton = screen.getByTestId('next-button');
+      fireEvent.click(nextButton);
+
+      await waitFor(() => {
+        expect(mockCreateDebtPosition).toHaveBeenCalled();
+      });
+    });
+
+    it('should handle amount formatting on blur with invalid number', async () => {
+      render(
+        <MemoryRouter>
+          <Step3
+            data={initialData}
+            setData={mockSetData}
+            onNext={mockOnNext}
+            onBack={mockOnBack}
+            step1Data={mockStep1Data}
+            step2Data={mockStep2Data}
+            isEditing={false}
+          />
+        </MemoryRouter>
+      );
+
+      const amountInput = screen.getByRole('textbox', { name: /Amount/i });
+
+      fireEvent.change(amountInput, { target: { value: 'invalid-number' } });
+      fireEvent.blur(amountInput);
+
+      // Should not throw error and maintain the invalid value
+      expect(amountInput).toHaveValue('');
+    });
   });
 });

--- a/src/routes/DebtPositionCreateWizard/components/Step/Step3.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step/Step3.tsx
@@ -515,6 +515,19 @@ const Step3 = ({
     return { isValid: true, syncedInstallments };
   };
 
+  const getSaveDraftHandler = (): (() => void) | undefined => {
+    if (isDraftInEdit) {
+      // DRAFT in edit: save without publishing
+      return handleSubmit((values) => onSubmit(values, false, false));
+    }
+    if (!isEditing) {
+      // Creation mode: save as draft
+      return handleSubmit((values) => onSubmit(values, true));
+    }
+    // UNPAID/EXPIRED in edit: no save draft option
+    return undefined;
+  };
+
   const onSubmit = async (
     values: Step3FormValues,
     isDraft = false,
@@ -908,13 +921,7 @@ const Step3 = ({
         onNext={handleSubmit((values) =>
           onSubmit(values, false, isDraftInEdit)
         )}
-        onSaveDraft={
-          isDraftInEdit
-            ? () => handleSubmit((values) => onSubmit(values, false, false))()
-            : !isEditing
-              ? () => handleSubmit((values) => onSubmit(values, true))()
-              : undefined
-        }
+        onSaveDraft={getSaveDraftHandler()}
         disableNext={false}
         nextLabel={getNextButtonLabel()}
         showSaveDraft={isDraftInEdit || !isEditing}

--- a/src/routes/DebtPositionCreateWizard/components/Step/Step3.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step/Step3.tsx
@@ -187,6 +187,19 @@ const Step3 = ({
   // Ref to avoid executing the setup logic more than once
   const hasSetupStep3Data = useRef(false);
 
+  // Ref to track if the last action was publish (for correct title in completed page)
+  const lastActionWasPublish = useRef(false);
+
+  const isDraftInEdit =
+    isEditing && debtPositionDetail?.status === DebtPositionStatus.DRAFT;
+
+  const getNextButtonLabel = (): string => {
+    if (isEditing) {
+      return isDraftInEdit ? 'commons.create' : 'commons.save';
+    }
+    return 'commons.create';
+  };
+
   const { mutate: createDebtPosition } = debtPositionsApi.createDebtPosition(
     (paymentObject) => {
       navigate(PageRoutes.DEBT_POSITION_CREATE_WIZARD_COMPLETED, {
@@ -209,7 +222,8 @@ const Step3 = ({
         navigate(PageRoutes.DEBT_POSITION_CREATE_WIZARD_COMPLETED, {
           state: {
             ...response,
-            isEditing: true
+            isEditing: true,
+            wasPublished: lastActionWasPublish.current
           },
           replace: true
         });
@@ -501,7 +515,11 @@ const Step3 = ({
     return { isValid: true, syncedInstallments };
   };
 
-  const onSubmit = async (values: Step3FormValues, isDraft = false) => {
+  const onSubmit = async (
+    values: Step3FormValues,
+    isDraft = false,
+    shouldPublish = false
+  ) => {
     // Check due date field if mandatory
     if (!isInstallment && values.flagMandatoryDueDate) {
       if (!values.dueDate.value) {
@@ -589,10 +607,14 @@ const Step3 = ({
           step1Data
         );
 
+        const shouldPublishPosition = shouldPublish;
+        lastActionWasPublish.current = shouldPublishPosition && isDraftInEdit;
+
         manageInstallments({
           organizationId,
           debtPositionId: Number(debtPositionId),
-          body: manageBody
+          body: manageBody,
+          publish: shouldPublishPosition
         });
       } catch (error) {
         console.error('Error converting form data:', error);
@@ -883,12 +905,21 @@ const Step3 = ({
       )}
       <WizardStepButtons
         onBack={onBack}
-        onNext={handleSubmit((values) => onSubmit(values, false))}
-        onSaveDraft={() => handleSubmit((values) => onSubmit(values, true))()}
+        onNext={handleSubmit((values) =>
+          onSubmit(values, false, isDraftInEdit)
+        )}
+        onSaveDraft={
+          isDraftInEdit
+            ? () => handleSubmit((values) => onSubmit(values, false, false))()
+            : !isEditing
+              ? () => handleSubmit((values) => onSubmit(values, true))()
+              : undefined
+        }
         disableNext={false}
-        nextLabel={isEditing ? 'commons.save' : 'commons.create'}
-        showSaveDraft={!isEditing}
-        saveDraftLabel="commons.saveDraft"
+        nextLabel={getNextButtonLabel()}
+        showSaveDraft={isDraftInEdit || !isEditing}
+        saveDraftLabel={isDraftInEdit ? 'commons.save' : 'commons.saveDraft'}
+        showSaveDraftIcon={!isDraftInEdit}
       />
     </form>
   );


### PR DESCRIPTION
In this PR, I added the ability to convert a debtPosition from draft to unpaid status.
When a debtPosition is in draft, clicking on "Edit" redirects the user to the pre-filled wizard.
In step 3 of the wizard, the user can choose whether to save the changes or save and publish the debtPosition

#### List of Changes

Added a publish boolean parameter to the update debtPosition API

In Step 3 of the wizard, if the debtPosition is in draft status:

 - A "Save" button is shown to save changes without publishing

 - A "Create" button is available to save changes and convert the debtPosition to unpaid status


#### How Has This Been Tested?

-visual testing
-unit tests


#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:



- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
