### PR TITLE
feat: [P4ADEV-3668] debt position wizard edit ability to modify some debtor data

### DIFF
--- a/src/routes/DebtPositionCreateWizard/components/Step/Step2AddDebtor.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step/Step2AddDebtor.tsx
@@ -247,6 +247,17 @@ const Step2AddDebtor = ({
     onNext();
   };
 
+  /**
+   * Helper function to determine if a field should be disabled in editing mode
+   * In editing mode:
+   * - Fiscal data fields (subjectType, taxCode) should remain disabled
+   * - Personal data fields should be editable
+   */
+  const isFieldDisabled = (fieldType: 'fiscal' | 'personal') => {
+    if (!isEditing) return false;
+    return fieldType === 'fiscal'; // Only fiscal fields are disabled in editing mode
+  };
+
   const getTaxCodeLabel = () => {
     return subjectTypeValue === SubjectType.BUSINESS
       ? t('debtPositionCreateWizard.step2.vat.label')
@@ -293,7 +304,7 @@ const Step2AddDebtor = ({
                 select
                 fullWidth
                 margin="normal"
-                disabled={isEditing}
+                disabled={isFieldDisabled('fiscal')}
                 error={isSubmitted && !!errors.subjectType?.value}
                 helperText={isSubmitted && errors.subjectType?.value?.message}
                 onChange={(e) => {
@@ -334,7 +345,7 @@ const Step2AddDebtor = ({
                 required
                 fullWidth
                 margin="normal"
-                disabled={isEditing}
+                disabled={isFieldDisabled('fiscal')}
                 error={isSubmitted && !!errors.taxCode?.value}
                 helperText={isSubmitted && errors.taxCode?.value?.message}
                 onChange={(e) => {
@@ -363,7 +374,7 @@ const Step2AddDebtor = ({
                 fullWidth
                 margin="normal"
                 required
-                disabled={isEditing}
+                disabled={isFieldDisabled('personal')}
                 error={isSubmitted && !!errors.fullName?.value}
                 helperText={isSubmitted && errors.fullName?.value?.message}
                 onChange={(e) => {
@@ -388,7 +399,7 @@ const Step2AddDebtor = ({
                     label={t('debtPositionCreateWizard.step2.address.label')}
                     fullWidth
                     required
-                    disabled={isEditing}
+                    disabled={isFieldDisabled('personal')}
                     error={isSubmitted && !!errors.address?.value}
                     helperText={isSubmitted && errors.address?.value?.message}
                     onChange={(e) => {
@@ -415,7 +426,7 @@ const Step2AddDebtor = ({
                     )}
                     fullWidth
                     required
-                    disabled={isEditing}
+                    disabled={isFieldDisabled('personal')}
                     error={isSubmitted && !!errors.civicNumber?.value}
                     helperText={
                       isSubmitted && errors.civicNumber?.value?.message
@@ -442,7 +453,7 @@ const Step2AddDebtor = ({
                     label={t('debtPositionCreateWizard.step2.zipCode.label')}
                     fullWidth
                     required
-                    disabled={isEditing}
+                    disabled={isFieldDisabled('personal')}
                     error={isSubmitted && !!errors.zipCode?.value}
                     helperText={isSubmitted && errors.zipCode?.value?.message}
                     onChange={(e) => {
@@ -471,7 +482,7 @@ const Step2AddDebtor = ({
                     select
                     fullWidth
                     required
-                    disabled={isEditing}
+                    disabled={isFieldDisabled('personal')}
                     error={isSubmitted && !!errors.country?.value}
                     helperText={isSubmitted && errors.country?.value?.message}
                     onChange={(e) => {
@@ -507,7 +518,7 @@ const Step2AddDebtor = ({
                     select
                     fullWidth
                     required
-                    disabled={isEditing}
+                    disabled={isFieldDisabled('personal')}
                     error={isSubmitted && !!errors.province?.value}
                     helperText={isSubmitted && errors.province?.value?.message}
                     onChange={(e) => {
@@ -542,7 +553,7 @@ const Step2AddDebtor = ({
                     label={t('debtPositionCreateWizard.step2.city.label')}
                     fullWidth
                     required
-                    disabled={isEditing}
+                    disabled={isFieldDisabled('personal')}
                     error={isSubmitted && !!errors.city?.value}
                     helperText={isSubmitted && errors.city?.value?.message}
                     onChange={(e) => {

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -1114,8 +1114,8 @@
         "maxInstallmentsReached": "Hai raggiunto il numero massimo di rate (12)",
         "minInstallmentsRequired": "Sono richieste almeno 2 rate",
         "remittance": {
-          "label": "Oggetto pagamento",
-          "required": "Il campo oggetto pagamento è obbligatorio"
+          "label": "Oggetto del pagamento",
+          "required": "Il campo oggetto del pagamento è obbligatorio"
         },
         "otherBeneficiaries": "Altri beneficiari",
         "sameBeneficiaries": "I beneficiari sono uguali alla rata precedente?",
@@ -1127,13 +1127,13 @@
         "label": "Altri beneficiari"
       },
       "paymentObject": {
-        "label": "Oggetto pagamento",
-        "required": "Il campo oggetto pagamento è obbligatorio"
+        "label": "Oggetto del pagamento",
+        "required": "Il campo oggetto del pagamento è obbligatorio"
       },
       "paymentOption": {
         "installments": "Soluzione rateale",
-        "label": "Opzione pagamento",
-        "required": "Il campo opzione pagamento è obbligatorio",
+        "label": "Opzione di pagamento",
+        "required": "Il campo opzione di pagamento è obbligatorio",
         "single": "Soluzione unica"
       },
       "title": "Avviso"


### PR DESCRIPTION
This PR allows users to modify personal data in the "Personal Data" section during step 2 of the debt position editing wizard. Previously, this section was read-only during the editing phase, but now users can update personal information as part of the debt position modification workflow.


#### How Has This Been Tested?

-visual testing
-unit tests

#### Screenshots (if appropriate):
<img width="1606" height="1110" alt="Screenshot 2025-09-03 101504" src="https://github.com/user-attachments/assets/b7dfcb30-03d1-434b-8770-0985748540fc" />


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
