### PR TITLE
feat: [P4ADEV-3208] prevent auto-filling of 'code' field

### DIFF
--- a/src/routes/DebtTypeOrgCreate/steps/Step1Configuration/index.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step1Configuration/index.tsx
@@ -64,10 +64,12 @@ export const Step1Configuration = ({ edit }: { edit?: boolean }) => {
 
       // If not editing, auto-fill fields with the selected debt type
       if (selectedType && !edit) {
-        Object.entries(selectedType).forEach(([key, val]) => {
-          setValue(key as keyof DebtTypeOrgForm, val);
+        Object.entries(selectedType).forEach(([key, value]) => {
+          const field = key as keyof DebtTypeOrgForm;
+          // code should not be auto-filled
+          if (field === 'code') return;
+          setValue(field, value);
         });
-        trigger();
       }
     }
   }, [edit, selectedId, selectionQuery.data, setValue, trigger]);

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -963,7 +963,7 @@
       "code": {
         "label": "Codice Sistema Gestionale",
         "required": "Il Codice Sistema Gestionale é obbligatorio",
-        "notUnique": "Il Codice Sistema Gestionale deve essere univoco. Codice inserito già esistente."
+        "notUnique": "Codice già esistente. Inserisci un altro codice"
       },
       "description": {
         "label": "Descrizione",


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Prevent auto-filling of 'code' field in Step1Configuration and update translation for notUnique message
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The 'code' field in Step1Configuration must have unique value and the user should insert a new unique one every time he want create a new Debt Type
#### How Has This Been Tested?
Tested by manual try
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
