### PR TITLE
feat: [P4ADEV-3808]  custom tooltip on debt positions and notices

### DIFF
--- a/src/components/ChipTruncateTooltip/index.test.tsx
+++ b/src/components/ChipTruncateTooltip/index.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '../../__tests__/renderers';
+import { render, screen, fireEvent } from '../../__tests__/renderers';
 import ChipTruncateTooltip from '.';
 
 describe('ChipTruncateTooltip', () => {
@@ -9,5 +9,38 @@ describe('ChipTruncateTooltip', () => {
     render(<ChipTruncateTooltip label={labelText} color="primary" />);
 
     expect(screen.getByText(labelText)).toBeInTheDocument();
+  });
+
+  it('shows custom tooltip when tooltipLabel is provided', async () => {
+    const labelText = 'Status';
+    const tooltipText = 'Custom tooltip message';
+
+    render(
+      <ChipTruncateTooltip
+        label={labelText}
+        tooltipLabel={tooltipText}
+        color="primary"
+      />
+    );
+
+    const chip = screen.getByText(labelText);
+    expect(chip).toBeInTheDocument();
+
+    // Hover to show tooltip
+    fireEvent.mouseOver(chip);
+
+    // Wait for tooltip to appear
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(tooltipText);
+  });
+
+  it('falls back to label as tooltip when tooltipLabel is not provided', async () => {
+    const labelText = 'Test Label';
+
+    render(<ChipTruncateTooltip label={labelText} color="primary" />);
+
+    const chip = screen.getByText(labelText);
+    fireEvent.mouseOver(chip);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(labelText);
   });
 });

--- a/src/components/ChipTruncateTooltip/index.tsx
+++ b/src/components/ChipTruncateTooltip/index.tsx
@@ -2,13 +2,19 @@ import React from 'react';
 import { Tooltip, Chip } from '@mui/material';
 import { ChipProps } from '@mui/material/Chip';
 
-const ChipTruncateTooltip: React.FC<ChipProps> = ({
+type ChipTruncateTooltipProps = ChipProps & {
+  tooltipLabel?: string;
+};
+
+const ChipTruncateTooltip: React.FC<ChipTruncateTooltipProps> = ({
   label,
   color,
-  variant
+  variant,
+  tooltipLabel,
+  ...otherProps
 }) => {
   return (
-    <Tooltip title={label} arrow>
+    <Tooltip title={tooltipLabel || label} arrow>
       <Chip
         label={label}
         color={color}
@@ -23,6 +29,7 @@ const ChipTruncateTooltip: React.FC<ChipProps> = ({
             cursor: 'default'
           }
         }}
+        {...otherProps}
       />
     </Tooltip>
   );

--- a/src/routes/DebtPositions/components/DebtPositionIUVDataGrid.tsx
+++ b/src/routes/DebtPositions/components/DebtPositionIUVDataGrid.tsx
@@ -78,6 +78,7 @@ export const IUVDataGrid = ({ data }: DataGridProps) => {
       renderCell: (params: GridRenderCellParams<InstallmentView>) => (
         <ChipTruncateTooltip
           label={t(`commons.status.${params.value}`)}
+          tooltipLabel={t(`DebtPositions.installment.tooltip.${params.value}`)}
           color={stateColors[params.value as InstallmentStatus]}
           variant="outlined"
         />

--- a/src/routes/DebtPositions/components/DebtPositionsDataGrid.tsx
+++ b/src/routes/DebtPositions/components/DebtPositionsDataGrid.tsx
@@ -72,6 +72,7 @@ export const DebtPositionsDataGrid = ({ data }: DataGridProps) => {
       renderCell: (params: GridRenderCellParams<ResultDataRow>) => (
         <ChipTruncateTooltip
           label={t(`commons.status.${params.value}`)}
+          tooltipLabel={t(`DebtPositions.status.tooltip.${params.value}`)}
           color={stateColors[params.value as DebtPositionStatus]}
         />
       )

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -59,6 +59,30 @@
       "titleIUV": "Avvisi (IUV)",
       "accessibleTitleIUV": "Risultato ricerca Avvisi",
       "accessibleTitleDP": "Risultato ricerca posizioni debitorie"
+    },
+    "status": {
+      "tooltip": {
+        "DRAFT": "Non ci sono ancora avvisi di pagamento per questa posizione debitoria.",
+        "TO_SYNC": "La posizione debitoria è stata creata ma non è ancora pagabile.",
+        "UNPAID": "La posizione debitoria è stata creata ed è pagabile.",
+        "PARTIALLY_PAID": "È stato effettuato solo una parte del pagamento.",
+        "PAID": "Tutti i pagamenti sono stati completati.",
+        "REPORTED": "Tutti i pagamenti sono stati rendicontati.",
+        "EXPIRED": "I pagamenti non sono stati effettuati entro la data di scadenza prevista.",
+        "CANCELLED": "La posizione debitoria è stata rimossa da un operatore."
+      }
+    },
+    "installment": {
+      "tooltip": {
+        "DRAFT": "L'avviso di pagamento non è stato ancora emesso.",
+        "TO_SYNC": "L'avviso di pagamento è stato registrato ma non è ancora pagabile.",
+        "UNPAID": "L'avviso di pagamento è stato emesso ed è pagabile.",
+        "PAID": "Il pagamento è stato completato.",
+        "REPORTED": "L'avviso di pagamento è stato rendicontato.",
+        "EXPIRED": "Il pagamento non è stato completato entro la data di scadenza stabilita.",
+        "INVALID": "L'avviso è stato invalidato perché il debitore ha avviato il pagamento con un'altra opzione.",
+        "CANCELLED": "L'avviso di pagamento è stato rimosso da un operatore."
+      }
     }
   },
   "FileUploaderFlowImport": {

--- a/src/utils/__tests__/loaders.test.tsx
+++ b/src/utils/__tests__/loaders.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   OperatorRole,
-  OrganizationDTO
+  OrganizationDTO,
+  OrganizationStatus
 } from '../../../generated/data-contracts';
 import { AxiosResponse } from 'axios';
 import { renderHook, waitFor } from '../../__tests__/renderers';
@@ -43,7 +44,8 @@ describe('loaders', () => {
           orgFiscalCode: '123456789',
           flagNotifyIo: false,
           flagNotifyOutcomePush: false,
-          flagPaymentNotification: false
+          flagPaymentNotification: false,
+          status: OrganizationStatus.ACTIVE
         }
       ];
 


### PR DESCRIPTION
This PR introduces customized tooltips for the statuses of IUV notices and debtor positions.

#### List of Changes

Added tooltipLabel prop to the ChipTruncateTooltip component


#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
<img width="1660" height="699" alt="Screenshot 2025-09-19 135440" src="https://github.com/user-attachments/assets/ecc357e4-9fa0-4db1-9d1b-0fd8514525c2" />

<img width="1718" height="831" alt="Screenshot 2025-09-19 135511" src="https://github.com/user-attachments/assets/3d7afdfa-30df-4b6a-8b85-46ee09b62d70" />

<img width="1705" height="1005" alt="Screenshot 2025-09-19 135552" src="https://github.com/user-attachments/assets/b825bdc0-ff1b-40b2-8f5b-4f6f4dd92ded" />


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
