### PR TITLE
feat: [P4ADEV-3517] View debt types for a specific Org id

### DIFF
--- a/src/routes/DebtTypesCreated/DebtTypesCreated.test.tsx
+++ b/src/routes/DebtTypesCreated/DebtTypesCreated.test.tsx
@@ -23,7 +23,31 @@ vi.mock('react-router', async () => {
 
 vi.mock('../../store/GlobalStore', () => ({
   useStore: () => ({
-    state: { organizationId: 123 }
+    state: {
+      organizationId: 123,
+      organizations: [
+        {
+          organizationId: 1,
+          ipaCode: 'REGIONE_A',
+          orgName: 'Regione A',
+          operatorRole: 'ROLE_ADMIN',
+          orgFiscalCode: '30002310204',
+          flagNotifyIo: true,
+          flagNotifyOutcomePush: false,
+          flagPaymentNotification: false
+        },
+        {
+          organizationId: 2,
+          ipaCode: 'REGIONE_B',
+          orgName: 'Regione B',
+          operatorRole: 'ROLE_ADMIN',
+          orgFiscalCode: '30002310206',
+          flagNotifyIo: true,
+          flagNotifyOutcomePush: false,
+          flagPaymentNotification: false
+        }
+      ]
+    }
   }),
   StoreProvider: ({ children }: { children: React.ReactNode }) => children
 }));

--- a/src/routes/DebtTypesCreated/DebtTypesCreated.tsx
+++ b/src/routes/DebtTypesCreated/DebtTypesCreated.tsx
@@ -2,18 +2,25 @@ import { Add } from '@mui/icons-material';
 import { Box, Tab, Tabs } from '@mui/material';
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate, useSearchParams } from 'react-router';
+import { useNavigate, useParams, useSearchParams } from 'react-router';
 import TitleComponent from '../../components/TitleComponent/TitleComponent';
 import { PageRoutes } from '../../routes';
 import ManagedOrgs from './ManagedOrgs/ManagedOrgs';
 import MyOrg from './MyOrg/MyOrg';
 import utils from '../../utils';
+import { useStore } from '../../store/GlobalStore';
 
 export const DebtTypesCreated = () => {
   const isSuperAdmin = utils.roles.useIsSuperAdmin();
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
+  const { organizationId: organizationIdByURL } = useParams<{
+    organizationId: string;
+  }>();
+  const {
+      state: { organizations },
+    } = useStore();
 
   const getInitialTab = () => {
     const tabParam = searchParams.get('tab');
@@ -89,24 +96,33 @@ export const DebtTypesCreated = () => {
       </Box>
     );
   };
-
-  return (
-    <>
-      <TitleComponent
-        title={t('commons.routes.DEBT_TYPES_DASHBOARD')}
-        callToAction={[
+  
+  const callToActionEl = [
           {
             icon: <Add />,
             buttonText: t('debtTypesCreated.callToAction'),
             onActionClick: () => navigate(PageRoutes.DEBT_TYPE_ORG_CREATE)
           }
-        ]}
-        description={t(
-          `debtTypesCreated.description${isSuperAdmin ? 'Full' : ''}`
+        ];
+  
+  const descriptionByUrl = t('debtTypesCreated.descriptionByURL') ;
+
+  const org = organizations.find(o => o.organizationId === Number(organizationIdByURL));
+
+  const titleByUrl = org ? org.orgName : undefined;
+
+  return (
+    <>
+      <TitleComponent
+        title={titleByUrl ?? t('commons.routes.DEBT_TYPES_DASHBOARD')}
+        callToAction={!organizationIdByURL ? callToActionEl : []}
+        description={t(!organizationIdByURL ?
+          `debtTypesCreated.description${isSuperAdmin ? 'Full' : ''}` :
+          descriptionByUrl
         )}
       />
 
-      {isSuperAdmin ? renderTabs() : null}
+      {isSuperAdmin && !organizationIdByURL ? renderTabs() : null}
 
       <Box>
         {tabValue === 0 ? (

--- a/src/routes/DebtTypesCreated/DebtTypesCreated.tsx
+++ b/src/routes/DebtTypesCreated/DebtTypesCreated.tsx
@@ -19,8 +19,8 @@ export const DebtTypesCreated = () => {
     organizationId: string;
   }>();
   const {
-      state: { organizations },
-    } = useStore();
+    state: { organizations }
+  } = useStore();
 
   const getInitialTab = () => {
     const tabParam = searchParams.get('tab');
@@ -96,30 +96,34 @@ export const DebtTypesCreated = () => {
       </Box>
     );
   };
-  
-  const callToActionEl = [
-          {
-            icon: <Add />,
-            buttonText: t('debtTypesCreated.callToAction'),
-            onActionClick: () => navigate(PageRoutes.DEBT_TYPE_ORG_CREATE)
-          }
-        ];
-  
-  const descriptionByUrl = t('debtTypesCreated.descriptionByURL') ;
 
-  const org = organizations.find(o => o.organizationId === Number(organizationIdByURL));
+  const callToActionEl = [
+    {
+      icon: <Add />,
+      buttonText: t('debtTypesCreated.callToAction'),
+      onActionClick: () => navigate(PageRoutes.DEBT_TYPE_ORG_CREATE)
+    }
+  ];
+
+  const descriptionByUrl = t('debtTypesCreated.descriptionByURL');
+
+  const org = organizations.find(
+    (o) => o.organizationId === Number(organizationIdByURL)
+  );
 
   const titleByUrl = org ? org.orgName : undefined;
+
+  const descriptionFullOrNot = `debtTypesCreated.description${isSuperAdmin ? 'Full' : ''}`;
+  const description = !organizationIdByURL
+    ? descriptionFullOrNot
+    : descriptionByUrl;
 
   return (
     <>
       <TitleComponent
         title={titleByUrl ?? t('commons.routes.DEBT_TYPES_DASHBOARD')}
         callToAction={!organizationIdByURL ? callToActionEl : []}
-        description={t(!organizationIdByURL ?
-          `debtTypesCreated.description${isSuperAdmin ? 'Full' : ''}` :
-          descriptionByUrl
-        )}
+        description={t(description)}
       />
 
       {isSuperAdmin && !organizationIdByURL ? renderTabs() : null}

--- a/src/routes/DebtTypesCreated/ManagedOrgs/ManagedOrgs.tsx
+++ b/src/routes/DebtTypesCreated/ManagedOrgs/ManagedOrgs.tsx
@@ -19,10 +19,13 @@ import FilterContainer, {
   FilterItem
 } from '../../../components/FilterContainer/FilterContainer';
 import Search from '@mui/icons-material/Search';
+import { generatePath, useNavigate } from 'react-router';
+import { PageRoutes } from '../..';
 
 export const ManagedOrgs = () => {
   const theme = useTheme();
   const { t } = useTranslation();
+  const navigate = useNavigate();
 
   const {
     state: { organizationId }
@@ -87,8 +90,11 @@ export const ManagedOrgs = () => {
     row: OrganizationWithDebtPositionTypeOrgCount | undefined
   ) => {
     if (!row) return;
-    //TODO: redirect to organization detail
-    console.log('Organization:', row);
+    navigate(
+      generatePath(PageRoutes.DEBT_TYPES_DASHBOARD_BYORG, {
+        organizationId: row.organizationId
+      })
+    );
   };
 
   const items: Array<FilterItem> = [

--- a/src/routes/DebtTypesCreated/MyOrg/MyOrg.tsx
+++ b/src/routes/DebtTypesCreated/MyOrg/MyOrg.tsx
@@ -13,7 +13,7 @@ import {
 import { DebtPositionTypeOrgWithCount } from '../../../../generated/data-contracts';
 import { useStore } from '../../../store/GlobalStore';
 import { formatDateTime } from '../../../utils/formatters';
-import { generatePath, useNavigate } from 'react-router';
+import { generatePath, useNavigate, useParams } from 'react-router';
 import { PageRoutes } from '../../../routes';
 import { useSearch } from '../../../hooks/useSearch';
 import FilterContainer, {
@@ -27,6 +27,9 @@ export const MyOrg = () => {
   const theme = useTheme();
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const { organizationId: organizationIdByURL } = useParams<{
+    organizationId: string;
+  }>();
 
   const initialFilters: DebtPositionTypeOrgWithCountFilters = utils.URI.decode(
     window.location.hash
@@ -38,7 +41,12 @@ export const MyOrg = () => {
     state: { organizationId }
   } = useStore();
 
-  const query = useDebtPositionTypeOrgSearch(organizationId);
+  // switch if list types using organizationID in URL or setted in the storage
+  const query = useDebtPositionTypeOrgSearch(
+    organizationIdByURL && !isNaN(Number(organizationIdByURL))
+      ? Number(organizationIdByURL)
+      : organizationId
+  );
 
   const {
     query: { data },

--- a/src/routes/debtTypeOrgs.tsx
+++ b/src/routes/debtTypeOrgs.tsx
@@ -24,6 +24,15 @@ export const debtTypeOrgsRoutes: Array<RouteObject> = [
         } as RouteHandleObject
       },
       {
+        id: 'DEBT_TYPES_DASHBOARD_BYORG',
+        element: <DebtTypesCreated />,
+        path: `:organizationId?`,
+        handle: {
+          backButton: true,
+          hideBreadcrumbs: false
+        } as RouteHandleObject
+      },
+      {
         id: 'DEBT_TYPE_ORG_DETAIL',
         path: 'detail/:debtPositionTypeOrgId',
         element: <DebtTypeDetailView />,

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -489,6 +489,51 @@
       "missingRequiredFields": "Verifica di aver compilato i filtri obbligatori"
     }
   },
+  "clientSil": {
+    "addNew": "Aggiungi nuovo",
+    "filters": {
+      "clientName": "Nome Client SIL",
+      "clientNamePlaceholder": "Inserisci il nome del client",
+      "clientId": "Client ID",
+      "clientIdPlaceholder": "Inserisci l'ID del client"
+    },
+    "table": {
+      "clientName": "Nome Client SIL",
+      "clientId": "Client ID"
+    },
+    "title": "Client SIL",
+    "description": "Gestisci i Client SIL dell'organizzazione",
+    "create": {
+      "title": "Aggiungi nuovo Client SIL",
+      "subtitle": "Il client ID e key secret saranno generati automaticamente dopo la creazione.",
+      "formLabel": "Form di creazione Client SIL",
+      "section": {
+        "description": {
+          "title": "Configurazione generale",
+          "subtitle": "Descrizione"
+        }
+      },
+      "success": {
+        "title": "Il SIL '{{clientName}}' è stato aggiunto!",
+        "description": "La trovi nella sezione Gestione SIL, dove puoi consultarlo in qualsiasi momento.",
+        "goToDetail": "Vedi dettaglio SIL"
+      },
+      "fields": {
+        "clientName": {
+          "label": "Nome Client SIL",
+          "placeholder": "Tassa seconde case",
+          "required": "Il nome del Client SIL è obbligatorio",
+          "maxLength": "Il nome non può superare i 100 caratteri",
+          "invalid": "Il nome del Client SIL può contenere solo caratteri alfanumerici ed i simboli - e _"
+        }
+      },
+      "error": {
+        "nameAlreadyExists": "Esiste già un Client SIL con questo nome",
+        "invalidData": "I dati inseriti non sono validi",
+        "generic": "Errore durante la creazione del Client SIL"
+      }
+    }
+  },
   "commons": {
     "404": "404: risorsa non disponibile",
     "info": "Informazioni",
@@ -754,6 +799,7 @@
       "DEBT_TYPES": "Tipi dovuti",
       "DEBT_TYPES_CATALOG": "Catalogo Tipi dovuti",
       "DEBT_TYPES_DASHBOARD": "Tipi dovuti impostati",
+      "DEBT_TYPES_DASHBOARD_BYORG": "Ente gestito",
       "DETAIL": "Dettagli",
       "DETAIL_FLOWS": "Dettaglio flusso",
       "EXPORT": "Export",
@@ -1504,6 +1550,7 @@
   "debtTypesCreated": {
     "callToAction": "Imposta nuovo",
     "descriptionFull": "In questa sezione trovi i Tipi di dovuti presenti nel proprio ente o negli enti gestiti.",
+    "descriptionByURL": "In questa sezione trovi i Tipi di dovuti presenti per l'ente gestito.",
     "description": "In questa sezione trovi i Tipi di dovuti presenti nel proprio ente.",
     "tabManagedOrganizations": "Enti gestiti",
     "tabMyOrganization": "Il mio ente",
@@ -1595,86 +1642,6 @@
     "apiName": "Nome API",
     "addAPI": "Aggiungi API"
   },
-  "orgSilServiceDetail": {
-    "description": "Ecco i dettagli dell'API.",
-    "notFound": "Servizio non trovato",
-    "noAuthConfigured": "Nessuna configurazione di autenticazione",
-    "sections": {
-      "generalConfig": {
-        "title": "Configurazione generale"
-      },
-      "authConfig": {
-        "title": "Modalità di autenticazione"
-      }
-    },
-    "fields": {
-      "applicationName": "Nome API",
-      "serviceUrl": "Service URL",
-      "serviceType": "Tipo Servizio",
-      "apiLegacy": "API Legacy",
-      "authConfig": "Auth Config",
-      "authUrl": "Auth URL",
-      "username": "Username",
-      "kid": "KID",
-      "subject": "Subject",
-      "issuer": "Issuer",
-      "algorithm": "Algorithm",
-      "signingKey": "Signing Key"
-    },
-    "serviceTypes": {
-      "paymentNotification": "Notifica Pagamenti",
-      "amountActualization": "Attualizzazione Importo"
-    },
-    "authTypes": {
-      "basicAuth": "Basic Auth",
-      "jwtAuth": "Legacy JWT"
-    }
-  },
-  "clientSil": {
-    "addNew": "Aggiungi nuovo",
-    "filters": {
-      "clientName": "Nome Client SIL",
-      "clientNamePlaceholder": "Inserisci il nome del client",
-      "clientId": "Client ID",
-      "clientIdPlaceholder": "Inserisci l'ID del client"
-    },
-    "table": {
-      "clientName": "Nome Client SIL",
-      "clientId": "Client ID"
-    },
-    "title": "Client SIL",
-    "description": "Gestisci i Client SIL dell'organizzazione",
-    "create": {
-      "title": "Aggiungi nuovo Client SIL",
-      "subtitle": "Il client ID e key secret saranno generati automaticamente dopo la creazione.",
-      "formLabel": "Form di creazione Client SIL",
-      "section": {
-        "description": {
-          "title": "Configurazione generale",
-          "subtitle": "Descrizione"
-        }
-      },
-      "success": {
-        "title": "Il SIL '{{clientName}}' è stato aggiunto!",
-        "description": "La trovi nella sezione Gestione SIL, dove puoi consultarlo in qualsiasi momento.",
-        "goToDetail": "Vedi dettaglio SIL"
-      },
-      "fields": {
-        "clientName": {
-          "label": "Nome Client SIL",
-          "placeholder": "Tassa seconde case",
-          "required": "Il nome del Client SIL è obbligatorio",
-          "maxLength": "Il nome non può superare i 100 caratteri",
-          "invalid": "Il nome del Client SIL può contenere solo caratteri alfanumerici ed i simboli - e _"
-        }
-      },
-      "error": {
-        "nameAlreadyExists": "Esiste già un Client SIL con questo nome",
-        "invalidData": "I dati inseriti non sono validi",
-        "generic": "Errore durante la creazione del Client SIL"
-      }
-    }
-  },
   "orgSilServiceCreate": {
     "actualization": "Attualizzazione importo",
     "paidNotificationOutcome": "Notifica Pagamenti",
@@ -1712,6 +1679,41 @@
       "requiredServiceType": "Il tipo di servizio è obbligatorio",
       "requiredLegacyType": "Seleziona un tipo di autenticazione legacy",
       "requiredField": "Campo obbligatorio"
+    }
+  },
+  "orgSilServiceDetail": {
+    "description": "Ecco i dettagli dell'API.",
+    "notFound": "Servizio non trovato",
+    "noAuthConfigured": "Nessuna configurazione di autenticazione",
+    "sections": {
+      "generalConfig": {
+        "title": "Configurazione generale"
+      },
+      "authConfig": {
+        "title": "Modalità di autenticazione"
+      }
+    },
+    "fields": {
+      "applicationName": "Nome API",
+      "serviceUrl": "Service URL",
+      "serviceType": "Tipo Servizio",
+      "apiLegacy": "API Legacy",
+      "authConfig": "Auth Config",
+      "authUrl": "Auth URL",
+      "username": "Username",
+      "kid": "KID",
+      "subject": "Subject",
+      "issuer": "Issuer",
+      "algorithm": "Algorithm",
+      "signingKey": "Signing Key"
+    },
+    "serviceTypes": {
+      "paymentNotification": "Notifica Pagamenti",
+      "amountActualization": "Attualizzazione Importo"
+    },
+    "authTypes": {
+      "basicAuth": "Basic Auth",
+      "jwtAuth": "Legacy JWT"
     }
   },
   "registry": {


### PR DESCRIPTION
This PR add a functionality to view debt types for a specific organizationId setted in url bypassing the stored one.

#### List of Changes
- Custom existing page
- Add a organization id management
- fix test

#### Motivation and Context
To have a "custom" debt types list for a specific Organization

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
