### PR TITLE
feat: [P4ADEV-3483] open payment detail in a new tab during assessment creation 

### DIFF
--- a/src/components/BackButton/index.test.tsx
+++ b/src/components/BackButton/index.test.tsx
@@ -1,0 +1,177 @@
+import { screen, fireEvent } from '@testing-library/react';
+import { useNavigate } from 'react-router';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { i18nTestSetup } from '../../__tests__/i18nTestSetup';
+import { render } from '../../__tests__/renderers';
+import { BackButton } from '.';
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return {
+    ...actual,
+    useNavigate: vi.fn(),
+    useLocation: vi.fn()
+  };
+});
+
+const mockNavigate = vi.fn();
+const mockUseNavigate = useNavigate as ReturnType<typeof vi.fn>;
+const mockUseLocation = vi.mocked(await import('react-router')).useLocation;
+
+describe('BackButton', () => {
+  beforeEach(() => {
+    i18nTestSetup({
+      'commons.back': 'Back'
+    });
+
+    mockNavigate.mockClear();
+    mockUseNavigate.mockReturnValue(mockNavigate);
+
+    Object.defineProperty(window, 'history', {
+      value: { length: 2 },
+      writable: true
+    });
+  });
+
+  describe('when history is available', () => {
+    beforeEach(() => {
+      mockUseLocation.mockReturnValue({
+        key: 'some-key',
+        pathname: '/current-path',
+        search: '',
+        hash: '',
+        state: null
+      });
+    });
+
+    it('should render button with default text', () => {
+      render(<BackButton />);
+
+      const button = screen.getByRole('button', { name: 'Back' });
+      expect(button).toBeInTheDocument();
+      expect(button).toHaveTextContent('Back');
+    });
+
+    it('should render button with custom text', () => {
+      const customText = 'Go back to list';
+      render(<BackButton text={customText} />);
+
+      const button = screen.getByRole('button', { name: customText });
+      expect(button).toBeInTheDocument();
+      expect(button).toHaveTextContent(customText);
+    });
+
+    it('should call navigate(-1) when clicked without custom onClick', () => {
+      render(<BackButton />);
+
+      const button = screen.getByRole('button', { name: 'Back' });
+      fireEvent.click(button);
+
+      expect(mockNavigate).toHaveBeenCalledWith(-1);
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call custom onClick when provided', () => {
+      const mockOnClick = vi.fn();
+      render(<BackButton onClick={mockOnClick} />);
+
+      const button = screen.getByRole('button', { name: 'Back' });
+      fireEvent.click(button);
+
+      expect(mockOnClick).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('should have ArrowBack icon', () => {
+      render(<BackButton />);
+
+      const button = screen.getByRole('button', { name: 'Back' });
+      const icon = button.querySelector('svg');
+      expect(icon).toBeInTheDocument();
+    });
+
+    it('should have correct accessibility attributes', () => {
+      render(<BackButton />);
+
+      const button = screen.getByRole('button', { name: 'Back' });
+      expect(button).toHaveAttribute('aria-label', 'Back');
+    });
+  });
+
+  describe('when history is NOT available', () => {
+    it('should NOT render when location.key is "default"', () => {
+      mockUseLocation.mockReturnValue({
+        key: 'default',
+        pathname: '/current-path',
+        search: '',
+        hash: '',
+        state: null
+      });
+
+      render(<BackButton />);
+
+      const button = screen.queryByRole('button', { name: 'Back' });
+      expect(button).not.toBeInTheDocument();
+    });
+
+    it('should NOT render when window.history.length is 1', () => {
+      mockUseLocation.mockReturnValue({
+        key: 'some-key',
+        pathname: '/current-path',
+        search: '',
+        hash: '',
+        state: null
+      });
+
+      Object.defineProperty(window, 'history', {
+        value: { length: 1 },
+        writable: true
+      });
+
+      render(<BackButton />);
+
+      const button = screen.queryByRole('button', { name: 'Back' });
+      expect(button).not.toBeInTheDocument();
+    });
+
+    it('should NOT render when both conditions are false', () => {
+      mockUseLocation.mockReturnValue({
+        key: 'default',
+        pathname: '/current-path',
+        search: '',
+        hash: '',
+        state: null
+      });
+
+      Object.defineProperty(window, 'history', {
+        value: { length: 1 },
+        writable: true
+      });
+
+      render(<BackButton />);
+
+      const button = screen.queryByRole('button', { name: 'Back' });
+      expect(button).not.toBeInTheDocument();
+    });
+  });
+
+  describe('edge cases', () => {
+    beforeEach(() => {
+      mockUseLocation.mockReturnValue({
+        key: 'some-key',
+        pathname: '/current-path',
+        search: '',
+        hash: '',
+        state: null
+      });
+    });
+
+    it('should handle empty text', () => {
+      render(<BackButton text="" />);
+
+      const button = screen.getByRole('button', { name: '' });
+      expect(button).toBeInTheDocument();
+      expect(button).toHaveTextContent('');
+    });
+  });
+});

--- a/src/components/BackButton/index.tsx
+++ b/src/components/BackButton/index.tsx
@@ -1,7 +1,7 @@
 import { ArrowBack } from '@mui/icons-material';
 import Button from '@mui/material/Button';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router';
+import { useNavigate, useLocation } from 'react-router';
 
 export type BackButtonProps = {
   text?: string;
@@ -10,8 +10,15 @@ export type BackButtonProps = {
 
 export const BackButton = (props: BackButtonProps) => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { t } = useTranslation();
   const { text = t('commons.back'), onClick = () => navigate(-1) } = props;
+
+  const hasHistory = location.key !== 'default' && window.history.length > 1;
+
+  if (!hasHistory) {
+    return null;
+  }
 
   return (
     <Button

--- a/src/routes/AssessmentCreate/components/PaymentsTable.test.tsx
+++ b/src/routes/AssessmentCreate/components/PaymentsTable.test.tsx
@@ -19,6 +19,18 @@ const mockUsePaymentsTableFilters = {
   handleDateToChange: vi.fn()
 };
 
+vi.mock('../..', () => ({
+  PageRoutes: {
+    TELEMATIC_RECEIPT_DETAIL: '/telematic-receipt/:id'
+  }
+}));
+
+vi.mock('../../path/to/routes', () => ({
+  PageRoutes: {
+    TELEMATIC_RECEIPT_DETAIL: '/telematic-receipt/:id'
+  }
+}));
+
 vi.mock('../../../hooks/usePaymentsTableFilters', () => ({
   usePaymentsTableFilters: () => mockUsePaymentsTableFilters
 }));
@@ -227,6 +239,27 @@ describe('PaymentsTable', () => {
   });
 
   describe('Detail Actions', () => {
+    const mockWindowOpen = vi.fn();
+
+    beforeEach(() => {
+      mockWindowOpen.mockClear();
+      Object.defineProperty(window, 'open', {
+        value: mockWindowOpen,
+        writable: true
+      });
+
+      Object.defineProperty(window, 'location', {
+        value: {
+          origin: 'https://test-app.com'
+        },
+        writable: true
+      });
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
     it('renders detail button for each row', () => {
       render(<PaymentsTable {...defaultProps} />);
 
@@ -235,27 +268,182 @@ describe('PaymentsTable', () => {
       expect(iconButton).toBeInTheDocument();
     });
 
-    it('logs detail click when detail button is pressed', () => {
-      const consoleSpy = vi.spyOn(console, 'log');
+    it('opens detail page in new tab when detail button is clicked', () => {
+      const mockDataWithReceiptId: PagedPaidInstallmentsDTO = {
+        content: [
+          {
+            ...mockPaidInstallment,
+            receiptPaymentRequestId: '12345'
+          }
+        ],
+        totalElements: 1,
+        totalPages: 1,
+        number: 0,
+        size: 10
+      };
 
-      render(<PaymentsTable {...defaultProps} />);
+      render(<PaymentsTable {...defaultProps} data={mockDataWithReceiptId} />);
 
       const actionCell = screen.getByRole('gridcell', { name: '' });
       const detailButton = actionCell.querySelector('button');
+
       if (detailButton) {
         fireEvent.click(detailButton);
       }
 
-      expect(consoleSpy).toHaveBeenCalledWith(
-        'Detail clicked for:',
-        expect.objectContaining({
-          iud: 'test-iud-1',
-          iuv: 'test-iuv-1',
-          uniqueId: expect.stringContaining('test-iud-1-0')
-        })
+      expect(mockWindowOpen).toHaveBeenCalledTimes(1);
+      expect(mockWindowOpen).toHaveBeenCalledWith(
+        'https://test-app.com/telematic-receipt/12345',
+        '_blank',
+        'noopener,noreferrer'
+      );
+    });
+
+    it('generates correct URL path for detail navigation', () => {
+      const testReceiptId = '67890';
+      const mockDataWithSpecificId: PagedPaidInstallmentsDTO = {
+        content: [
+          {
+            ...mockPaidInstallment,
+            receiptPaymentRequestId: testReceiptId
+          }
+        ],
+        totalElements: 1,
+        totalPages: 1,
+        number: 0,
+        size: 10
+      };
+
+      render(<PaymentsTable {...defaultProps} data={mockDataWithSpecificId} />);
+
+      const actionCell = screen.getByRole('gridcell', { name: '' });
+      const detailButton = actionCell.querySelector('button');
+
+      if (detailButton) {
+        fireEvent.click(detailButton);
+      }
+
+      expect(mockWindowOpen).toHaveBeenCalledWith(
+        expect.stringContaining(`/telematic-receipt/${testReceiptId}`),
+        '_blank',
+        'noopener,noreferrer'
+      );
+    });
+
+    it('handles missing receiptPaymentRequestId gracefully', () => {
+      const mockDataWithoutReceiptId: PagedPaidInstallmentsDTO = {
+        content: [
+          {
+            ...mockPaidInstallment,
+            receiptPaymentRequestId: undefined
+          }
+        ],
+        totalElements: 1,
+        totalPages: 1,
+        number: 0,
+        size: 10
+      };
+
+      render(
+        <PaymentsTable {...defaultProps} data={mockDataWithoutReceiptId} />
       );
 
-      consoleSpy.mockRestore();
+      const actionCell = screen.getByRole('gridcell', { name: '' });
+      const detailButton = actionCell.querySelector('button');
+
+      if (detailButton) {
+        fireEvent.click(detailButton);
+      }
+
+      expect(mockWindowOpen).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses correct security parameters for new tab', () => {
+      render(<PaymentsTable {...defaultProps} />);
+
+      const actionCell = screen.getByRole('gridcell', { name: '' });
+      const detailButton = actionCell.querySelector('button');
+
+      if (detailButton) {
+        fireEvent.click(detailButton);
+      }
+
+      const [, target, features] = mockWindowOpen.mock.calls[0];
+
+      expect(target).toBe('_blank');
+      expect(features).toBe('noopener,noreferrer');
+    });
+
+    it('opens different URLs for different rows', () => {
+      const mockDataMultipleRows: PagedPaidInstallmentsDTO = {
+        content: [
+          {
+            ...mockPaidInstallment,
+            iud: 'iud-1',
+            receiptPaymentRequestId: '111'
+          },
+          {
+            ...mockPaidInstallment,
+            iud: 'iud-2',
+            receiptPaymentRequestId: '222'
+          }
+        ],
+        totalElements: 2,
+        totalPages: 1,
+        number: 0,
+        size: 10
+      };
+
+      render(<PaymentsTable {...defaultProps} data={mockDataMultipleRows} />);
+
+      const actionCells = screen.getAllByRole('gridcell', { name: '' });
+      const detailButtons = actionCells
+        .map((cell) => cell.querySelector('button'))
+        .filter(Boolean);
+
+      if (detailButtons[0]) {
+        fireEvent.click(detailButtons[0]);
+      }
+
+      expect(mockWindowOpen).toHaveBeenCalledWith(
+        expect.stringContaining('/telematic-receipt/111'),
+        '_blank',
+        'noopener,noreferrer'
+      );
+
+      mockWindowOpen.mockClear();
+
+      if (detailButtons[1]) {
+        fireEvent.click(detailButtons[1]);
+      }
+
+      expect(mockWindowOpen).toHaveBeenCalledWith(
+        expect.stringContaining('/telematic-receipt/222'),
+        '_blank',
+        'noopener,noreferrer'
+      );
+    });
+
+    it('integrates correctly with react-router generatePath', () => {
+      render(<PaymentsTable {...defaultProps} />);
+
+      const actionCell = screen.getByRole('gridcell', { name: '' });
+      const detailButton = actionCell.querySelector('button');
+
+      if (detailButton) {
+        fireEvent.click(detailButton);
+      }
+
+      const calledUrl = mockWindowOpen.mock.calls[0][0];
+      expect(calledUrl).toMatch('https://test-app.com/telematic-receipt/NaN');
+    });
+
+    it('renders detail button for each row', () => {
+      render(<PaymentsTable {...defaultProps} />);
+
+      const actionCell = screen.getByRole('gridcell', { name: '' });
+      const iconButton = actionCell.querySelector('button');
+      expect(iconButton).toBeInTheDocument();
     });
   });
 

--- a/src/routes/AssessmentCreate/components/PaymentsTable.tsx
+++ b/src/routes/AssessmentCreate/components/PaymentsTable.tsx
@@ -14,6 +14,8 @@ import {
   PaidInstallmentDTO
 } from '../../../api/classifications/paidInstallments/mappings';
 import { usePaymentsTableFilters } from '../../../hooks/usePaymentsTableFilters';
+import { generatePath } from 'react-router';
+import { PageRoutes } from '../..';
 
 // TEMPORARY: Type for row with added uniqueId until backend fixes duplicate IUDs
 type PaymentRowWithUniqueId = PaidInstallmentDTO & {
@@ -159,8 +161,12 @@ export const PaymentsTable = ({
   );
 
   const handleDetailClick = useCallback((row: PaymentRowWithUniqueId) => {
-    console.log('Detail clicked for:', row);
-    // TODO: Navigate to detail page when implemented
+    const detailPath = generatePath(PageRoutes.TELEMATIC_RECEIPT_DETAIL, {
+      id: Number(row.receiptPaymentRequestId)
+    });
+
+    const fullUrl = `${window.location.origin}${detailPath}`;
+    window.open(fullUrl, '_blank', 'noopener,noreferrer');
   }, []);
 
   const columns: Array<GridColDef> = [


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- The BackButton in breadcrumbs is now hidden if the history is empty
- Added navigation to another tab when clicking the button to view a payment detail while creating an assessment

<!--- Describe your changes in detail -->

#### Motivation and Context

It should be possible for the user to navigate to a payment detail during assessment creation while maintaining the selected preferences in the creation wizard. A requirement was identified that the detail page should open in a new tab. Consequently, the back button has been modified to not be rendered when the history is empty (as it is in the case of a newly opened tab).
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

- unit tests
- visual testing
- manual interaction
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
