### PR TITLE
feat: [P4ADEV-3465] update Sidebar and backoffice routes for improved role-based access control

### DIFF
--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -115,23 +115,6 @@ export const Sidebar: React.FC = () => {
       route: '/debtpositions',
       end: true
     });
-    additionalItems.push({
-      label: t('commons.routes.BACKOFFICE'),
-      icon: SettingsIcon,
-      end: false,
-      items: [
-        {
-          label: t('commons.routes.BACKOFFICE_TAXONOMY'),
-          route: PageRoutes.BACKOFFICE_TAXONOMY,
-          end: true
-        },
-        {
-          label: t('commons.routes.BACKOFFICE_EVENTS'),
-          route: PageRoutes.BACKOFFICE_EVENTS,
-          end: true
-        }
-      ]
-    });
   }
 
   if (isSuperAdmin || state.operatorRole == 'ROLE_ADMIN') {
@@ -166,6 +149,41 @@ export const Sidebar: React.FC = () => {
         items: debtypes
       }
     );
+
+    const commonBackOfficeItems = [
+      {
+        label: 'PLACEHOLDER MENU ITEM 1',
+        end: true
+      },
+      {
+        label: 'PLACEHOLDER MENU ITEM 2',
+        end: true
+      }
+    ];
+
+    // BACKOFFICE SECTION
+    additionalItems.push({
+      label: t('commons.routes.BACKOFFICE'),
+      icon: SettingsIcon,
+      end: false,
+      items: [
+        ...(isSuperAdmin
+          ? [
+              {
+                label: t('commons.routes.BACKOFFICE_TAXONOMY'),
+                route: PageRoutes.BACKOFFICE_TAXONOMY,
+                end: true
+              },
+              {
+                label: t('commons.routes.BACKOFFICE_EVENTS'),
+                route: PageRoutes.BACKOFFICE_EVENTS,
+                end: true
+              },
+              ...commonBackOfficeItems
+            ]
+          : commonBackOfficeItems)
+      ]
+    });
   }
 
   return (

--- a/src/components/Sidebar/sidebar.test.tsx
+++ b/src/components/Sidebar/sidebar.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import { Sidebar } from './Sidebar';
+import { StoreProvider } from '../../store/GlobalStore';
+import { OperatorRoleEnum } from '../../../generated/data-contracts';
+import { Theme } from '../../utils/theme';
+import { MemoryRouter } from 'react-router';
+import { setOperatorRole } from '../../store/OperatorRoleStore';
+import utils from '../../utils';
+
+const renderSidebar = () =>
+  render(
+    <StoreProvider>
+      <MemoryRouter>
+        <Theme>
+          <Sidebar />
+        </Theme>
+      </MemoryRouter>
+    </StoreProvider>
+  );
+
+describe('Sidebar component', () => {
+  it('should not render backoffice section when the role is operator', () => {
+    setOperatorRole(OperatorRoleEnum.ROLE_OPER);
+    vi.spyOn(utils.roles, 'useIsSuperAdmin').mockImplementation(() => false);
+
+    renderSidebar();
+
+    expect(screen.queryByText('commons.routes.BACKOFFICE')).toBeNull();
+  });
+
+  it('should render backoffice section with all sub menu items when the role is superAdmin', () => {
+    setOperatorRole(OperatorRoleEnum.ROLE_ADMIN);
+    vi.spyOn(utils.roles, 'useIsSuperAdmin').mockImplementation(() => true);
+
+    renderSidebar();
+
+    expect(screen.queryByText('commons.routes.BACKOFFICE')).toBeDefined();
+    expect(
+      screen.queryByText('commons.routes.BACKOFFICE_TAXONOMY')
+    ).toBeDefined();
+    expect(
+      screen.queryByText('commons.routes.BACKOFFICE_EVENTS')
+    ).toBeDefined();
+    // PLEASE UPDATE WITH THE DEFINTIVE MENU ITEMS NAME
+    expect(screen.queryByText('PLACEHOLDER MENU ITEM 1')).toBeDefined();
+    expect(screen.queryByText('PLACEHOLDER MENU ITEM 2')).toBeDefined();
+  });
+
+  it('should render backoffice section with a limited sub menu items when the role is admin', () => {
+    setOperatorRole(OperatorRoleEnum.ROLE_ADMIN);
+    vi.spyOn(utils.roles, 'useIsSuperAdmin').mockImplementation(() => false);
+
+    renderSidebar();
+
+    expect(screen.queryByText('commons.routes.BACKOFFICE')).toBeDefined();
+    expect(screen.queryByText('commons.routes.BACKOFFICE_TAXONOMY')).toBeNull();
+    expect(screen.queryByText('commons.routes.BACKOFFICE_EVENTS')).toBeNull();
+    // PLEASE UPDATE WITH THE DEFINTIVE MENU ITEMS NAME
+    expect(screen.queryByText('PLACEHOLDER MENU ITEM 1')).toBeDefined();
+    expect(screen.queryByText('PLACEHOLDER MENU ITEM 2')).toBeDefined();
+  });
+});

--- a/src/routes/backoffice.tsx
+++ b/src/routes/backoffice.tsx
@@ -16,11 +16,7 @@ export const backofficeRoutes = [
   {
     id: 'BACKOFFICE',
     path: `backoffice/`,
-    element: (
-      <SuperAdminRouteGuard>
-        <Outlet />
-      </SuperAdminRouteGuard>
-    ),
+    element: <Outlet />,
     children: [
       {
         element: <Navigate replace to={`${deployPath}/`} />,
@@ -29,6 +25,11 @@ export const backofficeRoutes = [
       {
         id: 'BACKOFFICE_TAXONOMY',
         path: 'taxonomy/',
+        element: (
+          <SuperAdminRouteGuard>
+            <Outlet />
+          </SuperAdminRouteGuard>
+        ),
         children: [
           {
             id: 'BACKOFFICE_TAXONOMY_INDEX',
@@ -60,7 +61,11 @@ export const backofficeRoutes = [
       {
         id: 'BACKOFFICE_EVENTS',
         path: 'events/',
-        element: <EventsContainer />,
+        element: (
+          <SuperAdminRouteGuard>
+            <EventsContainer />
+          </SuperAdminRouteGuard>
+        ),
         children: [
           {
             id: 'BACKOFFICE_EVENTS_INDEX',

--- a/src/utils/roles.ts
+++ b/src/utils/roles.ts
@@ -1,5 +1,14 @@
 import { useStore } from '../store/GlobalStore';
 
+/** Roles
++---------------+--------------+----------+
+| INTERMEDIARIO | INTERMEDIATO |          |
+| SUPERADMIN    | ADMIN        | ADMIN    |
+| OPERATOR      |              | OPERATOR |
++---------------+--------------+----------+
+SUPERADMIN > ADMIN > OPERATOR
+*/
+
 /** this hook returns true if the logged user is a super admin */
 const useIsSuperAdmin = () => {
   const { state } = useStore();


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. Update sidebar component to manage the new backoffice sub-menu items
2. Update backoffice rules moving superaAdmin guard to  BACKOFFICE_TAXONOMY and BACKOFFICE_EVENTS section
3. Added unit test to check the visibility of backoffice and backoffice sections by roles

<!--- Describe your changes in detail -->

#### Motivation and Context
This change is required because backoffice section will have two new section. An normal admin (not superAdmin) should see these new section except for BACKOFFICE TAXONOMY and BACKOFFICE EVENTS
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

Tested by manual testing and by unit tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
