### PR TITLE
feat: [P4ADEV-3555] debt position wizard create manage messages for required fields

### DIFF
--- a/src/components/Wizard/WizardStepWrapper.tsx
+++ b/src/components/Wizard/WizardStepWrapper.tsx
@@ -1,19 +1,24 @@
 import { Box, Grid, Typography } from '@mui/material';
 import { theme } from '@pagopa/mui-italia';
 import { PropsWithChildren } from 'react';
+import { useTranslation } from 'react-i18next';
 
 type Props = {
   title?: string;
   subtitle?: string;
   alertMessage?: string;
+  showRequiredFieldsMessage?: boolean;
 };
 
 const WizardStepWrapper = ({
   title,
   subtitle,
   alertMessage,
+  showRequiredFieldsMessage = false,
   children
 }: PropsWithChildren<Props>) => {
+  const { t } = useTranslation();
+
   return (
     <Box
       bgcolor={theme.palette.common.white}
@@ -36,6 +41,15 @@ const WizardStepWrapper = ({
         {alertMessage && (
           <Typography variant="body1" color="error" sx={{ marginBottom: 2 }}>
             {alertMessage}
+          </Typography>
+        )}
+        {showRequiredFieldsMessage && (
+          <Typography
+            variant="body2"
+            color="error.main"
+            sx={{ fontWeight: 400, marginBottom: 1, marginTop: 2 }}
+          >
+            {t('commons.requiredFieldDescription')}
           </Typography>
         )}
       </Grid>

--- a/src/routes/DebtPositionCreateWizard/components/Step/Step1GeneralConfiguration.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step/Step1GeneralConfiguration.tsx
@@ -233,6 +233,7 @@ const Step1GeneralConfiguration = ({
       <WizardStepWrapper
         title={t('debtPositionCreateWizard.generalConfiguration.title')}
         subtitle={t('debtPositionCreateWizard.generalConfiguration.subtitle')}
+        showRequiredFieldsMessage={true}
       >
         <SectionBox
           title={t('debtPositionCreateWizard.step1.title')}

--- a/src/routes/DebtPositionCreateWizard/components/Step/Step2AddDebtor.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step/Step2AddDebtor.tsx
@@ -270,6 +270,7 @@ const Step2AddDebtor = ({
       <WizardStepWrapper
         title={t('debtPositionCreateWizard.addDebtor.title')}
         subtitle={t('debtPositionCreateWizard.addDebtor.subtitle')}
+        showRequiredFieldsMessage={true}
       >
         <SectionBox
           title={t('debtPositionCreateWizard.step2.title')}

--- a/src/routes/DebtPositionCreateWizard/components/Step/Step3.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step/Step3.tsx
@@ -684,6 +684,7 @@ const Step3 = ({
       <WizardStepWrapper
         title={t('debtPositionCreateWizard.configurationAlert.title')}
         subtitle={t('debtPositionCreateWizard.configurationAlert.subtitle')}
+        showRequiredFieldsMessage={true}
       >
         <SectionBox
           title={t('debtPositionCreateWizard.step3.title')}


### PR DESCRIPTION
In this PR, the text "* Indicates a required field" has been added to each step of the debt position creation/edit wizard.


#### How Has This Been Tested?

-visual testing
-unit tests

#### Screenshots (if appropriate):
<img width="1318" height="631" alt="Screenshot 2025-08-29 090748" src="https://github.com/user-attachments/assets/0adab315-2a54-41b5-a013-2b32fd05ffc7" />

<img width="919" height="806" alt="Screenshot 2025-08-29 090802" src="https://github.com/user-attachments/assets/79f41144-3e21-4a44-8676-940450a2ce81" />

<img width="986" height="718" alt="Screenshot 2025-08-29 090844" src="https://github.com/user-attachments/assets/2da2972c-6423-48dd-b321-2aff8fc29dff" />


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
