### PR TITLE
fix: [P4ADEV-3750] Set required prop to false for ControlledTextField components in ReportingFilters

### DIFF
--- a/src/routes/Reporting/components/ReportingFilters.tsx
+++ b/src/routes/Reporting/components/ReportingFilters.tsx
@@ -34,6 +34,7 @@ export const ReportingFilters = ({
           adornment={<SearchIcon />}
           sx={{ flex: 0.3 }}
           key={FilterFieldIds.IUF}
+          required={false}
         />
         <FormComponent.ControlledTextField
           name="regulationUniqueIdentifier"
@@ -42,6 +43,7 @@ export const ReportingFilters = ({
           label={t('commons.searchRegulationUniqueIdentifier')}
           adornment={<SearchIcon />}
           key={FilterFieldIds.REGULATION_UNIQUE_IDENTIFIER}
+          required={false}
         />
         <Stack sx={{ flex: 0.4 }}>
           <FormComponent.ControlledDateRange


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Set required prop to false for ControlledTextField components in ReportingFilters.

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This is required because 'ID Rendicontazione' and 'ID Regolamento' aren't required filters.
#### How Has This Been Tested?
Tested manually.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
