### PR TITLE
feat: [P4ADEV-3103] At least one filter for "flows" pages

### DIFF
--- a/src/components/ExportFlowOverview/ExportFlowOverview.tsx
+++ b/src/components/ExportFlowOverview/ExportFlowOverview.tsx
@@ -23,6 +23,7 @@ import { downloadBlob } from '../../utils/download';
 import EmptyDataGrid from '../EmptyDataGrid/EmptyDataGrid';
 import { formatDateTime } from '../../utils/formatters';
 import utils from '../../utils';
+import { ReactNode, useEffect, useState } from 'react';
 
 export type ExportFlowOverviewProps = {
   routingCategory: string;
@@ -57,7 +58,6 @@ const ExportFlowOverview = ({
     applyFilters,
     handleDateFromChange,
     handleDateToChange,
-    hasActiveFilters,
     sortModel,
     handleSortModelChange,
     handlePaginationChange
@@ -65,8 +65,19 @@ const ExportFlowOverview = ({
     exportFileType: exportFileTypes
   });
 
-  const { data, isLoading } = getExportFiles(organizationId, appliedFilters);
+  const { data, isLoading, isError } = getExportFiles(
+    organizationId,
+    appliedFilters
+  );
   const isEmptyData = !data?.content || data.content.length === 0;
+
+  useEffect(() => {
+    if (isError) {
+      setError(true);
+    } else {
+      setError(false);
+    }
+  }, [isError]);
 
   const getFile = getExportFile(organizationId);
 
@@ -159,6 +170,18 @@ const ExportFlowOverview = ({
     }
   ];
 
+  const [error, setError] = useState<boolean>(false);
+  const errorMessage: ReactNode = (
+    <Typography
+      variant="body2"
+      color="error"
+      mt={2}
+      data-testid="explort-error-text"
+    >
+      {t('commons.filters.atLeastOneFilter')}
+    </Typography>
+  );
+
   return (
     <>
       <TitleComponent
@@ -179,7 +202,7 @@ const ExportFlowOverview = ({
             <Typography variant="h4">{sectionTitle}</Typography>
           </Box>
         )}
-
+        {error && errorMessage}
         <FilterContainer
           items={[
             {
@@ -215,8 +238,7 @@ const ExportFlowOverview = ({
               type: COMPONENT_TYPE.button,
               label: t('commons.filters.filterResults'),
               gridWidth: 1,
-              onClick: applyFilters,
-              disabled: !hasActiveFilters()
+              onClick: applyFilters
             }
           ]}
         />

--- a/src/components/Reporting/Reporting.tsx
+++ b/src/components/Reporting/Reporting.tsx
@@ -1,25 +1,41 @@
 import SearchCard from '../SearchCard/SearchCard';
 import ActionCard from '../ActionCard/ActionCard';
 import { FileUpload } from '@mui/icons-material';
-import { Grid } from '@mui/material';
+import { Grid, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import TitleComponent from '../TitleComponent/TitleComponent';
 import { generatePath, useNavigate } from 'react-router';
 import { PageRoutes } from '../../routes';
-import { useCallback, useState } from 'react';
+import { ReactNode, useCallback, useState } from 'react';
 import { BaseFilterValues, FilterFieldValue } from '../../models/Filters';
+import { noFilterSetted } from '../../utils/filtersValidation';
 
 export const Reporting = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [filters, setFilters] = useState<Array<BaseFilterValues>>([{}]);
+  const [error, setError] = useState<boolean>(false);
+  const errorMessage: ReactNode = (
+    <Typography
+      variant="body2"
+      color="error"
+      mt={2}
+      data-testid="reporting-error-text"
+    >
+      {t('commons.filters.atLeastOneFilter')}
+    </Typography>
+  );
 
   const navigateToResults = useCallback(() => {
-    navigate(PageRoutes.REPORTING_SEARCH_RESULTS, {
-      state: {
-        filters: filters[0]
-      }
-    });
+    if (!noFilterSetted(filters[0])) {
+      navigate(PageRoutes.REPORTING_SEARCH_RESULTS, {
+        state: {
+          filters: filters[0]
+        }
+      });
+    } else {
+      setError(true);
+    }
   }, [0, filters, navigate]);
 
   const resetCurrentFilters = useCallback(() => {
@@ -57,16 +73,19 @@ export const Reporting = () => {
               filterContext="REPORTING"
               filterValues={filters[0]}
               onFilterChange={handleFilterChange}
+              render={error && errorMessage}
               button={[
                 {
                   label: t('commons.filters.remove'),
                   variant: 'outlined',
-                  onClick: resetCurrentFilters
+                  onClick: resetCurrentFilters,
+                  id: 'reporting-reset-btn'
                 },
                 {
                   label: t('commons.filters.filterResults'),
                   variant: 'contained',
-                  onClick: navigateToResults
+                  onClick: navigateToResults,
+                  id: 'reporting-search-btn'
                 }
               ]}
             />

--- a/src/components/ReportingSearchResults/ReportingSearchResults.tsx
+++ b/src/components/ReportingSearchResults/ReportingSearchResults.tsx
@@ -1,6 +1,6 @@
 import { useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Grid, Stack, useTheme } from '@mui/material';
+import { Grid, Stack, Typography, useTheme } from '@mui/material';
 import TitleComponent from '../TitleComponent/TitleComponent';
 import SearchResultsDataGrid from './ReportingDataGrid';
 import { BaseFilterValues } from '../../models/Filters';
@@ -10,6 +10,8 @@ import useReportingSearch, {
 } from '../../hooks/useReportingSearch';
 import useReportingFilters from '../../hooks/useReportingFilters';
 import FilterContainer from '../FilterContainer/FilterContainer';
+import { ReactNode, useState } from 'react';
+import { noFilterSetted } from '../../utils/filtersValidation';
 
 export type LocationState = {
   filters: BaseFilterValues;
@@ -18,6 +20,13 @@ export type LocationState = {
 const ReportingSearchResults = () => {
   const theme = useTheme();
   const { t } = useTranslation();
+  const [error, setError] = useState(false);
+
+  const errorMessage: ReactNode = (
+    <Typography variant="body2" color="error" data-testid="filters-error-text">
+      {t('commons.filters.atLeastOneFilter')}
+    </Typography>
+  );
 
   const { state } = useLocation() as { state?: LocationState };
 
@@ -27,10 +36,17 @@ const ReportingSearchResults = () => {
     initialFilters: initialFilters as ReportingFilters
   });
 
-  const { filters } = useReportingFilters({
-    onFilter: () => {
+  const runSearch = () => {
+    if (!noFilterSetted(reporting.filterValues)) {
       reporting.applyFilters();
+      setError(false);
+    } else {
+      setError(true);
     }
+  };
+
+  const { filters } = useReportingFilters({
+    onFilter: runSearch
   });
 
   return (
@@ -40,6 +56,7 @@ const ReportingSearchResults = () => {
         description={t('reportingSearchResults.description')}
       />
       <Stack gap={3}>
+        {error && errorMessage}
         <FilterContainer
           items={filters}
           values={reporting.filterValues}

--- a/src/components/TelematicReceipt/TelematicReceipt.tsx
+++ b/src/components/TelematicReceipt/TelematicReceipt.tsx
@@ -1,25 +1,40 @@
 import SearchCard from '../SearchCard/SearchCard';
 import ActionCard from '../ActionCard/ActionCard';
 import { Download, Upload } from '@mui/icons-material';
-import { Grid } from '@mui/material';
+import { Grid, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { generatePath, useNavigate } from 'react-router-dom';
 import { PageRoutes } from '../../routes';
 import TitleComponent from '../TitleComponent/TitleComponent';
-import { useCallback, useState } from 'react';
+import { ReactNode, useCallback, useState } from 'react';
 import { BaseFilterValues, FilterFieldValue } from '../../models/Filters';
 
 export const TelematicReceipt = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [filters, setFilters] = useState<Array<BaseFilterValues>>([{}]);
+  const [error, setError] = useState<boolean>(false);
+  const errorMessage: ReactNode = (
+    <Typography
+      variant="body2"
+      color="error"
+      mt={2}
+      data-testid="multifilters-error-text"
+    >
+      {t('commons.filters.atLeastOneFilter')}
+    </Typography>
+  );
 
   const navigateToResults = useCallback(() => {
-    navigate(PageRoutes.TELEMATIC_RECEIPT_SEARCH_RESULTS, {
-      state: {
-        filters: filters[0]
-      }
-    });
+    if (filters[0] && Object.keys(filters[0]).length > 0) {
+      navigate(PageRoutes.TELEMATIC_RECEIPT_SEARCH_RESULTS, {
+        state: {
+          filters: filters[0]
+        }
+      });
+    } else {
+      setError(true);
+    }
   }, [0, filters, navigate]);
 
   const resetCurrentFilters = useCallback(() => {
@@ -57,6 +72,7 @@ export const TelematicReceipt = () => {
               filterContext="TELEMATIC"
               filterValues={filters[0]}
               onFilterChange={handleFilterChange}
+              render={error && errorMessage}
               button={[
                 {
                   label: t('commons.filters.remove'),

--- a/src/components/TelematicReceipt/TelematicReceipt.tsx
+++ b/src/components/TelematicReceipt/TelematicReceipt.tsx
@@ -77,12 +77,14 @@ export const TelematicReceipt = () => {
                 {
                   label: t('commons.filters.remove'),
                   variant: 'outlined',
-                  onClick: resetCurrentFilters
+                  onClick: resetCurrentFilters,
+                  id: 'telematic-receipt-reset-btn'
                 },
                 {
                   label: t('commons.filters.filterResults'),
                   variant: 'contained',
-                  onClick: navigateToResults
+                  onClick: navigateToResults,
+                  id: 'telematic-receipt-search-btn'
                 }
               ]}
             />

--- a/src/components/TelematicReceipt/TelematicReceipt.tsx
+++ b/src/components/TelematicReceipt/TelematicReceipt.tsx
@@ -8,6 +8,7 @@ import { PageRoutes } from '../../routes';
 import TitleComponent from '../TitleComponent/TitleComponent';
 import { ReactNode, useCallback, useState } from 'react';
 import { BaseFilterValues, FilterFieldValue } from '../../models/Filters';
+import { noFilterSetted } from '../../utils/filtersValidation';
 
 export const TelematicReceipt = () => {
   const { t } = useTranslation();
@@ -26,7 +27,7 @@ export const TelematicReceipt = () => {
   );
 
   const navigateToResults = useCallback(() => {
-    if (filters[0] && Object.keys(filters[0]).length > 0) {
+    if (!noFilterSetted(filters[0])) {
       navigate(PageRoutes.TELEMATIC_RECEIPT_SEARCH_RESULTS, {
         state: {
           filters: filters[0]

--- a/src/components/TelematicReceiptSearchResults/TelematicReceiptSearchResults.tsx
+++ b/src/components/TelematicReceiptSearchResults/TelematicReceiptSearchResults.tsx
@@ -24,11 +24,7 @@ const TelematicReceiptSearchResults = () => {
   const [error, setError] = useState(false);
 
   const errorMessage: ReactNode = (
-    <Typography
-      variant="body2"
-      color="error"
-      data-testid="filters-error-text"
-    >
+    <Typography variant="body2" color="error" data-testid="filters-error-text">
       {t('commons.filters.atLeastOneFilter')}
     </Typography>
   );
@@ -46,7 +42,6 @@ const TelematicReceiptSearchResults = () => {
     } else {
       setError(true);
     }
-    
   };
   const { filters } = useTelematicReceiptsFilters({
     onFilter: runSearch

--- a/src/components/TelematicReceiptSearchResults/TelematicReceiptSearchResults.tsx
+++ b/src/components/TelematicReceiptSearchResults/TelematicReceiptSearchResults.tsx
@@ -1,4 +1,4 @@
-import { Grid, Stack, useTheme } from '@mui/material';
+import { Grid, Stack, Typography, useTheme } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import SearchResultsDataGrid from './SearchResultsDataGrid';
 import TitleComponent from '../TitleComponent/TitleComponent';
@@ -10,6 +10,8 @@ import { useLocation } from 'react-router-dom';
 import useTelematicReceiptsFilters from '../../hooks/useTelematicReceiptsFilters';
 import FilterContainer from '../FilterContainer/FilterContainer';
 import { PagedReceiptView } from '../../../generated/data-contracts';
+import { ReactNode, useState } from 'react';
+import { noFilterSetted } from '../../utils/filtersValidation';
 
 export type LocationState = {
   filters: BaseFilterValues;
@@ -18,8 +20,18 @@ export type LocationState = {
 const TelematicReceiptSearchResults = () => {
   const theme = useTheme();
   const { t } = useTranslation();
-
   const location = useLocation();
+  const [error, setError] = useState(false);
+
+  const errorMessage: ReactNode = (
+    <Typography
+      variant="body2"
+      color="error"
+      data-testid="filters-error-text"
+    >
+      {t('commons.filters.atLeastOneFilter')}
+    </Typography>
+  );
 
   const initialFilters = (location.state?.filters || {}) as BaseFilterValues;
 
@@ -27,8 +39,17 @@ const TelematicReceiptSearchResults = () => {
     initialFilters: initialFilters as TelematicReceiptFilters
   });
 
+  const runSearch = () => {
+    if (!noFilterSetted(telematicReceipt.filterValues)) {
+      telematicReceipt.applyFilters();
+      setError(false);
+    } else {
+      setError(true);
+    }
+    
+  };
   const { filters } = useTelematicReceiptsFilters({
-    onFilter: telematicReceipt.applyFilters
+    onFilter: runSearch
   });
 
   return (
@@ -37,8 +58,8 @@ const TelematicReceiptSearchResults = () => {
         title={t('commons.routes.TELEMATIC_RECEIPT_SEARCH_RESULTS')}
         description={t('telematicreceiptSearchResults.description')}
       />
-     
       <Stack gap={3}>
+        {error && errorMessage}
         <FilterContainer
           items={filters}
           values={telematicReceipt.filterValues}

--- a/src/components/TelematicReceiptSearchResults/TelematicReceiptSearchResults.tsx
+++ b/src/components/TelematicReceiptSearchResults/TelematicReceiptSearchResults.tsx
@@ -37,7 +37,7 @@ const TelematicReceiptSearchResults = () => {
         title={t('commons.routes.TELEMATIC_RECEIPT_SEARCH_RESULTS')}
         description={t('telematicreceiptSearchResults.description')}
       />
-
+     
       <Stack gap={3}>
         <FilterContainer
           items={filters}

--- a/src/hooks/useReportingFilters.tsx
+++ b/src/hooks/useReportingFilters.tsx
@@ -39,7 +39,6 @@ export const useReportingFilters = ({
       {
         type: COMPONENT_TYPE.dateRange,
         label: 'dateRange',
-        required: true,
         gridWidth: 5,
         from: { label: t('commons.from') },
         to: { label: t('commons.to') },

--- a/src/hooks/useReportingSearch.tsx
+++ b/src/hooks/useReportingSearch.tsx
@@ -6,6 +6,7 @@ import {
   PaymentsReportingQuery
 } from '../api/getPaymentsReporting';
 import { usePaginationState } from './usePaginationState';
+import { noFilterSetted } from '../utils/filtersValidation';
 
 export type ReportingFilters = {
   dateRange?: {
@@ -45,7 +46,9 @@ export const useReportingSearch = ({
   const query = getPaymentsReporting(organizationId);
 
   useEffect(() => {
-    query.mutate(filterToRequest());
+    if (!noFilterSetted(filterValues)) {
+      query.mutate(filterToRequest());
+    }
   }, [organizationId, paginationParams.page, paginationParams.size, sort]);
 
   const filterToRequest = (): PaymentsReportingQuery => ({

--- a/src/hooks/useTelematicReceiptsFilters.tsx
+++ b/src/hooks/useTelematicReceiptsFilters.tsx
@@ -47,7 +47,6 @@ export const useTelematicReceiptsFilters = ({
       {
         type: COMPONENT_TYPE.dateRange,
         label: 'dateRange',
-        required: true,
         gridWidth: 5,
         from: { label: t('commons.outcomeFrom') },
         to: { label: t('commons.to') },

--- a/src/hooks/useTelematicReceiptsSearch.tsx
+++ b/src/hooks/useTelematicReceiptsSearch.tsx
@@ -4,6 +4,7 @@ import { FilterFieldValue } from '../models/Filters';
 import { getReceipts, TelematicReceiptsQuery } from '../api/receipts';
 import { ReceiptOriginType } from '../../generated/apiClient';
 import { usePaginationState } from './usePaginationState';
+import { noFilterSetted } from '../utils/filtersValidation';
 
 export type TelematicReceiptFilters = {
   dateRange?: {
@@ -41,7 +42,9 @@ export const useTelematicReceiptSearch = ({
   const query = getReceipts(organizationId);
 
   useEffect(() => {
-    query.mutate(filterToRequest());
+    if (!noFilterSetted(filterValues)) {
+      query.mutate(filterToRequest());
+    }
   }, [organizationId, paginationParams.page, paginationParams.size, sort]);
 
   const filterToRequest = (): TelematicReceiptsQuery => ({

--- a/src/models/Step3Schema.ts
+++ b/src/models/Step3Schema.ts
@@ -936,9 +936,7 @@ export function convertFormDataToManageDebtPositionDTO(
       };
 
       // Determine action: 'M' for existing installments, 'I' for new ones
-      const action: Action = formInstallment.isNew
-        ? Action.I
-        : Action.M;
+      const action: Action = formInstallment.isNew ? Action.I : Action.M;
       return {
         action,
         installment: updatedInstallment

--- a/src/utils/filtersValidation.test.tsx
+++ b/src/utils/filtersValidation.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { noFilterSetted } from './filtersValidation';
+
+describe('noFilterSetted', () => {
+  it('should return true when filters object is empty', () => {
+    expect(noFilterSetted({})).toBe(true);
+  });
+
+  it('should return true when all string values are empty or whitespace', () => {
+    expect(
+      noFilterSetted({
+        iuv: '',
+        iuf: '   ',
+      })
+    ).toBe(true);
+  });
+
+  it('should return true when all non-string values are falsy', () => {
+    expect(
+      noFilterSetted({
+        draft: false,
+        count: 0,
+        active: null,
+      })
+    ).toBe(true);
+  });
+
+  it('should return false when at least one string value is not empty', () => {
+    expect(
+      noFilterSetted({
+        name: 'Mario',
+        city: '',
+      })
+    ).toBe(false);
+  });
+
+  it('should return false when at least one non-string value is truthy', () => {
+    expect(
+      noFilterSetted({
+        draft: true,
+        count: 0,
+      })
+    ).toBe(false);
+  });
+
+  it('should handle mixed values correctly', () => {
+    expect(
+      noFilterSetted({
+        name: '',
+        city: '  ',
+        active: false,
+        count: 42,
+      })
+    ).toBe(false);
+  });
+});

--- a/src/utils/filtersValidation.tsx
+++ b/src/utils/filtersValidation.tsx
@@ -1,17 +1,17 @@
 type FilterValues = Record<string, unknown>;
 
 /**
-* Checks if ad object filters contains non empty filters
+ * Checks if ad object filters contains non empty filters
  * @param filters - Object with filters
  * @returns true if there is at least one filter filled
  */
 export const noFilterSetted = (filters: FilterValues) => {
-    const listEntries = Object.values(filters);
-    return (
-      !Array.isArray(listEntries) || 
-      listEntries.length === 0 || 
-      listEntries.every(el => typeof el === 'string' ? el.trim() === '' : !el)
-    );
-    };
+  const listEntries = Object.values(filters);
+  return (
+    !Array.isArray(listEntries) ||
+    listEntries.length === 0 ||
+    listEntries.every((el) => (typeof el === 'string' ? el.trim() === '' : !el))
+  );
+};
 
 export default { noFilterSetted };

--- a/src/utils/filtersValidation.tsx
+++ b/src/utils/filtersValidation.tsx
@@ -1,0 +1,17 @@
+type FilterValues = Record<string, unknown>;
+
+/**
+* Checks if ad object filters contains non empty filters
+ * @param filters - Object with filters
+ * @returns true if there is at least one filter filled
+ */
+export const noFilterSetted = (filters: FilterValues) => {
+    const listEntries = Object.values(filters);
+    return (
+      !Array.isArray(listEntries) || 
+      listEntries.length === 0 || 
+      listEntries.every(el => typeof el === 'string' ? el.trim() === '' : !el)
+    );
+    };
+
+export default { noFilterSetted };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,6 +7,7 @@ import { FileshareApi } from '../../generated/fileshare/fileshareClient';
 import storage from './storage';
 import notify from './notify';
 import roles from './roles';
+import filtersValidation from './filtersValidation';
 
 export default {
   apiClient: new Api({ baseURL: config.baseURL, timeout: config.apiTimeout }),
@@ -20,5 +21,6 @@ export default {
   style,
   storage,
   notify,
-  roles
+  roles,
+  filtersValidation
 };


### PR DESCRIPTION
This PR adds a check to the search functionality of the "flows" section:
- telematic receipts
- reporting
- export

#### List of Changes
- Creation of a specific utility to test if a filters object contains at least one filter filled
- mod of search card and results page of Telematic receipts
- mod of search card and results page of Reporting
- mod of search card and results page of Export component (shared within several pages)

#### Motivation and Context
To alert user when it doesn't fill at least one search filter.

#### How Has This Been Tested?
- unit tests
- visual tests

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
