### PR TITLE
feat: [P4ADEV-3565] Regenerate secret in ClientSIL Detail

### DIFF
--- a/src/api/clientSil/clientSil.test.ts
+++ b/src/api/clientSil/clientSil.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor } from '../../__tests__/renderers';
-import { getClientSils, deleteClientSil, getClientDetail } from './index';
+import {
+  getClientSils,
+  deleteClientSil,
+  getClientDetail,
+  generateClientSecret
+} from './index';
 import { buildQueryParams } from './mappings';
 import type { ClientSilFilteredRequest } from './mappings';
 import { AxiosResponse } from 'axios';
@@ -11,7 +16,8 @@ vi.mock('../../utils', () => ({
       bff: {
         getClients: vi.fn(),
         deleteClient: vi.fn(),
-        getClient: vi.fn()
+        getClient: vi.fn(),
+        generateClientSecret: vi.fn()
       }
     }
   }
@@ -255,6 +261,74 @@ describe('ClientSil API', () => {
         );
         expect(result.current.data).toEqual(dataMock);
       });
+    });
+  });
+
+  describe('regenerate secret values', () => {
+    it('should call generateClientSecret API with correct parameters', async () => {
+      const organizationId = 123;
+      const clientId = 'client123';
+
+      vi.mocked(utils.apiClient.bff.generateClientSecret).mockResolvedValue({
+        data: undefined
+      } as AxiosResponse);
+
+      const { result } = renderHook(() => generateClientSecret(organizationId));
+
+      result.current.mutate(clientId);
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(utils.apiClient.bff.generateClientSecret).toHaveBeenCalledWith(
+        organizationId,
+        clientId
+      );
+    });
+
+    it('should handle generateClientSecret error', async () => {
+      const organizationId = 123;
+      const clientId = 'client123';
+      const mockError = new Error('generateClientSecret failed');
+
+      vi.mocked(utils.apiClient.bff.generateClientSecret).mockRejectedValue(
+        mockError
+      );
+
+      const { result } = renderHook(() => generateClientSecret(organizationId));
+
+      result.current.mutate(clientId);
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(result.current.error).toBe(mockError);
+      expect(utils.apiClient.bff.generateClientSecret).toHaveBeenCalledWith(
+        organizationId,
+        clientId
+      );
+    });
+
+    it('should successfully complete generateClientSecret mutation', async () => {
+      const organizationId = 123;
+      const clientId = 'client123';
+
+      vi.mocked(utils.apiClient.bff.generateClientSecret).mockResolvedValue({
+        data: undefined
+      } as AxiosResponse);
+
+      const { result } = renderHook(() => generateClientSecret(organizationId));
+
+      result.current.mutate(clientId);
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.isSuccess).toBe(true);
+      expect(result.current.isError).toBe(false);
     });
   });
 });

--- a/src/api/clientSil/index.ts
+++ b/src/api/clientSil/index.ts
@@ -66,12 +66,6 @@ export const deleteClientSil = (organizationId: number) =>
     }
   });
 
-export default {
-  getClientSils,
-  createClientSil,
-  deleteClientSil
-};
-
 /**
  * Hook for getting the details of a specific SIL
  * @param organizationId - Organization ID
@@ -92,4 +86,31 @@ export const getClientDetail = (organizationId: number, clientId: string) => {
       return clientDetail;
     }
   });
+};
+
+/**
+ * Hook for update client secret of a specific SIL
+ * @param organizationId - Organization ID
+ * @param clientId - Cient ID
+ * @returns useQuery hook for executing the API call
+ */
+export const generateClientSecret = (organizationId: number) =>
+  useMutation({
+    mutationKey: ['generateClientSecret', organizationId],
+    mutationFn: async (clientId: string) => {
+      const { data } = await utils.apiClient.bff.generateClientSecret(
+        organizationId,
+        clientId
+      );
+      parseAndLog(clientDTOSchema, data);
+      return data;
+    }
+  });
+
+export default {
+  getClientSils,
+  createClientSil,
+  deleteClientSil,
+  getClientDetail,
+  generateClientSecret
 };

--- a/src/routes/ClientSilDetail/ClientSecret.test.tsx
+++ b/src/routes/ClientSilDetail/ClientSecret.test.tsx
@@ -2,34 +2,76 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { screen, render, fireEvent } from '../../__tests__/renderers';
 import ClientSecret from './ClientSecret';
 import { copyToClipboard } from '../../utils/clipboard';
+import { generateClientSecret } from '../../api/clientSil';
 
 vi.mock('../../utils/clipboard', () => ({
   copyToClipboard: vi.fn()
 }));
+vi.mock('../../api/clientSil', () => ({
+  generateClientSecret: vi.fn()
+}));
 
 describe('ClientSecret Component', () => {
   const secret = 'secret-value';
+  const organizationId = 123;
+  const clientId = 'client-1';
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it('show middott as default', () => {
-    render(<ClientSecret secretValue={secret} />);
+    render(
+      <ClientSecret
+        secretValue={secret}
+        organizationId={organizationId}
+        clientId={clientId}
+      />
+    );
     expect(screen.getByText(/••••••/)).toBeInTheDocument();
   });
 
   it('show value when the visible-button-toggle is clicked', () => {
-    render(<ClientSecret secretValue={secret} />);
+    render(
+      <ClientSecret
+        secretValue={secret}
+        organizationId={organizationId}
+        clientId={clientId}
+      />
+    );
     const toggleButton = screen.getByTestId('show-secret-value');
     fireEvent.click(toggleButton);
     expect(screen.getByText(secret)).toBeInTheDocument();
   });
 
   it('use copyToClipboard when copy-button is clicked', () => {
-    render(<ClientSecret secretValue={secret} />);
+    render(
+      <ClientSecret
+        secretValue={secret}
+        organizationId={organizationId}
+        clientId={clientId}
+      />
+    );
     const copyButton = screen.getByTestId('specific-params-copy-button');
     fireEvent.click(copyButton);
     expect(copyToClipboard).toHaveBeenCalledWith(secret, expect.any(Function));
+  });
+
+  it('use Reloadsecrete button to reload secret value', async () => {
+    const organizationId = 123;
+    const mockGenerate = generateClientSecret as ReturnType<typeof vi.fn>;
+    mockGenerate.mockReturnValue({
+      mutateAsync: vi.fn()
+    });
+    render(
+      <ClientSecret
+        secretValue={secret}
+        organizationId={organizationId}
+        clientId={clientId}
+      />
+    );
+    const reloadButton = screen.getByTestId('reload-secret-button');
+    fireEvent.click(reloadButton);
+    expect(generateClientSecret).toHaveBeenCalledWith(organizationId);
   });
 });

--- a/src/routes/ClientSilDetail/ClientSecret.tsx
+++ b/src/routes/ClientSilDetail/ClientSecret.tsx
@@ -14,23 +14,45 @@ import { useState } from 'react';
 import { copyToClipboard } from '../../utils/clipboard';
 import { ContentCopy } from '@mui/icons-material';
 import { useTranslation } from 'react-i18next';
+import utils from '../../utils';
+import { generateClientSecret } from '../../api/clientSil';
 
 type ClientSecretProps = {
   secretValue: string;
+  organizationId: number;
+  clientId: string;
 };
 
-const ClientSecret = ({ secretValue }: ClientSecretProps) => {
+const ClientSecret = ({
+  secretValue,
+  organizationId,
+  clientId
+}: ClientSecretProps) => {
   const theme = useTheme();
   const { t } = useTranslation();
   const [showSecret, setShowSecret] = useState<boolean>(false);
+  const [currentSecretValue, setCurrentSecretValue] = useState(secretValue);
   const [tooltipTriggered, setTooltipTriggered] = useState<boolean>(false);
+
+  const reloadSecretMutation = generateClientSecret(organizationId);
 
   const toggleValue = () => {
     setShowSecret(!showSecret);
   };
 
   const handleCopy = () => {
-    copyToClipboard(secretValue, () => setTooltipTriggered(true));
+    copyToClipboard(currentSecretValue, () => setTooltipTriggered(true));
+  };
+
+  const handleReloadSecret = async () => {
+    try {
+      const data = await reloadSecretMutation.mutateAsync(clientId);
+      setCurrentSecretValue(data.clientSecret);
+      setShowSecret(true);
+      utils.notify.emit(t('clientSilDetail.reloadSecretOK'), 'success');
+    } catch {
+      utils.notify.emit(t('clientSilDetail.reloadSecretKO'), 'error');
+    }
   };
 
   return (
@@ -52,7 +74,7 @@ const ClientSecret = ({ secretValue }: ClientSecretProps) => {
         </Button>
       </Stack>
       <Grid container gap={1}>
-        <Grid xs={6}>
+        <Grid item xs={8}>
           <Stack
             spacing={2}
             direction={'row'}
@@ -70,7 +92,7 @@ const ClientSecret = ({ secretValue }: ClientSecretProps) => {
                   overflow: 'hidden'
                 }}
               >
-                {secretValue}
+                {currentSecretValue}
               </Typography>
             ) : (
               <Typography pl={2} overflow={'hidden'}>
@@ -103,8 +125,13 @@ const ClientSecret = ({ secretValue }: ClientSecretProps) => {
             </Box>
           </Stack>
         </Grid>
-        <Grid xs={4}>
-          <Button variant="outlined" size="small">
+        <Grid item xs={2}>
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={handleReloadSecret}
+            data-testid="reload-secret-button"
+          >
             <CachedIcon color="primary"></CachedIcon>&nbsp;{t('commons.reload')}
           </Button>
         </Grid>

--- a/src/routes/ClientSilDetail/index.test.tsx
+++ b/src/routes/ClientSilDetail/index.test.tsx
@@ -7,9 +7,11 @@ import ClientSilDetail from '.';
 vi.mock('../../api/clientSil', () => ({
   getClientDetail: vi.fn(),
   deleteClientSil: vi.fn(),
+  generateClientSecret: vi.fn(),
   default: {
     getClientDetail: vi.fn(),
-    deleteClientSil: vi.fn()
+    deleteClientSil: vi.fn(),
+    generateClientSecret: vi.fn()
   }
 }));
 

--- a/src/routes/ClientSilDetail/index.tsx
+++ b/src/routes/ClientSilDetail/index.tsx
@@ -149,7 +149,11 @@ const ClientSilDetail = () => {
       data: [
         {
           childrenComponent: (
-            <ClientSecret secretValue={data?.clientSecret || ''} />
+            <ClientSecret
+              secretValue={data?.clientSecret || ''}
+              organizationId={organizationId}
+              clientId={data?.clientId || ''}
+            />
           )
         }
       ]

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -542,7 +542,9 @@
   },
   "clientSilDetail": {
     "description": "Ecco i dettagli del Client SIL censito",
-    "key": "Key"
+    "key": "Key",
+    "reloadSecretOK": "Secret key rigenerata correttamente",
+    "reloadSecretKO": "Non è stato possibile rigenerare la Secret key"
   },
   "commons": {
     "404": "404: risorsa non disponibile",
@@ -1655,6 +1657,45 @@
     "apiName": "Nome API",
     "addAPI": "Aggiungi API"
   },
+  "orgSilServiceCreate": {
+    "actualization": "Attualizzazione importo",
+    "paidNotificationOutcome": "Notifica Pagamenti",
+    "legacyBasic": "Legacy Basic",
+    "legacyJWT": "Legacy JWT",
+    "title": "Aggiungi nuova API",
+    "description": "Inserisci i dati delle API ad esporre in Piattaforma Unitaria per essere utilizzati nei processi di Notifica Pagamenti ed Attualizzazione Importo.",
+    "subTitle": "Configurazione dell'API",
+    "generalConfiguration": "Configurazione generale",
+    "APIName": "Nome API",
+    "serviceURL": "Service URL",
+    "serviceType": "Tipo Servizio",
+    "authMethod": "Modalità di autenticazione",
+    "flagLegacy": "L'API deve mantenere la retrocompatibilità con i vecchi metodi di autenticazione?",
+    "authConfig": "Auth Config",
+    "basicUser": "User",
+    "basicPassword": "Password",
+    "basicAuthURL": "Auth URL",
+    "jwtKid": "KID",
+    "jwtIssuer": "Issuer",
+    "jwtSubject": "Subject",
+    "jwtAlgorithm": "Algorithm",
+    "jwtSigningKey": "Signing key",
+    "newService": {
+      "success": {
+        "title": "L'API ‘{{applicationName}}’ è stata aggiunta!",
+        "description": "La trovi nella sezione Org Sil Service, dove puoi consultarla in qualsiasi momento",
+        "goToDetail": "Vedi dettaglio API"
+      }
+    },
+    "validations": {
+      "requiredAPIName": "Il nome dell'API è obbligatorio",
+      "requiredURL": "L'URL del servizio è obbligatorio",
+      "invalidURL": "Formato URL non valido",
+      "requiredServiceType": "Il tipo di servizio è obbligatorio",
+      "requiredLegacyType": "Seleziona un tipo di autenticazione legacy",
+      "requiredField": "Campo obbligatorio"
+    }
+  },
   "orgSilServiceDetail": {
     "description": "Ecco i dettagli dell'API.",
     "delete": {
@@ -1697,45 +1738,6 @@
     "authTypes": {
       "basicAuth": "Basic Auth",
       "jwtAuth": "Legacy JWT"
-    }
-  },
-  "orgSilServiceCreate": {
-    "actualization": "Attualizzazione importo",
-    "paidNotificationOutcome": "Notifica Pagamenti",
-    "legacyBasic": "Legacy Basic",
-    "legacyJWT": "Legacy JWT",
-    "title": "Aggiungi nuova API",
-    "description": "Inserisci i dati delle API ad esporre in Piattaforma Unitaria per essere utilizzati nei processi di Notifica Pagamenti ed Attualizzazione Importo.",
-    "subTitle": "Configurazione dell'API",
-    "generalConfiguration": "Configurazione generale",
-    "APIName": "Nome API",
-    "serviceURL": "Service URL",
-    "serviceType": "Tipo Servizio",
-    "authMethod": "Modalità di autenticazione",
-    "flagLegacy": "L'API deve mantenere la retrocompatibilità con i vecchi metodi di autenticazione?",
-    "authConfig": "Auth Config",
-    "basicUser": "User",
-    "basicPassword": "Password",
-    "basicAuthURL": "Auth URL",
-    "jwtKid": "KID",
-    "jwtIssuer": "Issuer",
-    "jwtSubject": "Subject",
-    "jwtAlgorithm": "Algorithm",
-    "jwtSigningKey": "Signing key",
-    "newService": {
-      "success": {
-        "title": "L'API ‘{{applicationName}}’ è stata aggiunta!",
-        "description": "La trovi nella sezione Org Sil Service, dove puoi consultarla in qualsiasi momento",
-        "goToDetail": "Vedi dettaglio API"
-      }
-    },
-    "validations": {
-      "requiredAPIName": "Il nome dell'API è obbligatorio",
-      "requiredURL": "L'URL del servizio è obbligatorio",
-      "invalidURL": "Formato URL non valido",
-      "requiredServiceType": "Il tipo di servizio è obbligatorio",
-      "requiredLegacyType": "Seleziona un tipo di autenticazione legacy",
-      "requiredField": "Campo obbligatorio"
     }
   },
   "orgSilServiceEdit": {


### PR DESCRIPTION
This PR add the functionality called "regenerate secret value" for the ClientSIL Page.

#### List of Changes
- add api call to generate service
- add the api call & notify to the regen-button
- add tests

#### Motivation and Context
Solve the task

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
