### PR TITLE
fix: [P4ADEV-3726] assessments remove payments

### DIFF
--- a/src/hooks/usePaymentsTableFilters.test.tsx
+++ b/src/hooks/usePaymentsTableFilters.test.tsx
@@ -222,8 +222,7 @@ describe('usePaymentsTableFilters', () => {
         { wrapper: createWrapper() }
       );
 
-      // Con la nuova logica, una stringa con spazi viene considerata come filtro iniziale valido
-      expect(result.current.hasValidFilters).toBe(false); // Perché iuv è solo spazi vuoti
+      expect(result.current.hasValidFilters).toBe(false);
       expect(result.current.draftFilters.iuv).toBe('   ');
     });
 
@@ -476,7 +475,6 @@ describe('usePaymentsTableFilters', () => {
         { wrapper: createWrapper() }
       );
 
-      // Con la nuova logica, se c'è un filtro iniziale definito, lo usa
       expect(result.current.draftFilters.dateFrom).toEqual(initialDate);
       expect(result.current.draftFilters.dateTo).toBeUndefined();
     });

--- a/src/hooks/usePaymentsTableFilters.test.tsx
+++ b/src/hooks/usePaymentsTableFilters.test.tsx
@@ -201,7 +201,8 @@ describe('usePaymentsTableFilters', () => {
               dateTo: undefined,
               updateDateFrom: undefined,
               updateDateTo: undefined
-            }
+            },
+            isRemoveMode: false
           }),
         { wrapper: createWrapper() }
       );
@@ -215,14 +216,41 @@ describe('usePaymentsTableFilters', () => {
       const { result } = renderHook(
         () =>
           usePaymentsTableFilters({
-            initialFilters: { iuv: '   ' }
+            initialFilters: { iuv: '   ' },
+            isRemoveMode: false
+          }),
+        { wrapper: createWrapper() }
+      );
+
+      // Con la nuova logica, una stringa con spazi viene considerata come filtro iniziale valido
+      expect(result.current.hasValidFilters).toBe(false); // Perché iuv è solo spazi vuoti
+      expect(result.current.draftFilters.iuv).toBe('   ');
+    });
+
+    it('should always consider filters valid in remove mode', () => {
+      const { result } = renderHook(
+        () =>
+          usePaymentsTableFilters({
+            initialFilters: {},
+            isRemoveMode: true
           }),
         { wrapper: createWrapper() }
       );
 
       expect(result.current.hasValidFilters).toBe(true);
-      expect(result.current.draftFilters.dateFrom).toBeDefined();
-      expect(result.current.draftFilters.dateTo).toBeDefined();
+    });
+
+    it('should use empty filters in remove mode', () => {
+      const { result } = renderHook(
+        () =>
+          usePaymentsTableFilters({
+            initialFilters: {},
+            isRemoveMode: true
+          }),
+        { wrapper: createWrapper() }
+      );
+
+      expect(result.current.draftFilters).toEqual({});
     });
   });
 
@@ -437,19 +465,20 @@ describe('usePaymentsTableFilters', () => {
       expect(result.current.draftFilters.dateTo).toEqual(customDateTo);
     });
 
-    it('should use default filters when only one initial date is defined', () => {
+    it('should use provided initial filters when defined', () => {
+      const initialDate = new Date('2024-01-01');
       const { result } = renderHook(
         () =>
           usePaymentsTableFilters({
-            initialFilters: { dateFrom: new Date('2024-01-01') }
+            initialFilters: { dateFrom: initialDate },
+            isRemoveMode: false
           }),
         { wrapper: createWrapper() }
       );
 
-      expect(result.current.draftFilters.dateFrom).toEqual(
-        toStartOfDay(thirtyDaysAgo)
-      );
-      expect(result.current.draftFilters.dateTo).toEqual(toEndOfDay(today));
+      // Con la nuova logica, se c'è un filtro iniziale definito, lo usa
+      expect(result.current.draftFilters.dateFrom).toEqual(initialDate);
+      expect(result.current.draftFilters.dateTo).toBeUndefined();
     });
 
     it('should not auto-load more than once', () => {

--- a/src/hooks/usePaymentsTableFilters.tsx
+++ b/src/hooks/usePaymentsTableFilters.tsx
@@ -11,6 +11,7 @@ type UsePaymentsTableFiltersProps = {
   onFiltersChange?: (filters: PaymentsUIFilters) => void;
   onFilterValidationError?: (hasError: boolean) => void;
   autoLoadOnMount?: boolean;
+  isRemoveMode?: boolean;
 };
 
 const createStableDefaultFilters = (): PaymentsUIFilters => {
@@ -27,14 +28,23 @@ export const usePaymentsTableFilters = ({
   initialFilters = {},
   onFiltersChange,
   onFilterValidationError,
-  autoLoadOnMount = true
+  autoLoadOnMount = true,
+  isRemoveMode = false
 }: UsePaymentsTableFiltersProps = {}) => {
   const defaultFilters = useMemo((): PaymentsUIFilters => {
-    if (initialFilters?.dateFrom && initialFilters?.dateTo) {
-      return initialFilters;
+    // If there are explicit initial filters with defined values, we use them
+    const hasDefinedInitialFilters = Object.values(initialFilters).some(
+      (value) => Boolean(value) && (typeof value !== 'string' || value !== '')
+    );
+    if (hasDefinedInitialFilters) {
+      return initialFilters as PaymentsUIFilters;
+    }
+    // In remove mode, we use empty filters (no data filters)
+    if (isRemoveMode) {
+      return {};
     }
     return createStableDefaultFilters();
-  }, [initialFilters?.dateFrom, initialFilters?.dateTo]);
+  }, [initialFilters, isRemoveMode]);
 
   const [draftFilters, setDraftFilters] =
     useState<PaymentsUIFilters>(defaultFilters);
@@ -44,7 +54,13 @@ export const usePaymentsTableFilters = ({
   const hasAutoLoadedRef = useRef(false);
 
   // Validates that at least one filter is filled
+  // In remove mode, we don't require mandatory filters
   const hasValidFilters = useCallback(() => {
+    // In remove mode, we consider filters always valid (even empty)
+    if (isRemoveMode) {
+      return true;
+    }
+
     const { iuv, dateFrom, dateTo, updateDateFrom, updateDateTo } =
       draftFilters;
 
@@ -55,7 +71,7 @@ export const usePaymentsTableFilters = ({
       updateDateFrom ||
       updateDateTo
     );
-  }, [draftFilters]);
+  }, [draftFilters, isRemoveMode]);
 
   // Checks if there are active filters not yet applied
   const hasActiveFilters = useCallback(() => {

--- a/src/routes/AssessmentCreate/components/PaymentsTable.tsx
+++ b/src/routes/AssessmentCreate/components/PaymentsTable.tsx
@@ -91,7 +91,8 @@ export const PaymentsTable = ({
       onFiltersApplied?.(filters, { page: 0, size: 10 }, []);
     },
     onFilterValidationError,
-    autoLoadOnMount
+    autoLoadOnMount,
+    isRemoveMode
   });
 
   // Call onFiltersApplied when pagination, sorting, or filters change

--- a/src/routes/AssessmentCreate/components/Step2Payments.tsx
+++ b/src/routes/AssessmentCreate/components/Step2Payments.tsx
@@ -23,7 +23,6 @@ import { useStep2PaymentsState } from '../../../hooks/useStep2PaymentsState';
 import { usePaidInstallments } from '../../../hooks/usePaidInstallments';
 import { useGlobalPaymentSelection } from '../../../hooks/useGlobalPaymentSelection';
 import { usePaymentsManager } from '../../../hooks/usePaymentsManager';
-import { getAssessmentDetail } from '../../../api/assessments/assessmentDetail/assessmentDetail';
 import { deleteAssessmentDetails } from '../../../api/assessments';
 import { useStore } from '../../../store/GlobalStore';
 import { STATE } from '../../../store/types';
@@ -260,7 +259,7 @@ const Step2PaymentsComponent = forwardRef<
     [paymentsState.resetPaymentsData]
   );
 
-  // For Remove mode, use getAssessmentDetail instead of usePaidInstallments
+  // In Remove mode, disable usePaidInstallments - data loading handled by PaymentsTable
   const paymentsApi = usePaidInstallments({
     enabled:
       isActive && shouldLoadData && !!debtPositionTypeOrgCode && !isRemoveMode,
@@ -268,36 +267,6 @@ const Step2PaymentsComponent = forwardRef<
     debtPositionTypeOrgCode: debtPositionTypeOrgCode || '',
     onError: handleApiError
   });
-
-  const assessmentDetailQuery = getAssessmentDetail(
-    organizationId,
-    assessmentId || 0,
-    { size: 10, page: 0 }
-  );
-
-  // Effect for handling assessment detail data (Remove mode)
-  useEffect(() => {
-    if (
-      isRemoveMode &&
-      assessmentDetailQuery.data &&
-      !assessmentDetailQuery.isPending &&
-      !hasLoadedData
-    ) {
-      handleAssessmentDetailSuccess(assessmentDetailQuery.data);
-    }
-    if (isRemoveMode && assessmentDetailQuery.isError) {
-      handleApiError(assessmentDetailQuery.error as Error);
-    }
-  }, [
-    isRemoveMode,
-    assessmentDetailQuery.data,
-    assessmentDetailQuery.isPending,
-    assessmentDetailQuery.isError,
-    assessmentDetailQuery.error,
-    hasLoadedData,
-    handleAssessmentDetailSuccess,
-    handleApiError
-  ]);
 
   const operatingYearsQuery = useOperatingYears({
     includeAllOption: false,
@@ -505,7 +474,36 @@ const Step2PaymentsComponent = forwardRef<
       setIsManualApiCallPending(true);
 
       try {
-        const apiFilters = convertFiltersToAPI(uiFilters);
+        // In remove mode, convert filters without adding automatic dates
+        const convertFiltersForRemoval = (uiFilters: PaymentsUIFilters) => {
+          const apiFilters: {
+            iuv?: string;
+            paymentDateTimeFrom?: string;
+            paymentDateTimeTo?: string;
+            updateDateFrom?: string;
+            updateDateTo?: string;
+          } = {};
+
+          if (uiFilters.iuv?.trim()) {
+            apiFilters.iuv = uiFilters.iuv.trim();
+          }
+
+          // If explicitly present, add data filters
+          if (uiFilters.dateFrom && uiFilters.dateTo) {
+            apiFilters.paymentDateTimeFrom = uiFilters.dateFrom.toISOString();
+            apiFilters.paymentDateTimeTo = uiFilters.dateTo.toISOString();
+          }
+
+          if (uiFilters.updateDateFrom && uiFilters.updateDateTo) {
+            apiFilters.updateDateFrom = uiFilters.updateDateFrom.toISOString();
+            apiFilters.updateDateTo = uiFilters.updateDateTo.toISOString();
+          }
+
+          // We don't add default dates in remove mode
+          return apiFilters;
+        };
+
+        const apiFilters = convertFiltersForRemoval(uiFilters);
 
         const queryParams = {
           size: pagination.size,
@@ -556,7 +554,7 @@ const Step2PaymentsComponent = forwardRef<
     const hasApiError =
       operatingYearsQuery.isError ||
       (chaptersQuery.isError && debtPositionTypeOrgCode) ||
-      (isRemoveMode ? assessmentDetailQuery.isError : paymentsApi.isError);
+      (!isRemoveMode && paymentsApi.isError);
 
     if (hasApiError) {
       if (operatingYearsQuery.isError) {
@@ -565,12 +563,7 @@ const Step2PaymentsComponent = forwardRef<
       if (chaptersQuery.isError && debtPositionTypeOrgCode) {
         console.error('Chapters error:', chaptersQuery.error);
       }
-      if (isRemoveMode && assessmentDetailQuery.isError) {
-        console.error(
-          'Assessment Detail API error:',
-          assessmentDetailQuery.error
-        );
-      } else if (!isRemoveMode && paymentsApi.isError) {
+      if (!isRemoveMode && paymentsApi.isError) {
         console.error('Payments API error:', paymentsApi.error);
       }
       setValue('addPaymentsToAssessment', false);
@@ -582,8 +575,6 @@ const Step2PaymentsComponent = forwardRef<
     chaptersQuery.isError,
     chaptersQuery.error,
     isRemoveMode,
-    assessmentDetailQuery.isError,
-    assessmentDetailQuery.error,
     paymentsApi.isError,
     paymentsApi.error,
     debtPositionTypeOrgCode,
@@ -596,7 +587,6 @@ const Step2PaymentsComponent = forwardRef<
   }, [
     operatingYearsQuery.isError,
     chaptersQuery.isError,
-    assessmentDetailQuery.isError,
     paymentsApi.isError,
     debtPositionTypeOrgCode,
     handleExternalApiErrors
@@ -654,24 +644,29 @@ const Step2PaymentsComponent = forwardRef<
   );
 
   const initialTableFilters = useMemo(() => {
+    // In remove mode, we take the existing filters from the URL but remove the dates
+    if (isRemoveMode) {
+      const currentFilters = utils.URI.decode(window.location.hash);
+      // We remove only the data filters keeping the others (e.g. IUV)
+      return Object.fromEntries(
+        Object.entries(currentFilters).filter(
+          ([key]) => !['dateFrom', 'dateTo'].includes(key)
+        )
+      );
+    }
     return {
       dateFrom: startOfDay(subDays(new Date(), 30)),
       dateTo: endOfDay(new Date())
     };
-  }, []);
+  }, [isRemoveMode]);
 
   const isApiCallPending = useMemo(() => {
     if (isRemoveMode) {
-      return assessmentDetailQuery.isPending || isManualApiCallPending;
+      return isManualApiCallPending;
     } else {
       return paymentsApi.isLoading || isManualApiCallPending;
     }
-  }, [
-    isRemoveMode,
-    assessmentDetailQuery.isPending,
-    paymentsApi.isLoading,
-    isManualApiCallPending
-  ]);
+  }, [isRemoveMode, paymentsApi.isLoading, isManualApiCallPending]);
 
   // Reset data when debtPositionTypeOrgCode changes and step becomes active
   // This handles the case when user goes Step2->Step1->changes type->Step2
@@ -862,12 +857,11 @@ const Step2PaymentsComponent = forwardRef<
           onFilterValidationError={paymentsState.setShowFiltersValidationError}
           initialFilters={initialTableFilters}
           isLoading={
-            (isRemoveMode
-              ? assessmentDetailQuery.isPending
-              : paymentsApi.isLoading) && !hasLoadedData
+            (isRemoveMode ? isManualApiCallPending : paymentsApi.isLoading) &&
+            !hasLoadedData
           }
           isApiCallPending={isApiCallPending}
-          autoLoadOnMount={!hasLoadedData && !isRemoveMode}
+          autoLoadOnMount={!hasLoadedData}
           selectedIuds={currentPageSelectedIuds}
           isRemoveMode={isRemoveMode}
         />


### PR DESCRIPTION
When accessing the details of an assessment with associated payments and clicking on Remove, the wizard opens on the step where the payments to be removed should be displayed. However, the table may appear empty because the default date range filter is set to the last month. As a result, if the assessment has an outcome date older than one month, the table shows no records.

Solution: In the removal flow, remove the pre-populated date range filter and eliminate the requirement to apply at least one filter.


#### How Has This Been Tested?

-visual testing
-unit tests


#### Types of changes

- [ x Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
