### PR TITLE
feat: [P4ADEV-3582] assessment unhappy case manual creation

### DIFF
--- a/src/models/SuccessPageConfig.ts
+++ b/src/models/SuccessPageConfig.ts
@@ -177,6 +177,18 @@ export const SuccessPageConfig: SuccessOpts = {
       }
     ]
   },
+  'assessment-create-partial-success': {
+    title: 'assessmentCreate.partialSuccess.title',
+    description: 'assessmentCreate.partialSuccess.description',
+    buttonConfig: [
+      {
+        variant: 'contained',
+        size: 'large',
+        buttonLabel: 'assessmentCreate.partialSuccess.goToDetail',
+        customNavigation: 'ASSESSMENT_DETAIL'
+      }
+    ]
+  },
   'assessment-remove-payments': {
     title: 'assessmentCreate.removePayments.success.title',
     buttonConfig: [

--- a/src/routes/AssessmentCreate/AssessmentCreate.tsx
+++ b/src/routes/AssessmentCreate/AssessmentCreate.tsx
@@ -273,42 +273,69 @@ export const AssessmentCreate = () => {
       if (!assessmentId) {
         throw new Error('Assessment ID not received from the response');
       }
-      // STEP 2: If there are selected payments, create also assessment-details
+
+      // STEP 2: If there are selected payments, try to create assessment-details
+      let assessmentDetailsCreated = true;
       if (
         addPaymentsToAssessment &&
         values.selectedPaymentIuds &&
         values.selectedPaymentIuds.length > 0
       ) {
-        const assessmentRegistryId =
-          await getAssessmentRegistryIdFromChapter(values);
+        try {
+          const assessmentRegistryId =
+            await getAssessmentRegistryIdFromChapter(values);
 
-        if (!assessmentRegistryId) {
-          throw new Error(
-            'Assessment Registry ID not found for the selected chapter'
-          );
-        }
-
-        await utils.apiClient.bff.createAssessmentsDetail(
-          organizationId,
-          assessmentId,
-          {
-            assessmentRegistryId,
-            iuds: values.selectedPaymentIuds
+          if (!assessmentRegistryId) {
+            throw new Error(
+              'Assessment Registry ID not found for the selected chapter'
+            );
           }
-        );
+
+          await utils.apiClient.bff.createAssessmentsDetail(
+            organizationId,
+            assessmentId,
+            {
+              assessmentRegistryId,
+              iuds: values.selectedPaymentIuds
+            }
+          );
+        } catch (detailError) {
+          console.error('Error creating assessment details:', detailError);
+          assessmentDetailsCreated = false;
+        }
       }
 
-      // STEP 3: Final navigation
-      navigate(PageRoutes.RESPONSES_SUCCESS, {
-        replace: true,
-        state: {
-          category: 'assessment-create',
-          i18nParams: {
-            assessmentName: response.assessmentName
-          },
-          assessmentId: response.assessmentId
-        }
-      });
+      // STEP 3: Final navigation based on success type
+      if (
+        addPaymentsToAssessment &&
+        values.selectedPaymentIuds &&
+        values.selectedPaymentIuds.length > 0 &&
+        !assessmentDetailsCreated
+      ) {
+        // Partial success: assessment created but payments not associated
+        navigate(PageRoutes.RESPONSES_SUCCESS, {
+          replace: true,
+          state: {
+            category: 'assessment-create-partial-success',
+            i18nParams: {
+              assessmentName: response.assessmentName
+            },
+            assessmentId: response.assessmentId
+          }
+        });
+      } else {
+        // Full success: assessment created (with or without payments)
+        navigate(PageRoutes.RESPONSES_SUCCESS, {
+          replace: true,
+          state: {
+            category: 'assessment-create',
+            i18nParams: {
+              assessmentName: response.assessmentName
+            },
+            assessmentId: response.assessmentId
+          }
+        });
+      }
     } catch (error) {
       console.error('Error during creation:', error);
 

--- a/src/routes/AssessmentDetail/AssessmentDetail.tsx
+++ b/src/routes/AssessmentDetail/AssessmentDetail.tsx
@@ -129,7 +129,8 @@ export const AssessmentDetail = () => {
       return;
     }
 
-    const debtPositionTypeOrgCode = detailItem?.debtPositionTypeOrgCode;
+    const debtPositionTypeOrgCode =
+      data?.debtPositionTypeOrgCode || detailItem?.debtPositionTypeOrgCode;
 
     const searchParams = new URLSearchParams({
       mode: 'remove',
@@ -156,7 +157,8 @@ export const AssessmentDetail = () => {
       return;
     }
 
-    const debtPositionTypeOrgCode = detailItem?.debtPositionTypeOrgCode;
+    const debtPositionTypeOrgCode =
+      data?.debtPositionTypeOrgCode || detailItem?.debtPositionTypeOrgCode;
 
     const searchParams = new URLSearchParams({
       mode: 'add',

--- a/src/routes/UtilityPages/success.test.tsx
+++ b/src/routes/UtilityPages/success.test.tsx
@@ -73,6 +73,16 @@ vi.mock('../../models/SuccessPageConfig', () => ({
           actionID: 'DEBT_TYPES_CATALOG'
         }
       ]
+    },
+    'assessment-create-partial-success': {
+      title: 'assessmentCreate.partialSuccess.title',
+      description: 'assessmentCreate.partialSuccess.description',
+      buttonConfig: [
+        {
+          buttonLabel: 'assessmentCreate.partialSuccess.goToDetail',
+          customNavigation: 'ASSESSMENT_DETAIL'
+        }
+      ]
     }
   }
 }));
@@ -244,6 +254,78 @@ describe('SuccessPage', () => {
 
       // This is the actual behavior: PageRoutes[undefined || PageRoutes.HOME] = PageRoutes[PageRoutes.HOME] = undefined
       expect(mockNavigate).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  describe('partial success scenarios', () => {
+    it('renders partial success page with warning icon and appropriate messages', () => {
+      mockUseLocation.mockReturnValue({
+        state: {
+          category: 'assessment-create-partial-success',
+          assessmentId: 123,
+          i18nParams: { assessmentName: 'Test Assessment' }
+        }
+      });
+
+      render(<SuccessPage />);
+
+      expect(
+        screen.getByText('assessmentCreate.partialSuccess.title')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('assessmentCreate.partialSuccess.description')
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', {
+          name: 'assessmentCreate.partialSuccess.goToDetail'
+        })
+      ).toBeInTheDocument();
+
+      const warningIcon = document.querySelector(
+        '[data-testid="WarningAmberOutlinedIcon"]'
+      );
+      expect(warningIcon).toBeInTheDocument();
+    });
+
+    it('navigates to assessment detail when partial success button is clicked', () => {
+      mockUseLocation.mockReturnValue({
+        state: {
+          category: 'assessment-create-partial-success',
+          assessmentId: 456
+        }
+      });
+
+      render(<SuccessPage />);
+      const button = screen.getByRole('button', {
+        name: 'assessmentCreate.partialSuccess.goToDetail'
+      });
+      fireEvent.click(button);
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        PageRoutes.ASSESSMENT_DETAIL.replace(':id', '456')
+      );
+    });
+
+    it('shows success icon for normal assessment creation', () => {
+      mockUseLocation.mockReturnValue({
+        state: {
+          category: 'assessment-create',
+          assessmentId: 123
+        }
+      });
+
+      render(<SuccessPage />);
+
+      const successIcon = document.querySelector(
+        '[data-testid="CheckCircleOutlineOutlinedIcon"]'
+      );
+      expect(successIcon).toBeInTheDocument();
+
+      const warningIcon = document.querySelector(
+        '[data-testid="WarningAmberOutlinedIcon"]'
+      );
+      expect(warningIcon).not.toBeInTheDocument();
     });
   });
 });

--- a/src/routes/UtilityPages/success.tsx
+++ b/src/routes/UtilityPages/success.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate, useLocation, generatePath } from 'react-router';
 import { PageRoutes } from '../../routes';
 import CheckCircleOutlineOutlinedIcon from '@mui/icons-material/CheckCircleOutlineOutlined';
+import WarningAmberOutlinedIcon from '@mui/icons-material/WarningAmberOutlined';
 import { theme } from '@pagopa/mui-italia';
 import { SuccessPageConfig } from '../../models/SuccessPageConfig';
 import { useEffect } from 'react';
@@ -61,14 +62,28 @@ export const SuccessPage = () => {
     };
   });
 
+  const getIcon = () => {
+    const isPartialSuccess = category === 'assessment-create-partial-success';
+
+    if (isPartialSuccess) {
+      return (
+        <WarningAmberOutlinedIcon
+          sx={{ fontSize: 60, color: theme.palette.warning.main }}
+        />
+      );
+    }
+
+    return (
+      <CheckCircleOutlineOutlinedIcon
+        sx={{ fontSize: 60, color: theme.palette.secondary.main }}
+      />
+    );
+  };
+
   return (
     <>
       <ResponsePage
-        icon={
-          <CheckCircleOutlineOutlinedIcon
-            sx={{ fontSize: 60, color: theme.palette.secondary.main }}
-          />
-        }
+        icon={getIcon()}
         title={String(
           t(pageConfig?.title, {
             ...i18nParams,

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -190,6 +190,11 @@
       "description": "Puoi trovarlo nella sezione accertamento pagamenti, dove puoi consultarlo in qualsiasi momento.",
       "goToDetail": "Visualizza accertamento"
     },
+    "partialSuccess": {
+      "title": "Accertamento \"{{assessmentName}}\" creato con pagamenti non associati",
+      "description": "L'accertamento è stato creato correttamente, ma non è stato possibile associare i pagamenti selezionati. Puoi aggiungerli manualmente accedendo al dettaglio dell'accertamento.",
+      "goToDetail": "Vai al dettaglio e aggiungi pagamenti"
+    },
     "removePayments": {
       "title": "Rimuovi pagamenti",
       "description": "Cerca e seleziona i pagamenti nell’acertamento da rimuovere.",


### PR DESCRIPTION
With this PR we handled the scenario where an assessment is created with associated payments. 

When clicking on the Create CTA, the first API call to retrieve the assessment ID succeeds, but the second call to add the payments fails. In this case, the unhappy path is now managed by showing a partial success page, informing the user that the assessment was created but the payments were not added. Payments can be added later from the detail page of the newly created assessment.

#### List of Changes

-Added a partial-success route in successPageConfig

#### How Has This Been Tested?
-visual testing
-unit tests

#### Screenshots (if appropriate):
<img width="2562" height="927" alt="Screenshot 2025-09-10 091924" src="https://github.com/user-attachments/assets/9e99ad1f-b197-4a34-9416-d8e9d4abe43c" />


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
