### PR TITLE
fix: [P4ADEV-3625] drop unuseful remittanceInformation

### DIFF
--- a/src/components/DebtPositionsInstallmentDetail/DebtPositionsInstallmentDetail.tsx
+++ b/src/components/DebtPositionsInstallmentDetail/DebtPositionsInstallmentDetail.tsx
@@ -11,7 +11,6 @@ import { useStore } from '../../store/GlobalStore';
 import { STATE } from '../../store/types';
 import debtPositions from '../../api/debtPositions';
 import {
-  useLocation,
   useParams,
   useNavigate,
   generatePath
@@ -33,9 +32,6 @@ export const DebtPositionsInstallmentDetail = () => {
   const { state } = useStore();
   const { id } = useParams<{ id: string }>();
 
-  const {
-    state: { remittanceInformation: remittanceInformation }
-  } = useLocation();
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [timelineOpen, setTimelineOpen] = useState(false);
   const [openDeleteDialog, setOpenDeleteDialog] = useState(false);
@@ -129,8 +125,6 @@ export const DebtPositionsInstallmentDetail = () => {
     installment?.status && DEBT_RESOLVED_STATES.includes(installment.status);
 
   type DetailDataValue = Record<string, Array<DetailData>> | Array<DetailData>;
-
-  const summaryTitle: string = remittanceInformation || '';
 
   const installmentDetailData: DetailDataValue = {
     summaryData: [
@@ -266,7 +260,6 @@ export const DebtPositionsInstallmentDetail = () => {
           <DetailContainer
             sections={[
               {
-                title: { label: t(summaryTitle), variant: 'h6' },
                 description: installment?.debtPositionDescription,
                 data: installmentDetailData.summaryData,
                 inline: true,


### PR DESCRIPTION
Drop remittanceInformation from location state... this is an old implementation for viewing debt-position detail.

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
