### PR TITLE
fix: [P4ADEV-3614] removing implicit date filters to the flows > conservation section

### DIFF
--- a/src/api/receipts/index.ts
+++ b/src/api/receipts/index.ts
@@ -13,7 +13,7 @@ export const getReceipts = ({ organizationId }: { organizationId: number }) =>
         organizationId,
         query
       );
-      parseAndLog(pagedReceiptViewSchema, data)
+      parseAndLog(pagedReceiptViewSchema, data);
       return data;
     }
   });

--- a/src/api/receipts/index.ts
+++ b/src/api/receipts/index.ts
@@ -1,6 +1,8 @@
 import { useMutation } from '@tanstack/react-query';
 import utils from '../../utils';
 import { buildQueryParams, TelematicReceiptsFilteredRequest } from './mappings';
+import { parseAndLog } from '../../utils/loaders';
+import { pagedReceiptViewSchema } from '../../../generated/zod-schema';
 
 export const getReceipts = ({ organizationId }: { organizationId: number }) =>
   useMutation({
@@ -11,6 +13,7 @@ export const getReceipts = ({ organizationId }: { organizationId: number }) =>
         organizationId,
         query
       );
+      parseAndLog(pagedReceiptViewSchema, data)
       return data;
     }
   });

--- a/src/api/receipts/mappings.ts
+++ b/src/api/receipts/mappings.ts
@@ -27,10 +27,10 @@ export const buildQueryParams = ({
 }: TelematicReceiptsFilteredRequest): TelematicReceiptsFiltered => ({
   receiptOrigin: ReceiptOriginType.RECEIPT_PAGOPA,
   iuv: filters.iuv,
-  paymentDateTimeFrom:utils.formatters.date.code(filters?.dateRange?.from),
+  paymentDateTimeFrom: utils.formatters.date.code(filters?.dateRange?.from),
   paymentDateTimeTo: utils.formatters.date.code(filters?.dateRange?.to),
   debtPositionTypeOrgId: filters.typeOrgId,
   sort,
   page: pagination.page,
-  size: pagination.size,
+  size: pagination.size
 });

--- a/src/api/receipts/mappings.ts
+++ b/src/api/receipts/mappings.ts
@@ -16,23 +16,21 @@ export type TelematicReceiptsFilteredRequest = {
   sort: Array<string>;
 };
 
+type TelematicReceiptsFiltered = Parameters<
+  typeof utils.apiClient.bff.getReceipts
+>[1];
+
 export const buildQueryParams = ({
   filters,
   pagination,
   sort
-}: TelematicReceiptsFilteredRequest) => ({
-  paymentDateTimeFrom:
-    utils.formatters.date.code(filters?.dateRange?.from) ??
-    new Date(0).toISOString(),
-  paymentDateTimeTo:
-    utils.formatters.date.code(filters?.dateRange?.to) ??
-    new Date().toISOString(),
+}: TelematicReceiptsFilteredRequest): TelematicReceiptsFiltered => ({
+  receiptOrigin: ReceiptOriginType.RECEIPT_PAGOPA,
+  iuv: filters.iuv,
+  paymentDateTimeFrom:utils.formatters.date.code(filters?.dateRange?.from),
+  paymentDateTimeTo: utils.formatters.date.code(filters?.dateRange?.to),
+  debtPositionTypeOrgId: filters.typeOrgId,
+  sort,
   page: pagination.page,
   size: pagination.size,
-  ...(filters?.typeOrgId && {
-    debtPositionTypeOrgId: filters.typeOrgId
-  }),
-  ...(filters?.iuv && { iuv: filters.iuv }),
-  ...(sort.length && { sort }),
-  receiptOrigin: ReceiptOriginType.RECEIPT_PAGOPA
 });


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- removing implicit date filters to the flows > conservation section

<!--- Describe your changes in detail -->

#### Motivation and Context
This is required because, if the user doesn't enter the filter date (from and to), is implicitly assumed that the range is between new Date(0) and new Date(), that's wrong
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Manual testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
