### PR TITLE
fix: [P4ADEV-3697] decoding uri type date.to parameters as end of day date

### DIFF
--- a/src/utils/URI.ts
+++ b/src/utils/URI.ts
@@ -1,6 +1,7 @@
 import { formatDate, parse } from 'date-fns';
 import { unflatten, flatten } from 'flat';
 import queryString from 'query-string';
+import { endOfDay } from 'date-fns';
 
 function sanitizeKeyChars(input: string): string {
   // Allows letters, digits and literal dot
@@ -29,7 +30,11 @@ function decode(fragment: string): Record<string, string | Date> {
   Object.entries(parsed).forEach(([key, value]) => {
     const sanitizedKey = sanitizeKeyChars(key);
     if (isDateString(value)) {
-      flatObj[sanitizedKey] = toDate(value);
+      if (sanitizedKey.endsWith('to')) {
+        flatObj[sanitizedKey] = endOfDay(toDate(value));
+      } else {
+        flatObj[sanitizedKey] = toDate(value)
+      }
     } else {
       flatObj[sanitizedKey] = value;
     }

--- a/src/utils/URI.ts
+++ b/src/utils/URI.ts
@@ -33,7 +33,7 @@ function decode(fragment: string): Record<string, string | Date> {
       if (sanitizedKey.endsWith('to')) {
         flatObj[sanitizedKey] = endOfDay(toDate(value));
       } else {
-        flatObj[sanitizedKey] = toDate(value)
+        flatObj[sanitizedKey] = toDate(value);
       }
     } else {
       flatObj[sanitizedKey] = value;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Add a condition to the utils.URI.decode function to correctly manage the end of day date 

<!--- Describe your changes in detail -->

#### Motivation and Context
This is required because all type "date.to" URI parameters should be managed as end of day date. This was missing in the utils.URI.decode function
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Tested by manual tries
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
