### PR TITLE
fix: [P4ADEV-3501] fix translations label assessment detail

### DIFF
--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -243,7 +243,7 @@
       "step1": {
         "title": "Dettaglio accertamento",
         "fields": {
-          "name":{
+          "name": {
             "label": "Nome accertamento",
             "placeholder": "Accertamento",
             "required": "Il campo nome è obbligatorio"
@@ -726,7 +726,7 @@
     "taxCode": "Codice Tassonomico",
     "taxonomy": "Tassonomia",
     "to": "Al",
-    "resultFrom": "Esito da",
+    "resultFrom": "Esito dal",
     "transactionManager": "Gestore della transazione (PSP)",
     "unauthorized": "Non sei autorizzato ad accedere alla sezione, contatta il gestore dei permessi",
     "unknownOrganization": "Ente senza nome",


### PR DESCRIPTION
Fixed translation bug in the filters on Assessment Detail. The label "Esito da" was corrected to "Esito dal".


#### How Has This Been Tested?

-visual testing
-unit tests


#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:


- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
