### PR TITLE
fix: [P4ADEV-3746] assesment registry search

### DIFF
--- a/src/api/assessments/mappings.ts
+++ b/src/api/assessments/mappings.ts
@@ -22,7 +22,9 @@ export const buildAssessmentsRegistriesQueryParams = ({
   officeDescription: filters.OFFICE_DESCRIPTION,
   assessmentCode: filters.ASSESSMENT_CODE,
   assessmentDescription: filters.ASSESSMENT_DESCRIPTION,
-  operatingYear: format(filters.OPERATING_YEAR, 'yyyy'),
+  operatingYear: filters.OPERATING_YEAR
+    ? format(filters.OPERATING_YEAR, 'yyyy')
+    : undefined,
   status: filters.STATUS as AssessmentsRegistryStatus,
   page: pagination.page,
   size: pagination.size,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- fix: Guard against undefined date in assessments registry query params

<!--- Describe your changes in detail -->

#### Motivation and Context

The application was throwing an "Invalid time value" RangeError when navigating to the assessments registry search results page.
The root cause was that the `operatingYear` parameter was being passed to the `date-fns/format` utility as `undefined`, which is an invalid input.
This patch resolves the issue by introducing a conditional check. The `format` utility is now only invoked when `filters.OPERATING_YEAR` is a truthy value. Otherwise, `undefined` is passed along, effectively omitting the query parameter from the final API request as intended.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

- manual interaction

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
