### PR TITLE
feat: [P4ADEV-2925] using debtPositionTypeDescription instead of description in first accordion on debt type detail view

### DIFF
--- a/src/models/DebtTypeSectionsConfig.tsx
+++ b/src/models/DebtTypeSectionsConfig.tsx
@@ -166,7 +166,7 @@ export const getAccordionSectionsConfig = (
             },
             {
               label: t('commons.description'),
-              value: checkStringValue(data?.description)
+              value: checkStringValue(data?.debtPositionTypeDescription)
             }
           ]
         }

--- a/src/routes/DebtTypeDetailView/DebtTypeDetailView.test.tsx
+++ b/src/routes/DebtTypeDetailView/DebtTypeDetailView.test.tsx
@@ -55,7 +55,9 @@ describe('DebtTypeDetailView', () => {
       data: {
         response: {
           description: 'Test debt position ID',
-          code: 'test'
+          code: 'test',
+          debtPositionTypeDescription:
+            'Test debtPositionTypeDescription description'
         }
       },
       isLoading: false,
@@ -88,7 +90,7 @@ describe('DebtTypeDetailView', () => {
   it('renders title and description', () => {
     render(<DebtTypeDetailView />);
     const description = screen.queryAllByText('Test debt position ID');
-    expect(description.length).toBe(3);
+    expect(description.length).toBe(2);
     expect(screen.getByText('description')).toBeInTheDocument();
     expect(screen.getByText('selected operators')).toBeInTheDocument();
     expect(screen.getByText('3 operators')).toBeInTheDocument();


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Using debtPositionTypeDescription instead of description in first accordion on debt type detail view (description -> debtPositionTypeDescription)
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The previous property used (description) was wrong
#### How Has This Been Tested?
Tested by visual inspection
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
