### PR TITLE
feat: [P4ADEV-3562] creation wizard: list of Due Types

### DIFF
--- a/src/routes/DebtPositionCreateWizard/components/Step/Step1GeneralConfiguration.test.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step/Step1GeneralConfiguration.test.tsx
@@ -62,12 +62,14 @@ describe('Step1GeneralConfiguration', () => {
       debtPositionTypeOrgId: 1,
       description: 'Tipo 1',
       flagMandatoryDueDate: false,
+      flagActive: true,
       code: 'TYPE_1'
     },
     {
       debtPositionTypeOrgId: 2,
       description: 'Tipo 2',
       flagMandatoryDueDate: true,
+      flagActive: true,
       code: 'TYPE_2'
     }
   ];
@@ -524,6 +526,7 @@ describe('Step1GeneralConfiguration', () => {
           debtPositionTypeOrgId: 2,
           description: 'Tipo 2',
           flagMandatoryDueDate: true,
+          flagActive: true,
           code: 'TYPE_2'
         }
       ],
@@ -607,6 +610,7 @@ describe('Step1GeneralConfiguration', () => {
           debtPositionTypeOrgId: 999, // ID that won't match our processed types
           description: 'Tipo Non Processato',
           flagMandatoryDueDate: false,
+          flagActive: true,
           code: 'TYPE_1'
         }
       ],

--- a/src/routes/DebtPositionCreateWizard/components/Step/Step1GeneralConfiguration.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step/Step1GeneralConfiguration.tsx
@@ -54,17 +54,40 @@ const Step1GeneralConfiguration = ({
   const debtPositionsTypes: Array<DebtPositionType> = useMemo(() => {
     if (!debtPositionTypeOrgsData) return [];
 
-    return debtPositionTypeOrgsData
-      .filter(
-        (type) => type?.description && type?.debtPositionTypeOrgId !== undefined
-      )
-      .sort((a, b) => a.description.localeCompare(b.description))
-      .map((type) => ({
-        label: type.description,
-        value: type.debtPositionTypeOrgId as number,
-        flagMandatoryDueDate: type.flagMandatoryDueDate || false
-      }));
-  }, [debtPositionTypeOrgsData]);
+    let filteredTypes = debtPositionTypeOrgsData.filter(
+      (type) => type?.description && type?.debtPositionTypeOrgId !== undefined
+    );
+
+    if (!isEditing) {
+      filteredTypes = filteredTypes.filter((type) => type?.flagActive);
+    } else {
+      if (debtPositionTypeOrgCode && debtPositionTypeOrgsData) {
+        const originalType = debtPositionTypeOrgsData.find(
+          (typeOrg) => typeOrg.code === debtPositionTypeOrgCode
+        );
+
+        if (originalType && !originalType.flagActive) {
+          const isOriginalTypeIncluded = filteredTypes.some(
+            (type) =>
+              type.debtPositionTypeOrgId === originalType.debtPositionTypeOrgId
+          );
+
+          if (!isOriginalTypeIncluded) {
+            filteredTypes.push(originalType);
+          }
+        }
+      }
+    }
+
+    const sortedTypes = [...filteredTypes].sort((a, b) =>
+      a.description.localeCompare(b.description)
+    );
+    return sortedTypes.map((type) => ({
+      label: type.description,
+      value: type.debtPositionTypeOrgId as number,
+      flagMandatoryDueDate: type.flagMandatoryDueDate || false
+    }));
+  }, [debtPositionTypeOrgsData, isEditing, debtPositionTypeOrgCode]);
 
   const schema = createStep1GeneralConfigurationSchema(t);
 


### PR DESCRIPTION
In this PR, I added the logic to filter due types so that only active ones are displayed in the select field of Step 1 within the creation and editing wizard for debt positions


#### How Has This Been Tested?

-visual testing
-unit tests


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
