### PR TITLE
fix: [P4ADEV] removing a filter from selected should also reset his value

### DIFF
--- a/src/api/debtPositions.test.ts
+++ b/src/api/debtPositions.test.ts
@@ -545,7 +545,9 @@ describe('createDebtPosition', () => {
         expect(result.current.isSuccess).toBe(true);
       });
 
-      expect(apiMock).toHaveBeenCalledWith(organizationId, debtPositionId);
+      expect(apiMock).toHaveBeenCalledWith(organizationId, debtPositionId, {
+        nav: ''
+      });
     });
 
     it('handles empty installment registries array correctly', async () => {
@@ -568,7 +570,9 @@ describe('createDebtPosition', () => {
         expect(result.current.isSuccess).toBe(true);
       });
 
-      expect(apiMock).toHaveBeenCalledWith(organizationId, debtPositionId);
+      expect(apiMock).toHaveBeenCalledWith(organizationId, debtPositionId, {
+        nav: ''
+      });
     });
 
     it('handles null/undefined installment registries data gracefully', async () => {
@@ -590,7 +594,9 @@ describe('createDebtPosition', () => {
         expect(result.current.isSuccess).toBe(true);
       });
 
-      expect(apiMock).toHaveBeenCalledWith(organizationId, debtPositionId);
+      expect(apiMock).toHaveBeenCalledWith(organizationId, debtPositionId, {
+        nav: ''
+      });
     });
 
     it('handles API errors correctly for installment registries', async () => {
@@ -669,7 +675,9 @@ describe('createDebtPosition', () => {
         expect(result.current.isSuccess).toBe(true);
       });
 
-      expect(apiMock).toHaveBeenCalledWith(organizationId, debtPositionId);
+      expect(apiMock).toHaveBeenCalledWith(organizationId, debtPositionId, {
+        nav: ''
+      });
     });
 
     it('handles installment-specific event types correctly', async () => {
@@ -723,7 +731,9 @@ describe('createDebtPosition', () => {
       expect(eventTypes).toContain(PaymentEventType.IO_NOTIFIED);
       expect(eventTypes).toContain(PaymentEventType.SEND_NOTIFICATION_CREATED);
 
-      expect(apiMock).toHaveBeenCalledWith(organizationId, debtPositionId);
+      expect(apiMock).toHaveBeenCalledWith(organizationId, debtPositionId, {
+        nav: ''
+      });
     });
   });
 });

--- a/src/api/debtPositions.ts
+++ b/src/api/debtPositions.ts
@@ -308,7 +308,11 @@ const getInstallmentRegistriesMutation = () => {
       const { data: registries } =
         await utils.apiClient.bff.getInstallmentRegistries(
           organizationId,
-          debtPositionId
+          debtPositionId,
+          // to fix the issue with the nav parameter
+          {
+            nav: ''
+          }
         );
       if (registries && Array.isArray(registries)) {
         registries.forEach((registry) => {

--- a/src/api/orgSilServices.test.ts
+++ b/src/api/orgSilServices.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor } from '../__tests__/renderers';
 import {
   OrgSilServiceType,
-  OrgSilService
+  OrgSilServiceDTO
 } from '../../generated/data-contracts';
 import { setOrganizationId } from '../store/OrganizationIdStore';
 
@@ -38,7 +38,7 @@ describe('orgSilServices', () => {
 
   describe('isValidService', () => {
     it('returns true for service with valid orgSilServiceId', () => {
-      const validService: OrgSilService = {
+      const validService: OrgSilServiceDTO = {
         orgSilServiceId: 1,
         organizationId: 123,
         applicationName: 'Test Service',
@@ -50,7 +50,7 @@ describe('orgSilServices', () => {
     });
 
     it('returns false for service with null orgSilServiceId', () => {
-      const invalidService: OrgSilService = {
+      const invalidService: OrgSilServiceDTO = {
         orgSilServiceId: null,
         organizationId: 123,
         applicationName: 'Test Service',
@@ -62,7 +62,7 @@ describe('orgSilServices', () => {
     });
 
     it('returns false for service with undefined orgSilServiceId', () => {
-      const invalidService: OrgSilService = {
+      const invalidService: OrgSilServiceDTO = {
         orgSilServiceId: undefined,
         organizationId: 123,
         applicationName: 'Test Service',
@@ -74,7 +74,7 @@ describe('orgSilServices', () => {
     });
 
     it('returns false for service with zero orgSilServiceId', () => {
-      const invalidService: OrgSilService = {
+      const invalidService: OrgSilServiceDTO = {
         orgSilServiceId: 0,
         organizationId: 123,
         applicationName: 'Test Service',
@@ -86,7 +86,7 @@ describe('orgSilServices', () => {
     });
 
     it('returns false for service with negative orgSilServiceId', () => {
-      const invalidService: OrgSilService = {
+      const invalidService: OrgSilServiceDTO = {
         orgSilServiceId: -1,
         organizationId: 123,
         applicationName: 'Test Service',
@@ -99,7 +99,7 @@ describe('orgSilServices', () => {
   });
 
   describe('getOrgSilServices', () => {
-    const mockServices: Array<OrgSilService> = [
+    const mockServices: Array<OrgSilServiceDTO> = [
       {
         orgSilServiceId: 1,
         organizationId: 123,
@@ -296,7 +296,7 @@ describe('orgSilServices', () => {
     });
 
     it('returns notification services successfully', async () => {
-      const notificationServices: Array<OrgSilService> = [
+      const notificationServices: Array<OrgSilServiceDTO> = [
         {
           orgSilServiceId: 1,
           organizationId: 123,
@@ -342,7 +342,7 @@ describe('orgSilServices', () => {
     });
 
     it('returns actualization services successfully', async () => {
-      const actualizationServices: Array<OrgSilService> = [
+      const actualizationServices: Array<OrgSilServiceDTO> = [
         {
           orgSilServiceId: 2,
           organizationId: 123,
@@ -370,7 +370,7 @@ describe('orgSilServices', () => {
 
   describe('edge cases and integration', () => {
     it('handles mixed valid and invalid services correctly', async () => {
-      const mixedServices: Array<OrgSilService> = [
+      const mixedServices: Array<OrgSilServiceDTO> = [
         {
           orgSilServiceId: 1,
           organizationId: 123,
@@ -465,7 +465,7 @@ describe('orgSilServices', () => {
       ];
 
       testCases.forEach(({ id, expected }) => {
-        const service: OrgSilService = {
+        const service: OrgSilServiceDTO = {
           orgSilServiceId: id,
           organizationId: 123,
           applicationName: 'Test Service',

--- a/src/api/orgSilServices.ts
+++ b/src/api/orgSilServices.ts
@@ -2,15 +2,15 @@ import { useQuery } from '@tanstack/react-query';
 import { z } from 'zod';
 import utils from '../utils';
 import { parseAndLog } from '../utils/loaders';
-import { orgSilServiceSchema } from '../../generated/zod-schema';
+import { orgSilServiceDTOSchema } from '../../generated/zod-schema';
 import {
   OrgSilServiceType,
-  OrgSilService
+  OrgSilServiceDTO
 } from '../../generated/data-contracts';
 
 const isValidService = (
-  service: OrgSilService
-): service is OrgSilService & { orgSilServiceId: number } => {
+  service: OrgSilServiceDTO
+): service is OrgSilServiceDTO & { orgSilServiceId: number } => {
   return service.orgSilServiceId != null && service.orgSilServiceId > 0;
 };
 
@@ -27,7 +27,7 @@ const getOrgSilServices = (
       );
 
       try {
-        parseAndLog(z.array(orgSilServiceSchema), services, true);
+        parseAndLog(z.array(orgSilServiceDTOSchema), services, true);
         const validServices = services.filter(isValidService);
         return validServices;
       } catch {
@@ -56,5 +56,5 @@ export default {
   getActualizationServices
 };
 
-export type { OrgSilService };
+export type { orgSilServiceDTOSchema };
 export { isValidService };

--- a/src/routes/DebtTypeOrgCreate/hooks/useServiceSelectorState.test.tsx
+++ b/src/routes/DebtTypeOrgCreate/hooks/useServiceSelectorState.test.tsx
@@ -2,12 +2,12 @@
 import { describe, it, expect } from 'vitest';
 import { renderHook } from '../../../__tests__/renderers';
 import { useServiceSelectorState } from './useServiceSelectorState';
-import { OrgSilService } from '../../../api/orgSilServices';
+import { OrgSilServiceDTO } from '../../../../generated/data-contracts';
 
 describe('useServiceSelectorState', () => {
   const baseTranslationKey = 'test.service';
 
-  const mockServices: Array<OrgSilService> = [
+  const mockServices: Array<OrgSilServiceDTO> = [
     {
       orgSilServiceId: 1,
       organizationId: 123,
@@ -52,7 +52,7 @@ describe('useServiceSelectorState', () => {
   });
 
   it('filters out services with invalid IDs', () => {
-    const servicesWithInvalidIds: Array<OrgSilService> = [
+    const servicesWithInvalidIds: Array<OrgSilServiceDTO> = [
       ...mockServices,
       {
         orgSilServiceId: 0,
@@ -205,7 +205,7 @@ describe('useServiceSelectorState', () => {
   });
 
   it('handles services with missing optional fields gracefully', () => {
-    const minimalServices: Array<OrgSilService> = [
+    const minimalServices: Array<OrgSilServiceDTO> = [
       {
         orgSilServiceId: 1,
         organizationId: 123,
@@ -235,7 +235,7 @@ describe('useServiceSelectorState', () => {
   });
 
   it('handles services with additional optional fields', () => {
-    const richServices: Array<OrgSilService> = [
+    const richServices: Array<OrgSilServiceDTO> = [
       {
         orgSilServiceId: 1,
         organizationId: 123,
@@ -247,10 +247,6 @@ describe('useServiceSelectorState', () => {
         updateOperatorExternalId: 'operator123',
         updateTraceId: 'trace456',
         flagLegacy: false,
-        authConfig: {
-          clientId: 'client123',
-          secretKey: 'secret456'
-        } as any,
         _links: {
           self: { href: 'https://api.example.com/services/1' } as any
         }

--- a/src/routes/DebtTypeOrgCreate/hooks/useServiceSelectorState.ts
+++ b/src/routes/DebtTypeOrgCreate/hooks/useServiceSelectorState.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { UseQueryResult } from '@tanstack/react-query';
-import { OrgSilService } from '../../../api/orgSilServices';
+import { OrgSilServiceDTO } from '../../../../generated/data-contracts';
 
 type ServiceSelectorOption = {
   value: number;
@@ -18,15 +18,15 @@ type ServiceSelectorState = {
 };
 
 const hasValidId = (
-  service: OrgSilService
-): service is OrgSilService & { orgSilServiceId: number } => {
+  service: OrgSilServiceDTO
+): service is OrgSilServiceDTO & { orgSilServiceId: number } => {
   return (
     typeof service.orgSilServiceId === 'number' && service.orgSilServiceId > 0
   );
 };
 
 export const useServiceSelectorState = (
-  query: UseQueryResult<Array<OrgSilService>, Error>,
+  query: UseQueryResult<Array<OrgSilServiceDTO>, Error>,
   edit = false,
   baseTranslationKey: string
 ): ServiceSelectorState => {

--- a/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/components/ServiceSelector.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step2Behaviour/components/ServiceSelector.tsx
@@ -4,13 +4,13 @@ import { FormComponent } from '../../../../../components/FormComponent';
 import { DebtTypeOrgForm } from '../../../types';
 import { useServiceSelectorState } from '../../../hooks/useServiceSelectorState';
 import { UseQueryResult } from '@tanstack/react-query';
-import { OrgSilService } from '../../../../../api/orgSilServices';
+import { OrgSilServiceDTO } from '../.../../../../../../../generated/data-contracts';
 
 type ServiceSelectorProps = {
   control: Control<DebtTypeOrgForm>;
   name: keyof DebtTypeOrgForm;
   labelKey: string;
-  query: UseQueryResult<Array<OrgSilService>, Error>;
+  query: UseQueryResult<Array<OrgSilServiceDTO>, Error>;
   edit?: boolean;
   required?: boolean;
   baseTranslationKey: string;

--- a/src/store/FilterStore.test.ts
+++ b/src/store/FilterStore.test.ts
@@ -5,13 +5,17 @@ import {
   addFilterRow,
   removeFilterRow,
   updateFilter,
-  removeAllFilters
+  removeAllFilters,
+  filterValues,
+  initialFilterValues,
+  setFilterValues
 } from './FilterStore';
 
 describe('FilterStore', () => {
   beforeEach(() => {
     // Reset selectedFilters to its initial value before each test
     selectedFilters.value = [];
+    filterValues.value = initialFilterValues;
   });
 
   it('should initialize selectedFilters with an empty array', () => {
@@ -37,13 +41,22 @@ describe('FilterStore', () => {
   it('should remove the last filter row', () => {
     setSelectedFilters(['ACCOUNTING_DATE']);
     removeFilterRow('ACCOUNTING_DATE');
-    expect(selectedFilters.value).toEqual(['ACCOUNTING_DATE']);
+    expect(selectedFilters.value).toEqual([]);
   });
 
-  it('should update a filter by index', () => {
-    setSelectedFilters(['ACCOUNTING_DATE', 'AMOUNT']);
-    updateFilter('AMOUNT', 1);
-    expect(selectedFilters.value).toEqual(['ACCOUNTING_DATE', 'AMOUNT']);
+  it('should update a filter by index and reset the removed filter', () => {
+    setSelectedFilters(['IUV', 'AMOUNT']);
+    setFilterValues({
+      ...filterValues.value,
+      IUV: '123',
+      AMOUNT: 100
+    });
+    updateFilter('IUD', 1);
+    expect(selectedFilters.value).toEqual(['IUV', 'IUD']);
+    expect(filterValues.value.IUV).toEqual('123');
+    expect(filterValues.value.IUD).toEqual(initialFilterValues.IUD);
+    // Ensure that the previous filter value is reset
+    expect(filterValues.value.AMOUNT).toEqual(initialFilterValues.AMOUNT);
   });
 
   it('should remove all filters and reset to initial state', () => {

--- a/src/store/FilterStore.ts
+++ b/src/store/FilterStore.ts
@@ -67,18 +67,18 @@ export const addFilterRow = (nextId: KeyofFilterMap) => {
 
 export const removeFilterRow = (id: KeyofFilterMap) => {
   const filters = selectedFilters.value;
-  if (filters.length > 1) {
-    setSelectedFilters(filters.filter((filterId) => filterId !== id));
-    mapFilterNameToFilterValues[id].forEach((filter) => {
-      resetFilterValue(filter);
-    });
-  }
+  setSelectedFilters(filters.filter((filterId) => filterId !== id));
+  mapFilterNameToFilterValues[id].forEach((filter) => {
+    resetFilterValue(filter);
+  });
 };
 
 export const updateFilter = (id: KeyofFilterMap, index: number) => {
   const filters = [...selectedFilters.value];
+  const previousFilter = filters[index];
   filters[index] = id;
   setSelectedFilters(filters);
+  removeFilterRow(previousFilter);
 };
 
 export const filterValues = signal<FilterValues>(initialFilterValues);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Improved the updateFilter action and resetting the previous filter value to its default
- Modified a unit test to verify the filter value reset
- Updated the outdatated OrgSilService type with the new one OrgSilServiceDTO
<!--- Describe your changes in detail -->

#### Motivation and Context
This fix a bug with the filters state, resetting the old filter value to its default
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Manual and automatic (unit) test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
