### PR TITLE
feat: [P4ADEV-3769] operator debtType delete

### DIFF
--- a/src/api/debtPositionTypeOrgOperators/index.ts
+++ b/src/api/debtPositionTypeOrgOperators/index.ts
@@ -28,3 +28,18 @@ export const getDebtPositionTypeOrgOperators = (organizationId: number) =>
       return response;
     }
   });
+
+export const removeDebtPositionTypeOrgFromOperator = () =>
+  useMutation({
+    mutationKey: ['removeDebtPositionTypeOrgFromOperator'],
+    mutationFn: (params: {
+      organizationId: number;
+      mappedExternalUserId: string;
+      debtPositionTypeOrgId: number;
+    }) =>
+      utils.apiClient.bff.removeDebtPositionTypeOrgFromOperator(
+        params.organizationId,
+        params.mappedExternalUserId,
+        params.debtPositionTypeOrgId
+      )
+  });

--- a/src/api/debtPositions/index.ts
+++ b/src/api/debtPositions/index.ts
@@ -104,6 +104,11 @@ const deleteDebtPositionTypeOrgs = (
   debtPositionTypeOrgId: number
 ) =>
   useMutation({
+    mutationKey: [
+      'deleteDebtPositionTypeOrgs',
+      organizationId,
+      debtPositionTypeOrgId
+    ],
     mutationFn: () =>
       utils.apiClient.bff.deleteDebtPositionTypeOrg(
         organizationId,
@@ -278,18 +283,18 @@ const getInstallmentRegistriesMutation = () => {
 };
 
 export default {
-  getDebtPositionViews,
-  getInstallments,
-  getInstallmentDetail,
-  getDebtPositionDetail,
+  createDebtPosition,
+  deleteDebtPosition,
   deleteDebtPositionType,
   deleteDebtPositionTypeOrgs,
-  deleteDebtPosition,
-  publishDebtPosition,
-  createDebtPosition,
-  manageDebtPositionInstallments,
+  getDebtPositionDetail,
   getDebtPositionRegistriesMutation,
+  getDebtPositionViews,
+  getDebtPositionZipFile,
+  getInstallmentDetail,
   getInstallmentRegistriesMutation,
+  getInstallments,
   getPaymentNoticeFile,
-  getDebtPositionZipFile
+  manageDebtPositionInstallments,
+  publishDebtPosition
 };

--- a/src/components/GenericDialog/GenericDialog.tsx
+++ b/src/components/GenericDialog/GenericDialog.tsx
@@ -11,7 +11,7 @@ import { ReactNode } from 'react';
 export type GenericDialogProps = {
   open: boolean;
   title: string;
-  message?: string;
+  message?: string | React.ReactElement;
   confirmLabel?: string;
   cancelLabel?: string;
   children?: ReactNode;

--- a/src/routes/OperatorsDetail/components/ActionMenu.tsx
+++ b/src/routes/OperatorsDetail/components/ActionMenu.tsx
@@ -1,0 +1,51 @@
+import ActionMenu from '../../../components/ActionMenu/ActionMenu';
+import { DebtPositionTypeOrgDTO } from '../../../../generated/data-contracts';
+import RemoveCircleOutline from '@mui/icons-material/RemoveCircleOutline';
+import OpenInNew from '@mui/icons-material/OpenInNew';
+import { useTranslation } from 'react-i18next';
+
+type ActionMenuProps = {
+  row: DebtPositionTypeOrgDTO;
+  onDelete: (row: DebtPositionTypeOrgDTO) => void;
+};
+
+export const GridActionMenu = ({ row, onDelete }: ActionMenuProps) => {
+  const { t } = useTranslation();
+
+  const deleteItem = () => {
+    onDelete(row);
+  };
+
+  return (
+    <ActionMenu
+      rowId={row.debtPositionTypeId}
+      menuItems={[
+        {
+          icon: (
+            <RemoveCircleOutline
+              fontSize="small"
+              color="error"
+              aria-label="remove operator detail item"
+              data-testid={`remove-detail-${row.debtPositionTypeId}`}
+            />
+          ),
+          label: t('commons.onlyRemove'),
+          action: deleteItem
+        },
+        {
+          icon: (
+            <OpenInNew
+              color="primary"
+              fontSize="small"
+              aria-label="go to operator detail item"
+              data-testid={`navigate-to-detail-${row.debtPositionTypeId}`}
+            />
+          ),
+          label: t('commons.goToDetail'),
+          // TODO: add go to detail
+          action: () => null
+        }
+      ]}
+    />
+  );
+};

--- a/src/routes/OperatorsDetail/components/OperatorDetailDataGrid.test.tsx
+++ b/src/routes/OperatorsDetail/components/OperatorDetailDataGrid.test.tsx
@@ -1,26 +1,35 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen } from '../../../__tests__/renderers';
+import { render, screen, fireEvent } from '../../../__tests__/renderers';
 import OperatorDetailDataGrid from './OperatorDetailDataGrid';
-import { PagedDebtPositionTypeOrgDTO } from '../../../../generated/data-contracts';
+import { PagedDebtPositionTypeOrgDTO } from '../../../../generated/apiClient';
+import utils from '../../../utils';
 
-// Mock ActionMenu to simple div showing menu items label and icons for testing
-vi.mock('../../../components/ActionMenu/ActionMenu', () => ({
-  default: (props: any) => {
+vi.mock('../../../utils', () => ({
+  default: {
+    dialog: {
+      open: vi.fn(),
+      close: vi.fn()
+    }
+  }
+}));
+
+vi.mock('./ActionMenu', () => ({
+  GridActionMenu: (props: any) => {
     return (
-      <div data-testid={`action-menu-${props.rowId}`}>
-        {props.menuItems.map((item: any, idx: number) => (
-          <button key={idx} onClick={item.action} aria-label={item.label}>
-            {item.label}
-            {item.icon}
-          </button>
-        ))}
+      <div data-testid={`grid-action-menu-${props.row.debtPositionTypeOrgId}`}>
+        <button
+          onClick={() => props.onDelete(props.row)}
+          data-testid={`delete-button-${props.row.debtPositionTypeOrgId}`}
+          aria-label="Delete"
+        >
+          Delete
+        </button>
       </div>
     );
   }
 }));
 
-// Mock EmptyDetailContainer as a simple div showing description
 vi.mock(
   '../../../components/DebtPositionsInstallmentDetail/EmptyDetailContainer',
   () => ({
@@ -30,7 +39,45 @@ vi.mock(
   })
 );
 
+vi.mock('../../../components/DataGrid/CustomDataGrid', () => ({
+  default: (props: any) => {
+    return (
+      <div data-testid="custom-data-grid">
+        <div data-testid="grid-headers">
+          {props.columns.map((col: any, idx: number) => (
+            <div key={idx} data-testid={`header-${col.field}`}>
+              {col.headerName}
+            </div>
+          ))}
+        </div>
+        <div data-testid="grid-rows">
+          {props.rows.map((row: any) => (
+            <div
+              key={props.getRowId(row)}
+              data-testid={`row-${props.getRowId(row)}`}
+            >
+              {props.columns.map((col: any, colIdx: number) => (
+                <div
+                  key={colIdx}
+                  data-testid={`cell-${props.getRowId(row)}-${col.field}`}
+                >
+                  {col.field === 'action' && col.renderCell
+                    ? col.renderCell({ row })
+                    : row[col.field]}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+}));
+
 describe('OperatorDetailDataGrid', () => {
+  const mockOnDelete = vi.fn();
+  const operatorName = 'Test Operator';
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -58,31 +105,54 @@ describe('OperatorDetailDataGrid', () => {
   } as PagedDebtPositionTypeOrgDTO;
 
   it('renders column headers correctly', () => {
-    render(<OperatorDetailDataGrid data={sampleData} />);
+    render(
+      <OperatorDetailDataGrid
+        data={sampleData}
+        onDelete={mockOnDelete}
+        operatorName={operatorName}
+      />
+    );
 
-    expect(screen.getByText('OperatorDetail.code')).toBeInTheDocument();
+    expect(screen.getByTestId('header-code')).toHaveTextContent(
+      'OperatorDetail.code'
+    );
     expect(
-      screen.getByText('OperatorDetail.debtPositionTypeDescription')
-    ).toBeInTheDocument();
-    expect(screen.getByText('commons.description')).toBeInTheDocument();
+      screen.getByTestId('header-debtPositionTypeDescription')
+    ).toHaveTextContent('OperatorDetail.debtPositionTypeDescription');
+    expect(screen.getByTestId('header-description')).toHaveTextContent(
+      'commons.description'
+    );
+    expect(screen.getByTestId('header-action')).toHaveTextContent('');
   });
 
   it('renders rows correctly', () => {
-    render(<OperatorDetailDataGrid data={sampleData} />);
+    render(
+      <OperatorDetailDataGrid
+        data={sampleData}
+        onDelete={mockOnDelete}
+        operatorName={operatorName}
+      />
+    );
 
     sampleData.content.forEach((row) => {
-      expect(screen.getByText(row.code)).toBeInTheDocument();
       expect(
-        screen.getByText(row.debtPositionTypeDescription as string)
-      ).toBeInTheDocument();
-      expect(screen.getByText(row.description)).toBeInTheDocument();
+        screen.getByTestId(`cell-${row.debtPositionTypeOrgId}-code`)
+      ).toHaveTextContent(row.code);
+      expect(
+        screen.getByTestId(
+          `cell-${row.debtPositionTypeOrgId}-debtPositionTypeDescription`
+        )
+      ).toHaveTextContent(row.debtPositionTypeDescription as string);
+      expect(
+        screen.getByTestId(`cell-${row.debtPositionTypeOrgId}-description`)
+      ).toHaveTextContent(row.description);
 
-      // Check presence of remove and navigate icons by data-testid inside the buttons
+      // action menu is rendered
       expect(
-        screen.getByTestId(`remove-detail-${row.debtPositionTypeId}`)
+        screen.getByTestId(`grid-action-menu-${row.debtPositionTypeOrgId}`)
       ).toBeInTheDocument();
       expect(
-        screen.getByTestId(`navigate-to-detail-${row.debtPositionTypeId}`)
+        screen.getByTestId(`delete-button-${row.debtPositionTypeOrgId}`)
       ).toBeInTheDocument();
     });
   });
@@ -97,10 +167,134 @@ describe('OperatorDetailDataGrid', () => {
           totalElements: 0,
           number: 0
         }}
+        onDelete={mockOnDelete}
+        operatorName={operatorName}
       />
     );
+
     expect(screen.getByTestId('empty-detail-container')).toHaveTextContent(
       'OperatorDetail.emptyData'
     );
+  });
+
+  it('renders EmptyDetailContainer when data is undefined', () => {
+    render(
+      <OperatorDetailDataGrid
+        onDelete={mockOnDelete}
+        operatorName={operatorName}
+      />
+    );
+
+    expect(screen.getByTestId('custom-data-grid')).toBeInTheDocument();
+    expect(screen.getByTestId('grid-rows')).toBeInTheDocument();
+  });
+
+  it('opens delete dialog when delete button is clicked', () => {
+    render(
+      <OperatorDetailDataGrid
+        data={sampleData}
+        onDelete={mockOnDelete}
+        operatorName={operatorName}
+      />
+    );
+
+    const deleteButton = screen.getByTestId('delete-button-1');
+    fireEvent.click(deleteButton);
+
+    expect(utils.dialog.open).toHaveBeenCalledWith({
+      ['data-testid']: 'delete-dialog',
+      title: 'OperatorDetail.deleteDialog.title',
+      message: expect.any(Object), // Trans component
+      confirmLabel: 'commons.onlyRemove',
+      cancelLabel: 'commons.close',
+      onConfirm: expect.any(Function),
+      onClose: expect.any(Function)
+    });
+  });
+
+  it('calls onDelete and closes dialog when delete is confirmed', () => {
+    render(
+      <OperatorDetailDataGrid
+        data={sampleData}
+        onDelete={mockOnDelete}
+        operatorName={operatorName}
+      />
+    );
+
+    const deleteButton = screen.getByTestId('delete-button-1');
+    fireEvent.click(deleteButton);
+
+    // Get the onConfirm function from the dialog.open call
+    const dialogOpenCall = (utils.dialog.open as any).mock.calls[0][0];
+    const onConfirm = dialogOpenCall.onConfirm;
+
+    // confirming the deletion
+    onConfirm();
+
+    expect(mockOnDelete).toHaveBeenCalledWith(sampleData.content[0]);
+    expect(utils.dialog.close).toHaveBeenCalled();
+  });
+
+  it('closes dialog when delete is cancelled', () => {
+    render(
+      <OperatorDetailDataGrid
+        data={sampleData}
+        onDelete={mockOnDelete}
+        operatorName={operatorName}
+      />
+    );
+
+    const deleteButton = screen.getByTestId('delete-button-1');
+    fireEvent.click(deleteButton);
+
+    // Get the onClose function from the dialog.open call
+    const dialogOpenCall = (utils.dialog.open as any).mock.calls[0][0];
+    const onClose = dialogOpenCall.onClose;
+
+    // cancelling the deletion
+    onClose();
+
+    expect(mockOnDelete).not.toHaveBeenCalled();
+    expect(utils.dialog.close).toHaveBeenCalled();
+  });
+
+  it('uses correct getRowId for rows', () => {
+    render(
+      <OperatorDetailDataGrid
+        data={sampleData}
+        onDelete={mockOnDelete}
+        operatorName={operatorName}
+      />
+    );
+
+    // rows are rendered with correct IDs
+    expect(screen.getByTestId('row-1')).toBeInTheDocument(); // debtPositionTypeOrgId
+    expect(screen.getByTestId('row-2')).toBeInTheDocument();
+  });
+
+  it('handles rows without debtPositionTypeOrgId correctly', () => {
+    const dataWithoutId = {
+      content: [
+        {
+          organizationId: 10,
+          debtPositionTypeId: 100,
+          code: 'CODE1',
+          debtPositionTypeDescription: 'Debt Desc 1',
+          description: 'Description 1'
+        }
+      ],
+      totalPages: 1
+    } as PagedDebtPositionTypeOrgDTO;
+
+    render(
+      <OperatorDetailDataGrid
+        data={dataWithoutId}
+        onDelete={mockOnDelete}
+        operatorName={operatorName}
+      />
+    );
+
+    // Should use fallback ID format: organizationId-debtPositionTypeId
+    expect(screen.getByTestId('row-10-100')).toBeInTheDocument();
   });
 });

--- a/src/routes/OperatorsDetail/components/OperatorDetailDataGrid.tsx
+++ b/src/routes/OperatorsDetail/components/OperatorDetailDataGrid.tsx
@@ -1,20 +1,46 @@
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import CustomDataGrid from '../../../components/DataGrid/CustomDataGrid';
-import { OpenInNew, RemoveCircleOutline } from '@mui/icons-material';
 import {
   DebtPositionTypeOrgDTO,
   PagedDebtPositionTypeOrgDTO
 } from '../../../../generated/apiClient';
 import { GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
-import ActionMenu from '../../../components/ActionMenu/ActionMenu';
 import EmptyDetailContainer from '../../../components/DebtPositionsInstallmentDetail/EmptyDetailContainer';
+import { GridActionMenu } from './ActionMenu';
+import utils from '../../../utils';
 
 type OperatorDetailDataGridProps = {
   data?: PagedDebtPositionTypeOrgDTO;
+  onDelete: (row: DebtPositionTypeOrgDTO) => void;
+  operatorName: string;
 };
 
-const OperatorDetailDataGrid = ({ data }: OperatorDetailDataGridProps) => {
+const OperatorDetailDataGrid = ({
+  data,
+  onDelete: propsOnDelete,
+  operatorName
+}: OperatorDetailDataGridProps) => {
   const { t } = useTranslation();
+
+  const onDelete = (row: DebtPositionTypeOrgDTO) => {
+    utils.dialog.open({
+      ['data-testid']: 'delete-dialog',
+      title: t('OperatorDetail.deleteDialog.title'),
+      message: (
+        <Trans
+          i18nKey="OperatorDetail.deleteDialog.message"
+          values={{ operatorName }}
+        />
+      ),
+      confirmLabel: t('commons.onlyRemove'),
+      cancelLabel: t('commons.close'),
+      onConfirm: () => {
+        propsOnDelete(row);
+        utils.dialog.close();
+      },
+      onClose: () => utils.dialog.close()
+    });
+  };
 
   const columns: Array<GridColDef<DebtPositionTypeOrgDTO>> = [
     {
@@ -43,35 +69,7 @@ const OperatorDetailDataGrid = ({ data }: OperatorDetailDataGridProps) => {
       align: 'right',
       headerAlign: 'right',
       renderCell: (params: GridRenderCellParams<DebtPositionTypeOrgDTO>) => (
-        <ActionMenu
-          rowId={params.row.debtPositionTypeId}
-          menuItems={[
-            {
-              icon: (
-                <RemoveCircleOutline
-                  color="error"
-                  aria-label="remove operator detail item"
-                  data-testid={`remove-detail-${params.row.debtPositionTypeId}`}
-                />
-              ),
-              label: t('commons.onlyRemove'),
-              // TODO: add remove logic
-              action: () => null
-            },
-            {
-              icon: (
-                <OpenInNew
-                  color="primary"
-                  aria-label="go to operator detail item"
-                  data-testid={`navigate-to-detail-${params.row.debtPositionTypeId}`}
-                />
-              ),
-              label: t('commons.goToDetail'),
-              // TODO: add go to detail
-              action: () => null
-            }
-          ]}
-        />
+        <GridActionMenu row={params.row} onDelete={onDelete} />
       )
     }
   ];

--- a/src/routes/OperatorsDetail/index.tsx
+++ b/src/routes/OperatorsDetail/index.tsx
@@ -19,12 +19,15 @@ import DetailContainer, {
 } from '../../components/DetailContainer/DetailContainer';
 import { useDebtPositionTypesByOrg } from '../../hooks/useDebtPositionTypesByOrg';
 import { useBreadcrumbs } from './hooks/useBreadcrumbs';
+import { DebtPositionTypeOrgDTO } from '../../../generated/data-contracts';
+import { removeDebtPositionTypeOrgFromOperator } from '../../api/debtPositionTypeOrgOperators';
 
 export const OperatorDetail = () => {
   const { t } = useTranslation();
   const theme = useTheme();
   const navigate = useNavigate();
   const initialFilters: FieldValues = utils.URI.decode(window.location.hash);
+  const deleteMutation = removeDebtPositionTypeOrgFromOperator();
 
   const { organizationId: paramOrganizationId, mappedExternalUserId } =
     useParams();
@@ -49,7 +52,7 @@ export const OperatorDetail = () => {
   useBreadcrumbs(query);
 
   const {
-    query: { isError, error, data, isSuccess },
+    query: { isError, error, data },
     applyFilters
   } = useSearch({ query, filters });
 
@@ -57,6 +60,11 @@ export const OperatorDetail = () => {
     console.error('Error loading operator details:', error);
     navigate(PageRoutes.RESPONSES_ERROR);
   }
+
+  const operatorName =
+    data?.operatorName || data?.operatorLastName
+      ? `${data?.operatorName || ''} ${data?.operatorLastName || ''}`
+      : data?.operatorFiscalCode || data?.operatorId || '-';
 
   const detailSections: Array<DetailSection> = [
     {
@@ -112,6 +120,26 @@ export const OperatorDetail = () => {
     }
   ];
 
+  const onDelete = ({
+    organizationId,
+    debtPositionTypeOrgId
+  }: DebtPositionTypeOrgDTO) => {
+    if (organizationId && mappedExternalUserId && debtPositionTypeOrgId) {
+      deleteMutation.mutateAsync({
+        organizationId,
+        mappedExternalUserId,
+        debtPositionTypeOrgId
+      });
+      applyFilters(filters);
+    } else {
+      utils.notify.emit(t('errors.generic'));
+    }
+  };
+
+  if (deleteMutation.isError) {
+    utils.notify.emit(t('errors.generic'));
+  }
+
   const handleFilterChange = (id: string, value: FilterFieldValue) => {
     setFilters((prevFilters) => ({
       ...prevFilters,
@@ -122,11 +150,7 @@ export const OperatorDetail = () => {
   return (
     <>
       <TitleComponent
-        title={
-          isSuccess
-            ? `${data?.operatorName || ''} ${data?.operatorLastName || ''}`
-            : '-'
-        }
+        title={operatorName}
         accessibleTitle={t('OperatorDetail.accessibleTitle', {
           operatorId: data?.operatorId,
           interpolation: { escapeValue: false }
@@ -177,7 +201,11 @@ export const OperatorDetail = () => {
           }}
           aria-label="results-table"
         >
-          <OperatorDetailDataGrid data={data?.pagedDebtPositionTypeOrg} />
+          <OperatorDetailDataGrid
+            data={data?.pagedDebtPositionTypeOrg}
+            operatorName={operatorName}
+            onDelete={onDelete}
+          />
         </Grid>
       </Grid>
     </>

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -1,4 +1,15 @@
 {
+  "OperatorDetail": {
+    "code": "Cod. Gestionale",
+    "debtPositionTypeDescription": "Tipo di dovuto",
+    "accessibleTitle": "Dettagli operatore",
+    "associatedDebtPositionTypes": "Tipi di dovuto associati",
+    "emptyData": "Non è ancora stato associato alcun tipo di dovuto. Associa un nuovo tipo dovuto",
+    "deleteDialog": {
+      "title": "Sei sicuro di voler rimuovere il Tipo di dovuto?",
+      "message": "Una volta rimosso l'utente <strong>{{operatorName}}</strong> non potrà gestire e operare su questo tipo di dovuto."
+    }
+  },
   "AssessmentRegistryCreate": {
     "accessibleTitle": "Creazione capitolo",
     "success": {
@@ -103,13 +114,6 @@
       "flowFile": "Qualcosa non ha funzionato: impossibile scaricare il file",
       "errorFlowFile": "Qualcosa non ha funzionato: impossibile scaricare il file"
     }
-  },
-  "OperatorDetail": {
-    "code": "Cod. Gestionale",
-    "debtPositionTypeDescription": "Tipo di dovuto",
-    "accessibleTitle": "Dettagli operatore",
-    "associatedDebtPositionTypes": "Tipi di dovuto associati",
-    "emptyData": "Non è ancora stato associato alcun tipo di dovuto. Associa un nuovo tipo dovuto"
   },
   "appPreview": {
     "title": "Anteprima in App IO",


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- adds OperatorDetail debtPositionTypeOrg delete
- adds OperatorDetail ActionMenu
- handles delete dialog logic
- fixes a tsc test error

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
With this PR the user can delete a debtType from the OperatorDetail page

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- visual testing
- unit tests

#### Screenshots (if appropriate):
<img width="904" height="450" alt="image" src="https://github.com/user-attachments/assets/dfefad6e-6bb1-454b-ad6c-9d8126b892a5" />
<img width="880" height="420" alt="image" src="https://github.com/user-attachments/assets/1266606f-9e4d-40a6-a543-8c78dba2f458" />

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
