### PR TITLE
feat: [P4ADEV-3574] persistent multiFilters with URI hash parameters

### DIFF
--- a/src/components/Assessment/Assessment.test.tsx
+++ b/src/components/Assessment/Assessment.test.tsx
@@ -70,7 +70,7 @@ describe('Assessment', () => {
         screen.queryByTestId('multifilters-error-text')
       ).not.toBeInTheDocument();
       expect(mockNavigate).toHaveBeenCalledWith(
-        '/piattaformaunitaria/assessment/search-results'
+        '/piattaformaunitaria/assessment/search-results#ASSESSMENT_NAME=test'
       );
     });
 

--- a/src/components/Assessment/Assessment.tsx
+++ b/src/components/Assessment/Assessment.tsx
@@ -37,7 +37,9 @@ export const Assessment = () => {
   function submitSearch() {
     if (isValid) {
       setError(false);
-      navigate(PageRoutes.ASSESSMENT_SEARCH_RESULTS, { hashObject: filterValues });
+      navigate(PageRoutes.ASSESSMENT_SEARCH_RESULTS, {
+        hashObject: filterValues
+      });
     } else {
       setError(true);
     }

--- a/src/components/Assessment/Assessment.tsx
+++ b/src/components/Assessment/Assessment.tsx
@@ -7,15 +7,15 @@ import { useTranslation } from 'react-i18next';
 import TitleComponent from '../TitleComponent/TitleComponent';
 import { useMultiFilters, FilterCategory } from '../../hooks/useMultiFilters';
 import { useState } from 'react';
-import { useNavigate } from 'react-router';
 import { PageRoutes } from '../../routes';
 import { ErrorMessage } from '../ErrorMessage/ErrorMessage';
+import { useAppNavigate } from '../../hooks/useAppNavigation';
 
 export const Assessment = () => {
   const { t } = useTranslation();
-  const navigate = useNavigate();
+  const navigate = useAppNavigate();
 
-  const { filterMap, removeAllFilters, isValid } = useMultiFilters({
+  const { filterValues, filterMap, removeAllFilters, isValid } = useMultiFilters({
     clearOnMount: true,
     filterCategory: FilterCategory.ASSESSMENT
   });
@@ -36,7 +36,8 @@ export const Assessment = () => {
 
   function submitSearch() {
     if (isValid) {
-      navigate(PageRoutes.ASSESSMENT_SEARCH_RESULTS);
+      setError(false);
+      navigate(PageRoutes.ASSESSMENT_SEARCH_RESULTS, { hashObject: filterValues });
     } else {
       setError(true);
     }

--- a/src/components/Assessment/Assessment.tsx
+++ b/src/components/Assessment/Assessment.tsx
@@ -15,10 +15,11 @@ export const Assessment = () => {
   const { t } = useTranslation();
   const navigate = useAppNavigate();
 
-  const { filterValues, filterMap, removeAllFilters, isValid } = useMultiFilters({
-    clearOnMount: true,
-    filterCategory: FilterCategory.ASSESSMENT
-  });
+  const { filterValues, filterMap, removeAllFilters, isValid } =
+    useMultiFilters({
+      clearOnMount: true,
+      filterCategory: FilterCategory.ASSESSMENT
+    });
 
   const [error, setError] = useState(false);
 

--- a/src/components/Classifications/Classifications.test.tsx
+++ b/src/components/Classifications/Classifications.test.tsx
@@ -83,7 +83,7 @@ describe('Classifications', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('multifilters-error-text')).toBeNull();
       expect(mockNavigate).toHaveBeenCalledWith(
-        '/piattaformaunitaria/classifications/search-results/'
+        '/piattaformaunitaria/classifications/search-results/#CLASSIFICATION_TYPE=some-type'
       );
     });
 

--- a/src/components/Classifications/Classifications.tsx
+++ b/src/components/Classifications/Classifications.tsx
@@ -6,14 +6,14 @@ import { useTranslation } from 'react-i18next';
 import TitleComponent from '../TitleComponent/TitleComponent';
 import { FilterCategory, useMultiFilters } from '../../hooks/useMultiFilters';
 import { PageRoutes } from '../../routes';
-import { useNavigate } from 'react-router';
 import { useState } from 'react';
 import { ErrorMessage } from '../ErrorMessage/ErrorMessage';
+import { useAppNavigate } from '../../hooks/useAppNavigation';
 
 export const Classifications = () => {
   const { t } = useTranslation();
-  const navigate = useNavigate();
-  const { filterMap, removeAllFilters, isValid } = useMultiFilters({
+  const navigate = useAppNavigate();
+  const {  filterValues, filterMap, removeAllFilters, isValid } = useMultiFilters({
     clearOnMount: true,
     filterCategory: FilterCategory.CLASSIFICATIONS
   });
@@ -22,7 +22,7 @@ export const Classifications = () => {
 
   function submitSearch() {
     if (isValid) {
-      navigate(PageRoutes.CLASSIFICATIONS_SEARCH_RESULTS);
+      navigate(PageRoutes.CLASSIFICATIONS_SEARCH_RESULTS, { hashObject: filterValues });
     } else {
       setError(true);
     }

--- a/src/components/Classifications/Classifications.tsx
+++ b/src/components/Classifications/Classifications.tsx
@@ -13,16 +13,19 @@ import { useAppNavigate } from '../../hooks/useAppNavigation';
 export const Classifications = () => {
   const { t } = useTranslation();
   const navigate = useAppNavigate();
-  const {  filterValues, filterMap, removeAllFilters, isValid } = useMultiFilters({
-    clearOnMount: true,
-    filterCategory: FilterCategory.CLASSIFICATIONS
-  });
+  const { filterValues, filterMap, removeAllFilters, isValid } =
+    useMultiFilters({
+      clearOnMount: true,
+      filterCategory: FilterCategory.CLASSIFICATIONS
+    });
 
   const [error, setError] = useState(false);
 
   function submitSearch() {
     if (isValid) {
-      navigate(PageRoutes.CLASSIFICATIONS_SEARCH_RESULTS, { hashObject: filterValues });
+      navigate(PageRoutes.CLASSIFICATIONS_SEARCH_RESULTS, {
+        hashObject: filterValues
+      });
     } else {
       setError(true);
     }

--- a/src/components/Treasury/Treasury.tsx
+++ b/src/components/Treasury/Treasury.tsx
@@ -5,23 +5,24 @@ import { Grid } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import TitleComponent from '../TitleComponent/TitleComponent';
 import { PageRoutes } from '../../routes';
-import { generatePath, useNavigate } from 'react-router';
+import { generatePath } from 'react-router';
 import { useState } from 'react';
 import { useMultiFilters, FilterCategory } from '../../hooks/useMultiFilters';
 import { ErrorMessage } from '../ErrorMessage/ErrorMessage';
+import { useAppNavigate } from '../../hooks/useAppNavigation';
 
 export const Treasury = () => {
   const { t } = useTranslation();
-  const { filterMap, removeAllFilters, isValid } = useMultiFilters({
+  const { filterValues, filterMap, removeAllFilters, isValid } = useMultiFilters({
     clearOnMount: true,
     filterCategory: FilterCategory.TREASURY
   });
-  const navigate = useNavigate();
+  const navigate = useAppNavigate();
   const [error, setError] = useState(false);
 
   function submitSearch() {
     if (isValid) {
-      navigate(PageRoutes.TREASURY_SEARCH_RESULTS);
+      navigate(PageRoutes.TREASURY_SEARCH_RESULTS, { hashObject: filterValues });
     } else {
       setError(true);
     }

--- a/src/components/Treasury/Treasury.tsx
+++ b/src/components/Treasury/Treasury.tsx
@@ -13,16 +13,19 @@ import { useAppNavigate } from '../../hooks/useAppNavigation';
 
 export const Treasury = () => {
   const { t } = useTranslation();
-  const { filterValues, filterMap, removeAllFilters, isValid } = useMultiFilters({
-    clearOnMount: true,
-    filterCategory: FilterCategory.TREASURY
-  });
+  const { filterValues, filterMap, removeAllFilters, isValid } =
+    useMultiFilters({
+      clearOnMount: true,
+      filterCategory: FilterCategory.TREASURY
+    });
   const navigate = useAppNavigate();
   const [error, setError] = useState(false);
 
   function submitSearch() {
     if (isValid) {
-      navigate(PageRoutes.TREASURY_SEARCH_RESULTS, { hashObject: filterValues });
+      navigate(PageRoutes.TREASURY_SEARCH_RESULTS, {
+        hashObject: filterValues
+      });
     } else {
       setError(true);
     }

--- a/src/components/TreasurySearchResults/index.tsx
+++ b/src/components/TreasurySearchResults/index.tsx
@@ -17,7 +17,6 @@ import { useSearch } from '../../hooks/useSearch';
 import { useStore } from '../../store/GlobalStore';
 import { getTreasuries } from '../../api/treasuries';
 import { ErrorMessage } from '../ErrorMessage/ErrorMessage';
-import utils from '../../utils';
 
 export type LocationState = {
   category: string;

--- a/src/components/TreasurySearchResults/index.tsx
+++ b/src/components/TreasurySearchResults/index.tsx
@@ -17,6 +17,7 @@ import { useSearch } from '../../hooks/useSearch';
 import { useStore } from '../../store/GlobalStore';
 import { getTreasuries } from '../../api/treasuries';
 import { ErrorMessage } from '../ErrorMessage/ErrorMessage';
+import utils from '../../utils';
 
 export type LocationState = {
   category: string;

--- a/src/hooks/useAppNavigation.ts
+++ b/src/hooks/useAppNavigation.ts
@@ -22,8 +22,10 @@ export function useAppNavigate() {
     const filteredOptions = Object.fromEntries(
       Object.entries(options || {}).filter(([_, v]) => v !== undefined)
     );
-  
-    Object.keys(filteredOptions).length > 0 ? navigate(path, options) : navigate(path);
+
+    Object.keys(filteredOptions).length > 0
+      ? navigate(path, options)
+      : navigate(path);
   };
 
   return appNavigate;

--- a/src/hooks/useAppNavigation.ts
+++ b/src/hooks/useAppNavigation.ts
@@ -15,9 +15,15 @@ export function useAppNavigate() {
     let path = to;
     if (options?.hashObject !== undefined) {
       const hash = utils.URI.encode(options.hashObject);
-      path = `${to}#${hash}`;
+      path = hash ? `${to}#${hash}` : to;
+      delete options.hashObject;
     }
-    navigate(path, options);
+
+    const filteredOptions = Object.fromEntries(
+      Object.entries(options || {}).filter(([_, v]) => v !== undefined)
+    );
+  
+    Object.keys(filteredOptions).length > 0 ? navigate(path, options) : navigate(path);
   };
 
   return appNavigate;

--- a/src/hooks/useAppNavigation.ts
+++ b/src/hooks/useAppNavigation.ts
@@ -20,10 +20,10 @@ export function useAppNavigate() {
     }
 
     const filteredOptions = Object.fromEntries(
-      Object.entries(options || {}).filter(([_, v]) => v !== undefined)
+      Object.entries(options || {}).filter(([, v]) => v !== undefined)
     );
 
-    Object.keys(filteredOptions).length > 0
+    return Object.keys(filteredOptions).length > 0
       ? navigate(path, options)
       : navigate(path);
   };

--- a/src/store/FilterStore.ts
+++ b/src/store/FilterStore.ts
@@ -4,14 +4,18 @@ import { FilterMap } from '../hooks/useMultiFilters';
 import { noFilterSetted } from '../utils/filtersValidation';
 import URI from '../utils/URI';
 
-const initialFilterValuesFromURI: Partial<FilterValues> = URI.decode(window.location.hash);
+const initialFilterValuesFromURI: Partial<FilterValues> = URI.decode(
+  window.location.hash
+);
 
 /**
  * Get initial selected filters based on the initial filter values from the URI
  * @param initialFilterValuesFromURI Partial<FilterValues>
  * @returns Array <keyof FilterMap>
  */
-const getInitialSelectedFilters = (initialFilterValuesFromURI:Partial<FilterValues> ): Array<keyof FilterMap> => {
+const getInitialSelectedFilters = (
+  initialFilterValuesFromURI: Partial<FilterValues>
+): Array<keyof FilterMap> => {
   const filters = Object.keys(initialFilterValuesFromURI) as Array<
     keyof FilterValues
   >;
@@ -28,7 +32,7 @@ const getInitialSelectedFilters = (initialFilterValuesFromURI:Partial<FilterValu
     }
   });
   return selected;
-}
+};
 
 export const initialFilterValues: FilterValues = {
   ACCOUNTING_DATE_FROM: null,
@@ -129,7 +133,9 @@ export const mapFilterNameToFilterValues: Record<
 export type KeyofFilterMap = keyof FilterMap;
 export type KeyofFilterValues = keyof FilterValues;
 
-export const selectedFilters = signal<Array<KeyofFilterMap>>(getInitialSelectedFilters(initialFilterValuesFromURI));
+export const selectedFilters = signal<Array<KeyofFilterMap>>(
+  getInitialSelectedFilters(initialFilterValuesFromURI)
+);
 
 export function setSelectedFilters(newState: Array<KeyofFilterMap>) {
   selectedFilters.value = newState;
@@ -156,7 +162,10 @@ export const updateFilter = (id: KeyofFilterMap, index: number) => {
   removeFilterRow(previousFilter);
 };
 
-export const filterValues = signal<FilterValues>({...initialFilterValues, ...initialFilterValuesFromURI});
+export const filterValues = signal<FilterValues>({
+  ...initialFilterValues,
+  ...initialFilterValuesFromURI
+});
 
 export const noFilterIsSelected = computed(() =>
   noFilterSetted(filterValues.value)
@@ -176,5 +185,5 @@ export const resetFilterValue = (id: keyof FilterValues) => {
 export const removeAllFilters = () => {
   setSelectedFilters([]);
   setFilterValues(initialFilterValues);
-  URI.set('', { replace: true })
+  URI.set('', { replace: true });
 };

--- a/src/store/FilterStore.ts
+++ b/src/store/FilterStore.ts
@@ -2,6 +2,33 @@ import { computed, signal } from '@preact/signals-react';
 import { FilterValues } from '../models/Filters';
 import { FilterMap } from '../hooks/useMultiFilters';
 import { noFilterSetted } from '../utils/filtersValidation';
+import URI from '../utils/URI';
+
+const initialFilterValuesFromURI: Partial<FilterValues> = URI.decode(window.location.hash);
+
+/**
+ * Get initial selected filters based on the initial filter values from the URI
+ * @param initialFilterValuesFromURI Partial<FilterValues>
+ * @returns Array <keyof FilterMap>
+ */
+const getInitialSelectedFilters = (initialFilterValuesFromURI:Partial<FilterValues> ): Array<keyof FilterMap> => {
+  const filters = Object.keys(initialFilterValuesFromURI) as Array<
+    keyof FilterValues
+  >;
+  const selected: Array<keyof FilterMap> = [];
+  filters.forEach((filter) => {
+    const mapEntry = Object.entries(mapFilterNameToFilterValues).find(
+      ([, value]) => value.includes(filter)
+    );
+    if (mapEntry) {
+      const [key] = mapEntry;
+      if (!selected.includes(key as keyof FilterMap)) {
+        selected.push(key as keyof FilterMap);
+      }
+    }
+  });
+  return selected;
+}
 
 export const initialFilterValues: FilterValues = {
   ACCOUNTING_DATE_FROM: null,
@@ -102,7 +129,7 @@ export const mapFilterNameToFilterValues: Record<
 export type KeyofFilterMap = keyof FilterMap;
 export type KeyofFilterValues = keyof FilterValues;
 
-export const selectedFilters = signal<Array<KeyofFilterMap>>([]);
+export const selectedFilters = signal<Array<KeyofFilterMap>>(getInitialSelectedFilters(initialFilterValuesFromURI));
 
 export function setSelectedFilters(newState: Array<KeyofFilterMap>) {
   selectedFilters.value = newState;
@@ -129,7 +156,7 @@ export const updateFilter = (id: KeyofFilterMap, index: number) => {
   removeFilterRow(previousFilter);
 };
 
-export const filterValues = signal<FilterValues>(initialFilterValues);
+export const filterValues = signal<FilterValues>({...initialFilterValues, ...initialFilterValuesFromURI});
 
 export const noFilterIsSelected = computed(() =>
   noFilterSetted(filterValues.value)
@@ -149,4 +176,5 @@ export const resetFilterValue = (id: keyof FilterValues) => {
 export const removeAllFilters = () => {
   setSelectedFilters([]);
   setFilterValues(initialFilterValues);
+  URI.set('', { replace: true })
 };

--- a/src/utils/URI.ts
+++ b/src/utils/URI.ts
@@ -4,8 +4,8 @@ import queryString from 'query-string';
 import { endOfDay } from 'date-fns';
 
 function sanitizeKeyChars(input: string): string {
-  // Allows letters, digits and literal dot
-  return input.replace(/[^a-zA-Z0-9.]/g, '');
+  // Allows letters, digits and literal dot and _
+  return input.replace(/[^a-zA-Z0-9._]/g, '');
 }
 
 const toDate = (value: string): Date => {
@@ -30,7 +30,7 @@ function decode(fragment: string): Record<string, string | Date> {
   Object.entries(parsed).forEach(([key, value]) => {
     const sanitizedKey = sanitizeKeyChars(key);
     if (isDateString(value)) {
-      if (sanitizedKey.endsWith('to')) {
+      if (/to$/i.test(sanitizedKey)) {
         flatObj[sanitizedKey] = endOfDay(toDate(value));
       } else {
         flatObj[sanitizedKey] = toDate(value);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Using a custom useNavigate hook instead of the original to set the values for hash filter parameters.
- Getting the initial hash filter parameters and initial active filters to keep filters persistent on page update and refresh
- Unit test updated

<!--- Describe your changes in detail -->

#### Motivation and Context
This is required for the multiFilters functionality to work properly in conjunction with the hash parameters. 

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Verified with a combination of manual testing and unit tests.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
