### PR TITLE
fix: [P4ADEV-3376] css fix

### DIFF
--- a/src/components/DetailContainer/DetailContainer.tsx
+++ b/src/components/DetailContainer/DetailContainer.tsx
@@ -86,6 +86,7 @@ const DetailContainer = ({
         <Typography
           fontWeight={item.variant ?? 600}
           variant={item.variant ?? 'body1'}
+          sx={{ wordBreak: 'break-word' }}
         >
           {
             // eslint-disable-next-line sonarjs/function-return-type

--- a/src/routes/RegistryDetailPage/components/ExpandableCard.tsx
+++ b/src/routes/RegistryDetailPage/components/ExpandableCard.tsx
@@ -44,7 +44,8 @@ export const ExpandableCard: React.FC<ExpandableCardProps> = ({
         <Typography
           variant="body1"
           sx={{
-            whiteSpace: 'pre-wrap'
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word'
           }}
           data-testid="specific-params-content"
         >


### PR DESCRIPTION
This PR fixes text on DetailContainer when the entire string overflow the parent container

#### List of Changes
- add word-break

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
