### PR TITLE
fix: [P4ADEV-3691] add debtPositionTypeOrgId filter to debtTypeOrgOperator in edit mode

### DIFF
--- a/src/routes/DebtTypeOrgCreate/steps/Step5Operators/components/OperatorSelector.test.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step5Operators/components/OperatorSelector.test.tsx
@@ -15,6 +15,8 @@ import * as api from '../../../../../api/debtPositionTypeOrgOperators';
 import { OperatorSelector } from './OperatorSelector';
 import { setUserInfo } from '../../../../../store/UserInfoStore';
 import { vi } from 'vitest';
+import { useSearch } from '../../../../../hooks/useSearch';
+import { useParams } from 'react-router';
 
 // Sample data to be returned by the mocked useSearch hook
 const testApiResponse = {
@@ -60,6 +62,14 @@ vi.mock('../../../../../hooks/useSearch', () => ({
   }))
 }));
 
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router')>();
+  return {
+    ...actual,
+    useParams: vi.fn()
+  };
+});
+
 // Spy on the API mock; return data synchronously as returned by useSearch
 vi.spyOn(api, 'getDebtPositionTypeOrgOperators').mockImplementation(
   () =>
@@ -89,9 +99,16 @@ const renderWithProviders = (edit?: boolean) => {
 };
 
 describe('OperatorSelector component integration', () => {
+  const mockedUseParams = vi.mocked(useParams);
+  const mockedUseSearch = vi.mocked(useSearch);
+
   beforeEach(() => {
-    // Reset the user info to empty before each test
+    // Reset mocks to a clean state before each test
+    vi.clearAllMocks();
     setUserInfo(undefined);
+
+    // Provide a default return value for useParams for tests in edit mode
+    mockedUseParams.mockReturnValue({ debtPositionTypeOrgId: '123' });
   });
 
   it('renders operators and displays selection alert', async () => {
@@ -172,6 +189,31 @@ describe('OperatorSelector component integration', () => {
     // Alert updates (now 2 selected)
     await waitFor(() => {
       expect(screen.getByText(/commons.selectedOperator/)).toBeInTheDocument();
+    });
+  });
+
+  describe('API filter logic', () => {
+    it('passes debtPositionTypeOrgId to useSearch filters when in edit mode', () => {
+      renderWithProviders(true);
+
+      expect(mockedUseSearch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filters: { debtPositionTypeOrgId: 123 }
+        })
+      );
+    });
+
+    it('does not pass debtPositionTypeOrgId when not in edit mode (create mode)', () => {
+      // Override beforeEach setup for create mode, which has no URL params
+      mockedUseParams.mockReturnValue({});
+
+      renderWithProviders(false);
+
+      expect(mockedUseSearch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filters: { debtPositionTypeOrgId: undefined }
+        })
+      );
     });
   });
 });

--- a/src/routes/DebtTypeOrgCreate/steps/Step5Operators/components/OperatorSelector.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step5Operators/components/OperatorSelector.tsx
@@ -16,6 +16,7 @@ import { OperatorsSelection } from '../../../../../../generated/data-contracts';
 import { useStore } from '../../../../../store/GlobalStore';
 import { useSearch } from '../../../../../hooks/useSearch';
 import { getDebtPositionTypeOrgOperators } from '../../../../../api/debtPositionTypeOrgOperators';
+import { useParams } from 'react-router';
 
 type OperatorData = {
   id: string;
@@ -28,6 +29,10 @@ type OperatorData = {
 
 export const OperatorSelector = ({ edit }: { edit?: boolean }) => {
   const { t } = useTranslation();
+
+  const { debtPositionTypeOrgId } = useParams<{
+    debtPositionTypeOrgId: string;
+  }>();
 
   const {
     state: { organizationId, userInfo }
@@ -69,7 +74,9 @@ export const OperatorSelector = ({ edit }: { edit?: boolean }) => {
   const query = getDebtPositionTypeOrgOperators(organizationId);
 
   const debtTypeOrgOperators = useSearch({
-    filters: {},
+    filters: {
+      debtPositionTypeOrgId: edit ? Number(debtPositionTypeOrgId) : undefined
+    },
     query
   });
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- fix: Correctly fetch operator enabled status in edit mode
- add: unit tests to confirm debtPositionTypeOrgId is passed in edit mode and NOT passed in in create mode

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

- unit tests
- visual testing
- manual interaction

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
