### PR TITLE
fix: [P4ADEV-3612] removing sort to the selected filters

### DIFF
--- a/src/components/MultiFilter/MultiFilter.tsx
+++ b/src/components/MultiFilter/MultiFilter.tsx
@@ -43,7 +43,6 @@ const MultiFilter = ({ filterMap, onFilterInteraction }: MultiFilterProps) => {
   return (
     <Stack gap={3}>
       {selectedFilters
-        .slice()
         .map((filterId, index) => (
           <Stack
             key={filterId}

--- a/src/components/MultiFilter/MultiFilter.tsx
+++ b/src/components/MultiFilter/MultiFilter.tsx
@@ -44,7 +44,6 @@ const MultiFilter = ({ filterMap, onFilterInteraction }: MultiFilterProps) => {
     <Stack gap={3}>
       {selectedFilters
         .slice()
-        .sort((a, b) => a.localeCompare(b))
         .map((filterId, index) => (
           <Stack
             key={filterId}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Unnecessary sorting removed for selected filters.

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Applied filters are stored in a dedicated array. They must be displayed in the same order as stored in the array. Visually sorting the applied filters caused this order to be misaligned.
#### How Has This Been Tested?
Verified with a combination of manual testing and unit tests.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
