### PR TITLE
feat: [P4ADEV-3669] notice detail add causal field

### DIFF
--- a/src/components/DebtPositionsInstallmentDetail/DebtPositionsInstallmentDetail.tsx
+++ b/src/components/DebtPositionsInstallmentDetail/DebtPositionsInstallmentDetail.tsx
@@ -134,6 +134,14 @@ export const DebtPositionsInstallmentDetail = () => {
 
   const installmentDetailData: DetailDataValue = {
     summaryData: [
+      ...(installment?.debtPositionDescription
+        ? [
+            {
+              value: installment.debtPositionDescription,
+              variant: 'h6' as const
+            }
+          ]
+        : []),
       {
         label: t('commons.state'),
         value: installment?.status

--- a/src/components/DebtPositionsInstallmentDetail/DebtPositionsInstallmentDetail.tsx
+++ b/src/components/DebtPositionsInstallmentDetail/DebtPositionsInstallmentDetail.tsx
@@ -134,14 +134,6 @@ export const DebtPositionsInstallmentDetail = () => {
 
   const installmentDetailData: DetailDataValue = {
     summaryData: [
-      ...(installment?.debtPositionDescription
-        ? [
-            {
-              value: installment.debtPositionDescription,
-              variant: 'h6' as const
-            }
-          ]
-        : []),
       {
         label: t('commons.state'),
         value: installment?.status
@@ -275,6 +267,7 @@ export const DebtPositionsInstallmentDetail = () => {
             sections={[
               {
                 title: { label: t(summaryTitle), variant: 'h6' },
+                description: installment?.debtPositionDescription,
                 data: installmentDetailData.summaryData,
                 inline: true,
                 footerLink: {

--- a/src/components/DetailContainer/DetailContainer.test.tsx
+++ b/src/components/DetailContainer/DetailContainer.test.tsx
@@ -148,4 +148,93 @@ describe('DetailContainer', () => {
       gridContainer?.querySelector('.MuiGrid-item.MuiGrid-grid-md-12')
     ).not.toBeNull();
   });
+
+  it('renders description when provided', () => {
+    const propsWithDescription = {
+      sections: [
+        {
+          title: { label: 'Test Title' },
+          description: 'This is a test description',
+          data: [{ label: 'Test Label', value: 'Test Value' }]
+        }
+      ]
+    };
+
+    render(<DetailContainer {...propsWithDescription} />);
+
+    expect(screen.getByText('This is a test description')).toBeDefined();
+    expect(screen.getByText('Test Title')).toBeDefined();
+  });
+
+  it('renders date values correctly', () => {
+    const propsWithDate = {
+      sections: [
+        {
+          data: [
+            {
+              label: 'Data Valida',
+              value: '2024-12-31',
+              valueType: 'date' as const
+            },
+            { label: 'Data Vuota', value: '', valueType: 'date' as const }
+          ]
+        }
+      ]
+    };
+
+    render(<DetailContainer {...propsWithDate} />);
+
+    expect(screen.getByText('Data Valida')).toBeDefined();
+    expect(screen.getByText('Data Vuota')).toBeDefined();
+    expect(screen.getByText('-')).toBeDefined();
+  });
+
+  it('renders childrenComponent when provided', () => {
+    const propsWithChildren = {
+      sections: [
+        {
+          data: [
+            {
+              label: 'Custom Component',
+              childrenComponent: (
+                <div data-testid="custom-component">Custom Content</div>
+              )
+            }
+          ]
+        }
+      ]
+    };
+
+    render(<DetailContainer {...propsWithChildren} />);
+
+    expect(screen.getByTestId('custom-component')).toBeDefined();
+    expect(screen.getByText('Custom Content')).toBeDefined();
+  });
+
+  it('renders footer link with icon and handles click', () => {
+    const mockOnLinkClick = vi.fn();
+    const propsWithFooterLink = {
+      sections: [
+        {
+          data: [{ label: 'Test Data', value: 'Test Value' }],
+          footerLink: {
+            label: 'Show Details',
+            icon: <span data-testid="footer-icon">📄</span>,
+            onLinkClick: mockOnLinkClick,
+            iconPosition: 'left' as const
+          }
+        }
+      ]
+    };
+
+    render(<DetailContainer {...propsWithFooterLink} />);
+
+    const footerButton = screen.getByText('Show Details');
+    expect(footerButton).toBeDefined();
+    expect(footerButton).toHaveClass('MuiButton-text');
+    expect(screen.getByTestId('footer-icon')).toBeDefined();
+
+    footerButton.click();
+    expect(mockOnLinkClick).toHaveBeenCalledOnce();
+  });
 });

--- a/src/components/DetailContainer/DetailContainer.tsx
+++ b/src/components/DetailContainer/DetailContainer.tsx
@@ -44,6 +44,7 @@ export type footerLinkConfig = {
 export type DetailSectionProps = {
   sections: Array<{
     title?: titleConfig;
+    description?: string;
     data: Array<DetailData>;
     inline?: boolean;
     footerLink?: footerLinkConfig;
@@ -140,6 +141,14 @@ const DetailContainer = ({
                 {section.title ? (
                   <Typography {...section.title}>
                     {section.title.label}
+                  </Typography>
+                ) : null}
+                {section.description ? (
+                  <Typography
+                    variant="h6"
+                    sx={{ mb: 2, wordBreak: 'break-word' }}
+                  >
+                    {section.description}
                   </Typography>
                 ) : null}
                 <Grid container direction="column">


### PR DESCRIPTION
With this PR, the causal field (debtPositionDescription) has been added to the debt position detail view.

#### List of Changes

Added description property to DetailContainer

#### Screenshot:
<img width="902" height="517" alt="Screenshot 2025-09-04 091811" src="https://github.com/user-attachments/assets/413ee98e-1d89-4304-8542-0f33ad5da6d4" />


#### How Has This Been Tested?

-visual testing
-unit tests


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
