### PR TITLE
fix: [P4ADEV-3624] Set required prop conditionally for ControlledTextField in in Step1Configuration

### DIFF
--- a/src/components/FormComponent/_ControlledTextField.tsx
+++ b/src/components/FormComponent/_ControlledTextField.tsx
@@ -20,13 +20,11 @@ export const _ControlledTextField = <T extends FieldValues>({
       <FormComponent.TextField
         forwardRef={ref}
         id={name}
-        required
         noAdornment={!props?.adornment}
         error={!!fieldState.error}
         helperText={<ErrorMessage messageKey={fieldState.error?.message} />}
         InputLabelProps={{
-          ...props.InputLabelProps,
-          shrink: !!field.value // Key fix: always shrink if value exists
+          ...props.InputLabelProps
         }}
         {...field}
         {...props}

--- a/src/routes/DebtTypeCreate/components/Step1Configuration.tsx
+++ b/src/routes/DebtTypeCreate/components/Step1Configuration.tsx
@@ -96,6 +96,7 @@ export const Step1Configuration = ({
                 data-testid="code"
                 defaultValue={editmode ? prefilledData?.code : ''}
                 disabled={editmode}
+                required={!editmode}
               />
               <Stack flex={3}>
                 <FormComponent.ControlledTextField
@@ -109,6 +110,7 @@ export const Step1Configuration = ({
                   adornment={`${form.getValues('description')?.length || 0}/100`}
                   defaultValue={editmode ? prefilledData?.description : ''}
                   disabled={editmode}
+                  required={!editmode}
                 />
                 <Typography variant="caption" px={1.5}>
                   {t('debtTypeCreate.configuration.debtType.helper')}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Set required prop conditionally for ControlledTextField in in Step1Configuration
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This is required to avoid label and value to overlap
#### How Has This Been Tested?
Tested by manual testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
