### PR TITLE
feat: [P4ADEV-3663] treasury label ordinante

### DIFF
--- a/src/components/ClassificationsSearchResults/SearchResultsDataGrid.tsx
+++ b/src/components/ClassificationsSearchResults/SearchResultsDataGrid.tsx
@@ -3,13 +3,13 @@ import { useTranslation } from 'react-i18next';
 import CustomDataGrid from '../DataGrid/CustomDataGrid';
 import { ReadMore } from '@mui/icons-material';
 import { IconButton } from '@mui/material';
-import { PagedTreasuredClassification } from '../../../generated/apiClient';
+import { PagedTreasuredClassificationExtendedDTO } from '../../../generated/apiClient';
 import { formatDate, moneyFormat } from '../../utils/formatters';
 import { generatePath, Link } from 'react-router';
 import { PageRoutes } from '../../routes';
 
 export type DataGridProps = {
-  data: PagedTreasuredClassification;
+  data: PagedTreasuredClassificationExtendedDTO;
 };
 
 const SearchResultsDataGrid = ({ data }: DataGridProps) => {

--- a/src/components/ClassificationsSearchResults/index.tsx
+++ b/src/components/ClassificationsSearchResults/index.tsx
@@ -14,7 +14,7 @@ import {
 } from '../../hooks/useMultiFilters';
 import { FilterDrawer } from '../Drawer/FilterDrawer';
 import { BaseFilterValues } from '../../models/Filters';
-import { PagedTreasuredClassification } from '../../../generated/data-contracts';
+import { PagedTreasuredClassificationExtendedDTO } from '../../../generated/data-contracts';
 import DownloadIcon from '@mui/icons-material/Download';
 import { getClassifications } from '../../api/classifications';
 import { useSearch } from '../../hooks/useSearch';
@@ -104,7 +104,10 @@ const ClassificationsSearchResults = () => {
         aria-label="results-table"
       >
         <SearchResultsDataGrid
-          data={classifications.query.data as PagedTreasuredClassification}
+          data={
+            classifications.query
+              .data as PagedTreasuredClassificationExtendedDTO
+          }
         />
       </Grid>
 

--- a/src/components/DetailContainer/DetailContainer.test.tsx
+++ b/src/components/DetailContainer/DetailContainer.test.tsx
@@ -75,7 +75,7 @@ describe('DetailContainer', () => {
       sections: [
         {
           data: [
-            { label: 'Ordinante', value: '' },
+            { label: 'Gestore della transazione (PSP)', value: '' },
             { label: 'Conto', value: '' }
           ]
         }
@@ -84,7 +84,9 @@ describe('DetailContainer', () => {
 
     render(<DetailContainer {...missingValuesProps} />);
 
-    const firstLabelDiv = screen.getByText('Ordinante').closest('div');
+    const firstLabelDiv = screen
+      .getByText('Gestore della transazione (PSP)')
+      .closest('div');
     const firstValueDiv = firstLabelDiv?.nextElementSibling;
     expect(firstValueDiv).toHaveTextContent('-');
 

--- a/src/components/DetailFlowPage/DetailFlowPage.tsx
+++ b/src/components/DetailFlowPage/DetailFlowPage.tsx
@@ -73,7 +73,7 @@ export const DetailFlowPage = () => {
         label: 'ID Rendicontazione',
         value: '2024-09-03PPAYITR1XXX-S500333000012024'
       },
-      { label: 'Ordinante', value: '' },
+      { label: 'Gestore della transazione (PSP)', value: '' },
       { label: 'Data Valuta', value: '02/09/2024' },
       { label: 'Data Contabile', value: '02/09/2024' },
       { label: 'Conto', value: '' },

--- a/src/routes/ClientSilDetail/index.test.tsx
+++ b/src/routes/ClientSilDetail/index.test.tsx
@@ -62,7 +62,9 @@ describe('ClientSIL Detail Page', () => {
     });
 
     // Mock the default export methods
-    const mockDeleteClientSil = clientSilApi.deleteClientSil as ReturnType<typeof vi.fn>;
+    const mockDeleteClientSil = clientSilApi.deleteClientSil as ReturnType<
+      typeof vi.fn
+    >;
     mockDeleteClientSil.mockReturnValue({
       mutateAsync: vi.fn()
     });

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -325,7 +325,7 @@
         "earnings": {
           "title": "Giornale di cassa",
           "accountCode": "Conto",
-          "pspLastName": "Ordinante",
+          "pspLastName": "Gestore della transazione (PSP)",
           "documentCode": "Codice documento",
           "billDate": "Data Valuta",
           "billYear": "Anno bolletta",
@@ -669,7 +669,7 @@
         "label": "IUF"
       },
       "payer": {
-        "label": "Ordinante",
+        "label": "Gestore della transazione (PSP)",
         "name": "Nome ordinante"
       },
       "remove": "Rimuovi filtri",
@@ -1898,7 +1898,7 @@
     "documentCode": "Codice documento",
     "importflowsdescription": "Carica un file .zip con l'informazione necessaria di Giornale di Cassa mancanti.",
     "importflowstitle": "Importa Flussi di Tesoreria",
-    "payer": "Ordinante",
+    "payer": "Gestore della transazione (PSP)",
     "search": "Cerca flussi di Tesoreria",
     "searchdescription": "inserisci almeno uno dei campi per cominciare la ricerca",
     "provisionalCode": "Codice provvisorio",


### PR DESCRIPTION
The label “Ordinante”, currently used both as a search filter and in the detail page, has been replaced with “Gestore della transazione (PSP)”. The replacement has been applied centrally to ensure that “Ordinante” is fully substituted across the application.

#### List of Changes

Fixed DTO import

Changed label from “Ordinante” to “Gestore della transazione (PSP)” throughout the project


#### How Has This Been Tested?

-visual testing
-unit tests


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
