### PR TITLE
feat: [P4ADEV-3226] add id and testid to debt position wizard

### DIFF
--- a/src/components/ClassificationsSearchResults/ClassificationsSearchResults.tsx
+++ b/src/components/ClassificationsSearchResults/ClassificationsSearchResults.tsx
@@ -15,7 +15,10 @@ import {
 import { FilterDrawer } from '../Drawer/FilterDrawer';
 import { BaseFilterValues } from '../../models/Filters';
 import UseClassificationsSearch from '../../hooks/useClassificationsSearch';
-import { ClassificationsEnum, PagedTreasuredClassification } from '../../../generated/data-contracts';
+import {
+  ClassificationsEnum,
+  PagedTreasuredClassification
+} from '../../../generated/data-contracts';
 import DownloadIcon from '@mui/icons-material/Download';
 
 export type LocationState = {

--- a/src/components/Wizard/WizardStepButtons.tsx
+++ b/src/components/Wizard/WizardStepButtons.tsx
@@ -32,9 +32,16 @@ const WizardStepButtons = ({
   const { t } = useTranslation();
 
   return (
-    <Box mt={4} display="flex" justifyContent="space-between">
+    <Box
+      mt={4}
+      display="flex"
+      justifyContent="space-between"
+      data-testid="wizard-step-buttons"
+    >
       <Box>
         <Button
+          id="wizard-back-button"
+          data-testid="wizard-back-button"
           variant="outlined"
           onClick={onBack}
           disabled={disableBack}
@@ -46,6 +53,8 @@ const WizardStepButtons = ({
       <Box display="flex" gap={4}>
         {showSaveDraft && (
           <Button
+            id="wizard-save-draft-button"
+            data-testid="wizard-save-draft-button"
             variant={showSaveDraftIcon ? 'text' : 'outlined'}
             onClick={onSaveDraft}
             disabled={disableSaveDraft}
@@ -54,7 +63,13 @@ const WizardStepButtons = ({
             {t(saveDraftLabel)}
           </Button>
         )}
-        <Button variant="contained" onClick={onNext} disabled={disableNext}>
+        <Button
+          id="wizard-next-button"
+          data-testid="wizard-next-button"
+          variant="contained"
+          onClick={onNext}
+          disabled={disableNext}
+        >
           {t(nextLabel)}
         </Button>
       </Box>

--- a/src/routes/DebtPositionCreateWizard/components/Beneficiary/BeneficiaryField.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Beneficiary/BeneficiaryField.tsx
@@ -150,6 +150,7 @@ const InternalBeneficiaryField = <T extends FieldValues>(
           <Divider sx={{ mt: 2, mb: 1 }} />
           <Box>
             <Button
+              data-testid="beneficiary-add-button"
               startIcon={<Add />}
               onClick={addBeneficiary}
               sx={{ mt: 1 }}
@@ -199,6 +200,7 @@ const InternalBeneficiaryField = <T extends FieldValues>(
     return (
       <Paper
         key={field.id}
+        data-testid={`beneficiary-item-${index}`}
         sx={{
           p: 2,
           mb: 2,
@@ -296,7 +298,7 @@ const InternalBeneficiaryField = <T extends FieldValues>(
   };
 
   return (
-    <Box>
+    <Box data-testid="beneficiaries-container">
       {fields.map((field, index) =>
         renderBeneficiary(field as BeneficiaryField, index)
       )}

--- a/src/routes/DebtPositionCreateWizard/components/Beneficiary/BeneficiaryFieldComponents.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Beneficiary/BeneficiaryFieldComponents.tsx
@@ -150,6 +150,7 @@ export function BeneficiaryHeader(
         </Typography>
       </Box>
       <Button
+        data-testid={`beneficiary-remove-${index}`}
         onClick={() => onRemove(index)}
         startIcon={<DeleteOutlineIcon />}
         color="error"
@@ -185,6 +186,7 @@ export function EntityNameField<T extends FieldValues>(
   return (
     <TextField
       {...field}
+      data-testid={`beneficiary-entity-name-${context.index}`}
       fullWidth
       label={t('debtPositionCreateWizard.step3.beneficiary.entityName.label')}
       required
@@ -237,6 +239,7 @@ export function AmountField<T extends FieldValues>(
   return (
     <TextField
       {...field}
+      data-testid={`beneficiary-amount-${index}`}
       fullWidth
       label={t('debtPositionCreateWizard.step3.beneficiary.amount.label')}
       required
@@ -288,6 +291,7 @@ export function TaxCodeField<T extends FieldValues>(
   return (
     <TextField
       {...field}
+      data-testid={`beneficiary-tax-code-${context.index}`}
       fullWidth
       label={t('debtPositionCreateWizard.step3.beneficiary.vat.label')}
       required
@@ -324,6 +328,7 @@ export function RemittanceField<T extends FieldValues>(
   return (
     <TextField
       {...field}
+      data-testid={`beneficiary-remittance-${context.index}`}
       fullWidth
       label={t('debtPositionCreateWizard.step3.beneficiary.remittance.label')}
       required
@@ -621,6 +626,7 @@ export function IBANField<T extends FieldValues>(
   return (
     <TextField
       {...field}
+      data-testid={`beneficiary-iban-${index}`}
       fullWidth
       label={t('debtPositionCreateWizard.step3.beneficiary.iban.label')}
       disabled={disabled}
@@ -674,6 +680,7 @@ export function PostalIbanField<T extends FieldValues>(
   return (
     <TextField
       {...field}
+      data-testid={`beneficiary-postal-iban-${index}`}
       fullWidth
       label={t('debtPositionCreateWizard.step3.beneficiary.postalIban.label')}
       disabled={disabled}
@@ -854,7 +861,7 @@ export function PostalAccountField<T extends FieldValues>(
     errors: FieldErrors<T>;
   }>
 ) {
-  const { field, t, disabled = false, context, errors } = props;
+  const { field, t, disabled = false, context, errors, index } = props;
 
   const actualValue =
     context.getValues(field.name as Path<T>) ?? field.value ?? '';
@@ -862,6 +869,7 @@ export function PostalAccountField<T extends FieldValues>(
   return (
     <TextField
       {...field}
+      data-testid={`beneficiary-postal-account-${index}`}
       fullWidth
       label={t(
         'debtPositionCreateWizard.step3.beneficiary.postalAccount.label'
@@ -904,6 +912,7 @@ export function TaxonomyCodeField<T extends FieldValues>(
   return (
     <TextField
       {...field}
+      data-testid={`beneficiary-taxonomy-code-${context.index}`}
       fullWidth
       label={t('debtPositionCreateWizard.step3.beneficiary.taxonomyCode.label')}
       required

--- a/src/routes/DebtPositionCreateWizard/components/Installment/AmountField.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Installment/AmountField.tsx
@@ -50,6 +50,8 @@ const AmountField = <T extends FieldValues>({
       render={({ field }) => (
         <TextField
           {...field}
+          id={`installment-amount-${index}`}
+          data-testid={`installment-amount-${index}`}
           fullWidth
           size="small"
           label={t('debtPositionCreateWizard.step3.installments.amount.label')}

--- a/src/routes/DebtPositionCreateWizard/components/Installment/BeneficiaryControl.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Installment/BeneficiaryControl.tsx
@@ -434,6 +434,8 @@ const BeneficiaryControl = <T extends FieldValues>({
               control={
                 <Switch
                   {...field}
+                  id={`installment-multibeneficiary-switch-${index}`}
+                  data-testid={`installment-multibeneficiary-switch-${index}`}
                   checked={!!field.value}
                   disabled={disabled}
                   onChange={(e) => {
@@ -476,6 +478,8 @@ const BeneficiaryControl = <T extends FieldValues>({
                 </FormLabel>
                 <RadioGroup
                   {...field}
+                  id={`installment-beneficiary-mode-${index}`}
+                  data-testid={`installment-beneficiary-mode-${index}`}
                   row
                   value={String(
                     field.value === undefined ? 'true' : field.value
@@ -543,13 +547,21 @@ const BeneficiaryControl = <T extends FieldValues>({
                 >
                   <FormControlLabel
                     value="true"
-                    control={<Radio />}
+                    control={
+                      <Radio
+                        data-testid={`installment-use-previous-beneficiaries-${index}`}
+                      />
+                    }
                     label={t('debtPositionCreateWizard.step3.installments.yes')}
                     disabled={!hasPreviousBeneficiaries}
                   />
                   <FormControlLabel
                     value="false"
-                    control={<Radio />}
+                    control={
+                      <Radio
+                        data-testid={`installment-create-new-beneficiaries-${index}`}
+                      />
+                    }
                     label={t('debtPositionCreateWizard.step3.installments.no')}
                     disabled={!hasPreviousBeneficiaries}
                   />

--- a/src/routes/DebtPositionCreateWizard/components/Installment/DateField.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Installment/DateField.tsx
@@ -61,6 +61,7 @@ const DateField = <T extends FieldValues>({
         return (
           <DatePicker
             {...field}
+            data-testid={`installment-due-date-${index}`}
             value={dateValue}
             label={t(
               'debtPositionCreateWizard.step3.installments.dueDate.label'
@@ -70,6 +71,7 @@ const DateField = <T extends FieldValues>({
             format="dd/MM/yyyy"
             slotProps={{
               textField: {
+                id: `installment-due-date-${index}`,
                 fullWidth: true,
                 required: flagMandatoryDueDate,
                 error: !!error,

--- a/src/routes/DebtPositionCreateWizard/components/Installment/InstallmentField.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Installment/InstallmentField.tsx
@@ -122,7 +122,11 @@ function InstallmentField<T extends FieldValues>({
   };
 
   return (
-    <Box component={Paper} sx={{ p: 3, mt: 4, borderRadius: 1 }}>
+    <Box
+      component={Paper}
+      data-testid="installments-container"
+      sx={{ p: 3, mt: 4, borderRadius: 1 }}
+    >
       <Typography variant="h4" component="h3" fontWeight="bold" mb={3}>
         {t('debtPositionCreateWizard.step3.installments.title')}
       </Typography>
@@ -169,6 +173,8 @@ function InstallmentField<T extends FieldValues>({
 
       <Box sx={{ display: 'flex', justifyContent: 'flex-start' }}>
         <Button
+          id="installment-add-button"
+          data-testid="installment-add-button"
           startIcon={<Add />}
           onClick={addInstallment}
           disabled={isMaxInstallments || disabled || isEditing}

--- a/src/routes/DebtPositionCreateWizard/components/Installment/InstallmentItem.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Installment/InstallmentItem.tsx
@@ -168,6 +168,8 @@ const InstallmentItem = <T extends FieldValues>({
   return (
     <Box sx={{ display: 'flex', alignItems: 'flex-start' }}>
       <IconButton
+        id={`installment-remove-${index}`}
+        data-testid={`installment-remove-${index}`}
         size="small"
         onClick={handleRemove}
         disabled={!onRemove || isEditing}
@@ -181,6 +183,7 @@ const InstallmentItem = <T extends FieldValues>({
       </IconButton>
 
       <Box
+        data-testid={`installment-item-${index}`}
         sx={{
           p: 2,
           border: '1px solid',

--- a/src/routes/DebtPositionCreateWizard/components/Installment/RemittanceField.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Installment/RemittanceField.tsx
@@ -46,6 +46,8 @@ const RemittanceField = <T extends FieldValues>({
       render={({ field }) => (
         <TextField
           {...field}
+          id={`installment-remittance-${index}`}
+          data-testid={`installment-remittance-${index}`}
           fullWidth
           size="small"
           label={t(

--- a/src/routes/DebtPositionCreateWizard/components/Step/Step1GeneralConfiguration.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step/Step1GeneralConfiguration.tsx
@@ -203,7 +203,7 @@ const Step1GeneralConfiguration = ({
   }
 
   return (
-    <form>
+    <form id="step1-general-configuration-form" data-testid="step1-form">
       <WizardStepWrapper
         title={t('debtPositionCreateWizard.generalConfiguration.title')}
         subtitle={t('debtPositionCreateWizard.generalConfiguration.subtitle')}
@@ -218,6 +218,8 @@ const Step1GeneralConfiguration = ({
             render={({ field }) => (
               <TextField
                 {...field}
+                id="debt-position-type-select"
+                data-testid="debt-position-type-field"
                 label={t(
                   'debtPositionCreateWizard.step1.debtPositionType.label'
                 )}
@@ -230,7 +232,11 @@ const Step1GeneralConfiguration = ({
                 helperText={errors.debtPositionType?.message}
               >
                 {debtPositionsTypes.map((option) => (
-                  <MenuItem key={option.value} value={option.value.toString()}>
+                  <MenuItem
+                    key={option.value}
+                    value={option.value.toString()}
+                    data-testid={`debt-position-type-option-${option.value}`}
+                  >
                     {option.label}
                   </MenuItem>
                 ))}
@@ -243,6 +249,8 @@ const Step1GeneralConfiguration = ({
             render={({ field }) => (
               <TextField
                 {...field}
+                id="description-input"
+                data-testid="description-field"
                 label={t('debtPositionCreateWizard.step1.description.label')}
                 fullWidth
                 margin="normal"

--- a/src/routes/DebtPositionCreateWizard/components/Step/Step2AddDebtor.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step/Step2AddDebtor.tsx
@@ -266,7 +266,7 @@ const Step2AddDebtor = ({
   };
 
   return (
-    <form>
+    <form id="step2-add-debtor-form" data-testid="step2-form">
       <WizardStepWrapper
         title={t('debtPositionCreateWizard.addDebtor.title')}
         subtitle={t('debtPositionCreateWizard.addDebtor.subtitle')}
@@ -285,6 +285,8 @@ const Step2AddDebtor = ({
             render={({ field }) => (
               <TextField
                 {...field}
+                id="subject-type-select"
+                data-testid="subject-type-field"
                 label={t('debtPositionCreateWizard.step2.subjectType.label')}
                 required
                 select
@@ -298,12 +300,18 @@ const Step2AddDebtor = ({
                   handleSubjectTypeChange(e);
                 }}
               >
-                <MenuItem value={SubjectType.INDIVIDUAL}>
+                <MenuItem
+                  value={SubjectType.INDIVIDUAL}
+                  data-testid="subject-type-option-individual"
+                >
                   {t(
                     'debtPositionCreateWizard.step2.subjectType.options.fisica'
                   )}
                 </MenuItem>
-                <MenuItem value={SubjectType.BUSINESS}>
+                <MenuItem
+                  value={SubjectType.BUSINESS}
+                  data-testid="subject-type-option-business"
+                >
                   {t(
                     'debtPositionCreateWizard.step2.subjectType.options.giuridica'
                   )}
@@ -318,6 +326,8 @@ const Step2AddDebtor = ({
             render={({ field }) => (
               <TextField
                 {...field}
+                id="tax-code-input"
+                data-testid="tax-code-field"
                 label={getTaxCodeLabel()}
                 placeholder={getTaxCodePlaceholder()}
                 required
@@ -346,6 +356,8 @@ const Step2AddDebtor = ({
             render={({ field }) => (
               <TextField
                 {...field}
+                id="full-name-input"
+                data-testid="full-name-field"
                 label={getCompanyNameLabel()}
                 fullWidth
                 margin="normal"
@@ -370,6 +382,8 @@ const Step2AddDebtor = ({
                 render={({ field }) => (
                   <TextField
                     {...field}
+                    id="address-input"
+                    data-testid="address-field"
                     label={t('debtPositionCreateWizard.step2.address.label')}
                     fullWidth
                     required
@@ -393,6 +407,8 @@ const Step2AddDebtor = ({
                 render={({ field }) => (
                   <TextField
                     {...field}
+                    id="civic-number-input"
+                    data-testid="civic-number-field"
                     label={t(
                       'debtPositionCreateWizard.step2.civicNumber.label'
                     )}
@@ -420,6 +436,8 @@ const Step2AddDebtor = ({
                 render={({ field }) => (
                   <TextField
                     {...field}
+                    id="zip-code-input"
+                    data-testid="zip-code-field"
                     label={t('debtPositionCreateWizard.step2.zipCode.label')}
                     fullWidth
                     required
@@ -446,6 +464,8 @@ const Step2AddDebtor = ({
                 render={({ field }) => (
                   <TextField
                     {...field}
+                    id="country-select"
+                    data-testid="country-field"
                     label={t('debtPositionCreateWizard.step2.country.label')}
                     select
                     fullWidth
@@ -459,9 +479,15 @@ const Step2AddDebtor = ({
                       handleFieldChange('country.value', value);
                     }}
                   >
-                    <MenuItem value="IT">Italia</MenuItem>
-                    <MenuItem value="FR">Francia</MenuItem>
-                    <MenuItem value="DE">Germania</MenuItem>
+                    <MenuItem value="IT" data-testid="country-option-IT">
+                      Italia
+                    </MenuItem>
+                    <MenuItem value="FR" data-testid="country-option-FR">
+                      Francia
+                    </MenuItem>
+                    <MenuItem value="DE" data-testid="country-option-DE">
+                      Germania
+                    </MenuItem>
                   </TextField>
                 )}
               />
@@ -474,6 +500,8 @@ const Step2AddDebtor = ({
                 render={({ field }) => (
                   <TextField
                     {...field}
+                    id="province-select"
+                    data-testid="province-field"
                     label={t('debtPositionCreateWizard.step2.province.label')}
                     select
                     fullWidth
@@ -487,9 +515,15 @@ const Step2AddDebtor = ({
                       handleFieldChange('province.value', value);
                     }}
                   >
-                    <MenuItem value="MI">MI</MenuItem>
-                    <MenuItem value="RM">RM</MenuItem>
-                    <MenuItem value="TO">TO</MenuItem>
+                    <MenuItem value="MI" data-testid="province-option-MI">
+                      MI
+                    </MenuItem>
+                    <MenuItem value="RM" data-testid="province-option-RM">
+                      RM
+                    </MenuItem>
+                    <MenuItem value="TO" data-testid="province-option-TO">
+                      TO
+                    </MenuItem>
                   </TextField>
                 )}
               />
@@ -502,6 +536,8 @@ const Step2AddDebtor = ({
                 render={({ field }) => (
                   <TextField
                     {...field}
+                    id="city-input"
+                    data-testid="city-field"
                     label={t('debtPositionCreateWizard.step2.city.label')}
                     fullWidth
                     required

--- a/src/routes/DebtPositionCreateWizard/components/Step/Step3.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step/Step3.tsx
@@ -676,7 +676,11 @@ const Step3 = ({
   };
 
   return (
-    <form onSubmit={handleSubmit((values) => onSubmit(values, false))}>
+    <form
+      id="step3-configuration-form"
+      data-testid="step3-form"
+      onSubmit={handleSubmit((values) => onSubmit(values, false))}
+    >
       <WizardStepWrapper
         title={t('debtPositionCreateWizard.configurationAlert.title')}
         subtitle={t('debtPositionCreateWizard.configurationAlert.subtitle')}
@@ -693,6 +697,8 @@ const Step3 = ({
                 render={({ field }) => (
                   <TextField
                     {...field}
+                    id="payment-object-input"
+                    data-testid="payment-object-field"
                     fullWidth
                     label={t(
                       'debtPositionCreateWizard.step3.paymentObject.label'
@@ -727,6 +733,8 @@ const Step3 = ({
                 render={({ field }) => (
                   <TextField
                     {...field}
+                    id="payment-option-select"
+                    data-testid="payment-option-field"
                     select
                     fullWidth
                     label={t(
@@ -738,10 +746,16 @@ const Step3 = ({
                     helperText={errors.paymentOption?.value?.message || ''}
                     onChange={(e) => handlePaymentOptionChange(e, field)}
                   >
-                    <MenuItem value="SINGLE">
+                    <MenuItem
+                      value="SINGLE"
+                      data-testid="payment-option-single"
+                    >
                       {t('debtPositionCreateWizard.step3.paymentOption.single')}
                     </MenuItem>
-                    <MenuItem value="INSTALLMENTS">
+                    <MenuItem
+                      value="INSTALLMENTS"
+                      data-testid="payment-option-installments"
+                    >
                       {t(
                         'debtPositionCreateWizard.step3.paymentOption.installments'
                       )}
@@ -758,6 +772,8 @@ const Step3 = ({
                 render={({ field }) => (
                   <TextField
                     {...field}
+                    id="amount-input"
+                    data-testid="amount-field"
                     fullWidth
                     label={t('debtPositionCreateWizard.step3.amount.label')}
                     required
@@ -803,6 +819,7 @@ const Step3 = ({
                   render={({ field: { onChange, value, ...field } }) => (
                     <DatePicker
                       {...field}
+                      data-testid="due-date-picker"
                       value={value}
                       label={t('debtPositionCreateWizard.step3.dueDate.label')}
                       disabled={data.dueDate?.readonly}
@@ -857,6 +874,7 @@ const Step3 = ({
                   control={control}
                   render={({ field }) => (
                     <FormControlLabel
+                      data-testid="multi-beneficiary-switch"
                       control={
                         <Switch
                           {...field}
@@ -879,7 +897,7 @@ const Step3 = ({
 
             {/* Beneficiary component - visible only when multi-beneficiary is true AND not in installment mode */}
             {isMultibeneficiary && !isInstallment && (
-              <Grid item xs={12} mt={2}>
+              <Grid item xs={12} mt={2} data-testid="beneficiary-section">
                 <BeneficiaryField<Step3FormValues>
                   ref={beneficiaryFieldRef}
                   control={control}
@@ -901,19 +919,21 @@ const Step3 = ({
       </WizardStepWrapper>
       {/* Installments component - visible only when installment option is selected */}
       {isInstallment && (
-        <InstallmentField<Step3FormValues>
-          control={control}
-          errors={errors}
-          isSubmitted={isSubmitted}
-          fieldNamePrefix="installments"
-          disabled={false}
-          flagMandatoryDueDate={data.flagMandatoryDueDate}
-          setValue={setValue}
-          getValues={getValues}
-          trigger={trigger}
-          onInstallmentsChange={handleInstallmentsChange}
-          isEditing={isEditing}
-        />
+        <div data-testid="installments-section">
+          <InstallmentField<Step3FormValues>
+            control={control}
+            errors={errors}
+            isSubmitted={isSubmitted}
+            fieldNamePrefix="installments"
+            disabled={false}
+            flagMandatoryDueDate={data.flagMandatoryDueDate}
+            setValue={setValue}
+            getValues={getValues}
+            trigger={trigger}
+            onInstallmentsChange={handleInstallmentsChange}
+            isEditing={isEditing}
+          />
+        </div>
       )}
       <WizardStepButtons
         onBack={onBack}


### PR DESCRIPTION
Added id and data-testid attributes to the Debt Position creation wizard components to improve testability and accessibility.


#### How Has This Been Tested?

-visual testing
-unit tests


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
