### PR TITLE
feat: [P4ADEV-3664] assessments edit chapters registry

### DIFF
--- a/src/api/assessments/assessments.test.ts
+++ b/src/api/assessments/assessments.test.ts
@@ -14,7 +14,10 @@ import {
   deleteAssessmentDetails
 } from '.';
 import { initialFilterValues } from '../../store/FilterStore';
-import { assessmentsRegistryDTOSchema } from '../../../generated/zod-schema';
+import {
+  assessmentsRegistrySchema,
+  assessmentsRegistryDTOSchema
+} from '../../../generated/zod-schema';
 import { createMock } from 'zodock';
 import * as loaders from '../../utils/loaders';
 import type { AssessmentsRegistry } from '../../../generated/data-contracts';
@@ -1070,7 +1073,7 @@ describe('updateAssessmentsRegistry', () => {
       assessmentRegistry
     );
     expect(mockParseAndLog).toHaveBeenCalledWith(
-      assessmentsRegistryDTOSchema,
+      assessmentsRegistrySchema,
       expectedResponse
     );
   });

--- a/src/api/assessments/index.ts
+++ b/src/api/assessments/index.ts
@@ -7,6 +7,7 @@ import {
 import { parseAndLog } from '../../utils/loaders';
 import {
   assessmentsRegistryDTOSchema,
+  assessmentsRegistrySchema,
   assessmentsSchema,
   assessmentsDetailSchema
 } from '../../../generated/zod-schema';
@@ -131,7 +132,7 @@ export const updateAssessmentsRegistry = (
         assessmentRegistryId,
         assessmentRegistry
       );
-      parseAndLog(assessmentsRegistryDTOSchema, data);
+      parseAndLog(assessmentsRegistrySchema, data);
       return data;
     }
   });

--- a/src/routes/AssessmentRegistryCreate/steps/Step1Configuration/index.tsx
+++ b/src/routes/AssessmentRegistryCreate/steps/Step1Configuration/index.tsx
@@ -52,7 +52,7 @@ export const Step1Configuration = ({ edit }: { edit?: boolean }) => {
             control={control}
             label={t('AssessmentRegistryCreate.debtPositionType')}
             options={selectionQuery?.optionsMap}
-            disabled={!selectionQuery?.optionsMap?.length}
+            disabled={edit || !selectionQuery?.optionsMap?.length}
             required
           />
         </SectionBox>


### PR DESCRIPTION
With this PR, during the editing phase of an assessment chapter, the due type field is disabled.


#### How Has This Been Tested?

-visual testing
-unit tests

#### Screenshots (if appropriate):
<img width="804" height="527" alt="Screenshot 2025-09-04 175011" src="https://github.com/user-attachments/assets/308ed0d1-bc0c-475f-bb34-a32df7251fce" />


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
