### PR TITLE
feat: [P4ADEV-3762] Org detail: added api key buttons

### DIFF
--- a/src/components/Assessment/Assessment.tsx
+++ b/src/components/Assessment/Assessment.tsx
@@ -10,6 +10,7 @@ import { useState } from 'react';
 import { PageRoutes } from '../../routes';
 import { ErrorMessage } from '../ErrorMessage/ErrorMessage';
 import { useAppNavigate } from '../../hooks/useAppNavigation';
+import { shouldShowGeneralError } from '../../utils/filtersValidation';
 
 export const Assessment = () => {
   const { t } = useTranslation();
@@ -43,7 +44,7 @@ export const Assessment = () => {
         hashObject: filterValues
       });
     } else {
-      setError(true);
+      setError(shouldShowGeneralError(filterValues));
     }
   }
 

--- a/src/components/ChipTruncateTooltip/index.test.tsx
+++ b/src/components/ChipTruncateTooltip/index.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '../../__tests__/renderers';
+import { render, screen, fireEvent } from '../../__tests__/renderers';
 import ChipTruncateTooltip from '.';
 
 describe('ChipTruncateTooltip', () => {
@@ -9,5 +9,38 @@ describe('ChipTruncateTooltip', () => {
     render(<ChipTruncateTooltip label={labelText} color="primary" />);
 
     expect(screen.getByText(labelText)).toBeInTheDocument();
+  });
+
+  it('shows custom tooltip when tooltipLabel is provided', async () => {
+    const labelText = 'Status';
+    const tooltipText = 'Custom tooltip message';
+
+    render(
+      <ChipTruncateTooltip
+        label={labelText}
+        tooltipLabel={tooltipText}
+        color="primary"
+      />
+    );
+
+    const chip = screen.getByText(labelText);
+    expect(chip).toBeInTheDocument();
+
+    // Hover to show tooltip
+    fireEvent.mouseOver(chip);
+
+    // Wait for tooltip to appear
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(tooltipText);
+  });
+
+  it('falls back to label as tooltip when tooltipLabel is not provided', async () => {
+    const labelText = 'Test Label';
+
+    render(<ChipTruncateTooltip label={labelText} color="primary" />);
+
+    const chip = screen.getByText(labelText);
+    fireEvent.mouseOver(chip);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(labelText);
   });
 });

--- a/src/components/ChipTruncateTooltip/index.tsx
+++ b/src/components/ChipTruncateTooltip/index.tsx
@@ -2,13 +2,19 @@ import React from 'react';
 import { Tooltip, Chip } from '@mui/material';
 import { ChipProps } from '@mui/material/Chip';
 
-const ChipTruncateTooltip: React.FC<ChipProps> = ({
+type ChipTruncateTooltipProps = ChipProps & {
+  tooltipLabel?: string;
+};
+
+const ChipTruncateTooltip: React.FC<ChipTruncateTooltipProps> = ({
   label,
   color,
-  variant
+  variant,
+  tooltipLabel,
+  ...otherProps
 }) => {
   return (
-    <Tooltip title={label} arrow>
+    <Tooltip title={tooltipLabel || label} arrow>
       <Chip
         label={label}
         color={color}
@@ -23,6 +29,7 @@ const ChipTruncateTooltip: React.FC<ChipProps> = ({
             cursor: 'default'
           }
         }}
+        {...otherProps}
       />
     </Tooltip>
   );

--- a/src/components/DebtPositionsPage/DebtPositionsPage.tsx
+++ b/src/components/DebtPositionsPage/DebtPositionsPage.tsx
@@ -15,7 +15,10 @@ import { FilterFieldIds } from '../../models/SearchCardFields';
 import { DateValidationError } from '@mui/x-date-pickers';
 import { ErrorMessage } from '../ErrorMessage/ErrorMessage';
 import utils from '../../utils';
-import { noFilterSetted } from '../../utils/filtersValidation';
+import {
+  noFilterSetted,
+  shouldShowGeneralError
+} from '../../utils/filtersValidation';
 
 export const DebtPositionsPage = () => {
   const { t } = useTranslation();
@@ -32,7 +35,7 @@ export const DebtPositionsPage = () => {
 
   const navigateToResults = useCallback(() => {
     if (!filters?.length || noFilterSetted(filters[activeTabIndex])) {
-      setShowError(true);
+      setShowError(shouldShowGeneralError(filters[activeTabIndex]));
       return;
     }
 

--- a/src/components/FilterContainer/FilterContainer.tsx
+++ b/src/components/FilterContainer/FilterContainer.tsx
@@ -247,7 +247,7 @@ const FilterContainer = ({
           item
           xs={gridWidth ?? 12}
           key={key}
-          sx={{ display: 'flex', alignItems: 'center', width: '100%' }}
+          sx={{ display: 'flex', alignItems: 'start', width: '100%' }}
         >
           <RenderComponent item={item} values={values} onChange={onChange} />
         </Grid>

--- a/src/components/FormComponent/_ControlledDateRange.tsx
+++ b/src/components/FormComponent/_ControlledDateRange.tsx
@@ -7,11 +7,15 @@ export type _ControlledDateRangeProps<T extends FieldValues> =
     name: Path<T>;
     control: Control<T>;
     label?: string;
+    shouldValidate?: boolean;
+    validationErrorMessage?: string;
+    validatePartialRange?: boolean;
   };
 
 export function _ControlledDateRange<T extends FieldValues>({
   name,
   control,
+  validatePartialRange = true,
   ...props
 }: _ControlledDateRangeProps<T>) {
   return (
@@ -24,26 +28,26 @@ export function _ControlledDateRange<T extends FieldValues>({
         return (
           <_DateRange
             {...props}
+            validatePartialRange={validatePartialRange}
+            shouldValidate={!!fieldState.error}
+            validationErrorMessage={fieldState.error?.message}
             from={
               props?.from
                 ? {
+                    ...props.from,
                     value: value.from,
                     onChange: (date) => {
                       field.onChange({ ...value, from: date });
-                    },
-                    errorMessage: fieldState.error?.message,
-                    ...props?.from
+                    }
                   }
                 : undefined
             }
             to={
               props?.to
                 ? {
+                    ...props.to,
                     value: value.to,
-                    onChange: (date) => field.onChange({ ...value, to: date }),
-                    errorMessage: fieldState.error?.message,
-                    label: props?.to?.label,
-                    ...props?.to
+                    onChange: (date) => field.onChange({ ...value, to: date })
                   }
                 : undefined
             }

--- a/src/components/FormComponent/_DateRange.tsx
+++ b/src/components/FormComponent/_DateRange.tsx
@@ -2,7 +2,7 @@ import { Stack, Typography } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { DateValidationError } from '@mui/x-date-pickers/models';
 import { endOfDay, startOfDay } from 'date-fns';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 export type DateRange = {
@@ -21,6 +21,9 @@ export type _DateRangeProps = {
   onFromErrorChange?: (error: DateValidationError | null) => void;
   onToErrorChange?: (error: DateValidationError | null) => void;
   rangeLabel?: string;
+  shouldValidate?: boolean;
+  validationErrorMessage?: string;
+  validatePartialRange?: boolean;
 };
 
 export const _DateRange = ({
@@ -30,7 +33,10 @@ export const _DateRange = ({
   required,
   onFromErrorChange,
   onToErrorChange,
-  rangeLabel
+  rangeLabel,
+  shouldValidate = false,
+  validationErrorMessage,
+  validatePartialRange = true
 }: _DateRangeProps) => {
   const { t } = useTranslation();
   const [startDateError, setStartDateError] =
@@ -39,6 +45,24 @@ export const _DateRange = ({
     null
   );
   const [isToDialogOpen, setIsToDialogOpen] = useState<boolean>(false);
+  const [partialFromError, setPartialFromError] = useState<string>('');
+  const [partialToError, setPartialToError] = useState<string>('');
+
+  useEffect(() => {
+    if (!validatePartialRange) return;
+
+    const hasFrom = Boolean(from?.value);
+    const hasTo = Boolean(to?.value);
+
+    setPartialFromError('');
+    setPartialToError('');
+
+    if (hasFrom && !hasTo) {
+      setPartialToError(t('dates.validations.insertTo'));
+    } else if (!hasFrom && hasTo) {
+      setPartialFromError(t('dates.validations.insertFrom'));
+    }
+  }, [from?.value, to?.value, validatePartialRange]);
 
   const handleStartDateChange = (date: Date | null) => {
     from?.onChange?.(date);
@@ -69,6 +93,37 @@ export const _DateRange = ({
     }
   };
 
+  const isFromMissingOnSubmit =
+    shouldValidate && !!validationErrorMessage && !from?.value;
+  const isToMissingOnSubmit =
+    shouldValidate && !!validationErrorMessage && !to?.value;
+
+  const fromHasError =
+    Boolean(startDateError) ||
+    isFromMissingOnSubmit ||
+    Boolean(partialFromError);
+
+  const toHasError =
+    Boolean(endDateError) || isToMissingOnSubmit || Boolean(partialToError);
+
+  let fromHelperText = '';
+  if (startDateError) {
+    fromHelperText = from?.errorMessage ?? t('dates.validations.from');
+  } else if (partialFromError) {
+    fromHelperText = partialFromError;
+  } else if (isFromMissingOnSubmit) {
+    fromHelperText = validationErrorMessage || '';
+  }
+
+  let toHelperText = '';
+  if (endDateError) {
+    toHelperText = to?.errorMessage ?? t('dates.validations.to');
+  } else if (partialToError) {
+    toHelperText = partialToError;
+  } else if (isToMissingOnSubmit) {
+    toHelperText = validationErrorMessage || '';
+  }
+
   return (
     <Stack spacing={1} width="100%">
       {rangeLabel && (
@@ -76,6 +131,7 @@ export const _DateRange = ({
           {rangeLabel}
         </Typography>
       )}
+
       <Stack
         direction={{ xs: 'row' }}
         justifyContent="row"
@@ -89,7 +145,7 @@ export const _DateRange = ({
           maxDate={from?.todayValue || undefined}
           sx={{ width: '100%' }}
           label={from?.label || t('dates.from')}
-          value={from?.value && startOfDay(from?.value)}
+          value={from?.value ? startOfDay(from.value) : null}
           onChange={handleStartDateChange}
           onAccept={handleStartDateOnAccept}
           onError={handleStartDateError}
@@ -97,10 +153,8 @@ export const _DateRange = ({
             textField: {
               size: 'small',
               variant: 'outlined',
-              error: !!startDateError,
-              helperText: startDateError
-                ? (from?.errorMessage ?? t('dates.validations.from'))
-                : '',
+              error: fromHasError,
+              helperText: fromHelperText,
               required
             }
           }}
@@ -110,7 +164,7 @@ export const _DateRange = ({
           <DatePicker
             sx={{ width: '100%' }}
             label={t('dates.to')}
-            value={to?.value && endOfDay(to?.value)}
+            value={to?.value ? endOfDay(to.value) : null}
             onChange={to?.onChange}
             open={isToDialogOpen}
             onClose={() => setIsToDialogOpen(false)}
@@ -124,10 +178,8 @@ export const _DateRange = ({
               textField: {
                 size: 'small',
                 variant: 'outlined',
-                error: !!endDateError,
-                helperText: endDateError
-                  ? (to?.errorMessage ?? t('dates.validations.to'))
-                  : '',
+                error: toHasError,
+                helperText: toHelperText,
                 required
               },
               inputAdornment: {

--- a/src/components/FormComponent/__tests__/_AmountField.test.tsx
+++ b/src/components/FormComponent/__tests__/_AmountField.test.tsx
@@ -1,0 +1,493 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  render,
+  fireEvent,
+  screen,
+  waitFor
+} from '../../../__tests__/renderers';
+import { i18nTestSetup } from '../../../__tests__/i18nTestSetup';
+const {
+  mockFormatAmountForDisplay,
+  mockIsValidAmountInput,
+  mockSanitizeAmountInput
+} = vi.hoisted(() => {
+  return {
+    mockFormatAmountForDisplay: vi.fn((v: unknown) => {
+      if (v == null || v === '') return '';
+      if (typeof v === 'number') return String(v).replace('.', ',');
+      if (typeof v === 'string') return v;
+      return '';
+    }),
+    mockIsValidAmountInput: vi.fn((s: string) =>
+      // eslint-disable-next-line sonarjs/concise-regex
+      /^[0-9]*([,.][0-9]*)?$/.test(s)
+    ),
+    mockSanitizeAmountInput: vi.fn((s: string) => s.replace(/[^\d.,]/g, ''))
+  };
+});
+
+vi.mock('../../../utils/formatters', () => ({
+  formatAmountForDisplay: mockFormatAmountForDisplay,
+  isValidAmountInput: mockIsValidAmountInput,
+  sanitizeAmountInput: mockSanitizeAmountInput
+}));
+
+import { _AmountField, AmountFieldProps } from '../_AmountField';
+
+i18nTestSetup({});
+
+describe('_AmountField', () => {
+  const defaultProps: AmountFieldProps = { label: 'Amount' };
+
+  beforeEach(() => {
+    mockFormatAmountForDisplay.mockClear();
+    mockIsValidAmountInput.mockClear();
+    mockSanitizeAmountInput.mockClear();
+  });
+
+  describe('Rendering and Initial State', () => {
+    it('should render with euro icon and placeholder', () => {
+      render(<_AmountField {...defaultProps} />);
+
+      const input = screen.getByRole('textbox', { name: 'Amount' });
+      const euroIcon = screen.getByTestId('EuroRoundedIcon');
+
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveAttribute('placeholder', '0,00');
+      expect(euroIcon).toBeInTheDocument();
+    });
+
+    it('should render with correct input attributes for decimal input', () => {
+      render(<_AmountField {...defaultProps} />);
+
+      const input = screen.getByRole('textbox', { name: 'Amount' });
+
+      expect(input).toHaveAttribute('inputMode', 'decimal');
+      expect(input).toHaveAttribute('pattern', '[0-9]*[,.]?[0-9]*');
+    });
+
+    it('should display formatted initial value', () => {
+      render(<_AmountField {...defaultProps} value={1234.56} />);
+
+      const input = screen.getByRole('textbox', { name: 'Amount' });
+
+      expect(input).toHaveValue('1234,56');
+      expect(mockFormatAmountForDisplay).toHaveBeenCalledWith(1234.56);
+    });
+
+    it('should handle empty/null initial values', () => {
+      const { rerender } = render(
+        <_AmountField {...defaultProps} value={null} />
+      );
+
+      let input = screen.getByRole('textbox', { name: 'Amount' });
+      expect(input).toHaveValue('');
+
+      rerender(<_AmountField {...defaultProps} value={undefined} />);
+      input = screen.getByRole('textbox', { name: 'Amount' });
+      expect(input).toHaveValue('');
+    });
+  });
+
+  describe('User Input Handling', () => {
+    it('should accept valid decimal input with comma', async () => {
+      const onChangeMock = vi.fn();
+      render(<_AmountField {...defaultProps} onChange={onChangeMock} />);
+
+      const input = screen.getByRole('textbox', { name: 'Amount' });
+
+      fireEvent.change(input, { target: { value: '123,45' } });
+
+      await waitFor(() => {
+        expect(input).toHaveValue('123,45');
+        expect(onChangeMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            target: expect.objectContaining({
+              value: '123.45'
+            })
+          })
+        );
+      });
+    });
+
+    it('should accept valid decimal input with dot', async () => {
+      const onChangeMock = vi.fn();
+      render(<_AmountField {...defaultProps} onChange={onChangeMock} />);
+
+      const input = screen.getByRole('textbox', { name: 'Amount' });
+
+      fireEvent.change(input, { target: { value: '123.45' } });
+
+      await waitFor(() => {
+        expect(input).toHaveValue('123.45');
+        expect(onChangeMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            target: expect.objectContaining({
+              value: '123.45'
+            })
+          })
+        );
+      });
+    });
+
+    it('should handle whole numbers correctly', async () => {
+      const onChangeMock = vi.fn();
+      render(<_AmountField {...defaultProps} onChange={onChangeMock} />);
+
+      const input = screen.getByRole('textbox', { name: 'Amount' });
+
+      fireEvent.change(input, { target: { value: '1000' } });
+
+      await waitFor(() => {
+        expect(input).toHaveValue('1000');
+        expect(onChangeMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            target: expect.objectContaining({
+              value: '1000'
+            })
+          })
+        );
+      });
+    });
+
+    it('should clear field when empty string is entered', async () => {
+      const onChangeMock = vi.fn();
+      render(
+        <_AmountField
+          {...defaultProps}
+          value="123,45"
+          onChange={onChangeMock}
+        />
+      );
+
+      const input = screen.getByRole('textbox', { name: 'Amount' });
+
+      fireEvent.change(input, { target: { value: '' } });
+
+      await waitFor(() => {
+        expect(input).toHaveValue('');
+        expect(onChangeMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            target: expect.objectContaining({
+              value: ''
+            })
+          })
+        );
+      });
+    });
+
+    it('should handle onChange being undefined', async () => {
+      render(<_AmountField {...defaultProps} />);
+
+      const input = screen.getByRole('textbox', { name: 'Amount' });
+
+      expect(() => {
+        fireEvent.change(input, { target: { value: '123,45' } });
+      }).not.toThrow();
+
+      await waitFor(() => {
+        expect(input).toHaveValue('123,45');
+      });
+    });
+  });
+
+  describe('Input Validation and Sanitization', () => {
+    it('should reject invalid input and not update value', async () => {
+      const onChangeMock = vi.fn();
+
+      render(<_AmountField {...defaultProps} onChange={onChangeMock} />);
+
+      const input = screen.getByRole('textbox', {
+        name: 'Amount'
+      }) as HTMLInputElement;
+
+      mockIsValidAmountInput.mockReturnValueOnce(false);
+
+      fireEvent.change(input, { target: { value: '123,999' } });
+
+      await waitFor(() => {
+        expect(input).toHaveValue('');
+        expect(onChangeMock).not.toHaveBeenCalled();
+        expect(mockSanitizeAmountInput).toHaveBeenCalledWith('123,999');
+        expect(mockIsValidAmountInput).toHaveBeenCalledWith('123,999');
+      });
+    });
+
+    it('should sanitize input before validation', async () => {
+      const onChangeMock = vi.fn();
+      render(<_AmountField {...defaultProps} onChange={onChangeMock} />);
+
+      const input = screen.getByRole('textbox', { name: 'Amount' });
+
+      fireEvent.change(input, { target: { value: '12€3,45' } });
+
+      await waitFor(() => {
+        expect(mockSanitizeAmountInput).toHaveBeenCalledWith('12€3,45');
+      });
+    });
+
+    it('should handle multiple decimal separators by keeping only first', async () => {
+      const onChangeMock = vi.fn();
+
+      render(<_AmountField {...defaultProps} onChange={onChangeMock} />);
+
+      const input = screen.getByRole('textbox', { name: 'Amount' });
+
+      mockSanitizeAmountInput.mockReturnValueOnce('12,3456');
+
+      fireEvent.change(input, { target: { value: '12,34,56' } });
+
+      await waitFor(() => {
+        expect(mockSanitizeAmountInput).toHaveBeenCalledWith('12,34,56');
+        expect(input).toHaveValue('12,3456');
+      });
+    });
+
+    it('should remove non-numeric characters except comma and dot', async () => {
+      const onChangeMock = vi.fn();
+      render(<_AmountField {...defaultProps} onChange={onChangeMock} />);
+
+      const input = screen.getByRole('textbox', { name: 'Amount' });
+
+      fireEvent.change(input, { target: { value: '1a2b3,4c5d' } });
+
+      await waitFor(() => {
+        expect(input).toHaveValue('123,45');
+        expect(mockSanitizeAmountInput).toHaveBeenCalledWith('1a2b3,4c5d');
+      });
+    });
+  });
+
+  describe('Value Synchronization', () => {
+    it('should update display value when prop value changes', async () => {
+      const { rerender } = render(
+        <_AmountField {...defaultProps} value={100} />
+      );
+
+      const input = screen.getByRole('textbox', { name: 'Amount' });
+      expect(input).toHaveValue('100');
+      expect(mockFormatAmountForDisplay).toHaveBeenCalledWith(100);
+
+      rerender(<_AmountField {...defaultProps} value={200.5} />);
+
+      await waitFor(() => {
+        expect(input).toHaveValue('200,5');
+        expect(mockFormatAmountForDisplay).toHaveBeenCalledWith(200.5);
+      });
+    });
+
+    it('should handle zero value correctly', async () => {
+      render(<_AmountField {...defaultProps} value={0} />);
+
+      const input = screen.getByRole('textbox', { name: 'Amount' });
+      expect(input).toHaveValue('0');
+      expect(mockFormatAmountForDisplay).toHaveBeenCalledWith(0);
+    });
+
+    it('should call formatAmountForDisplay on every value change', async () => {
+      const { rerender } = render(
+        <_AmountField {...defaultProps} value="123" />
+      );
+
+      expect(mockFormatAmountForDisplay).toHaveBeenCalledWith('123');
+
+      rerender(<_AmountField {...defaultProps} value="456.78" />);
+
+      expect(mockFormatAmountForDisplay).toHaveBeenCalledWith('456.78');
+    });
+  });
+
+  describe('Internal Format Conversion', () => {
+    it('should convert comma to dot in onChange event value', async () => {
+      const onChangeMock = vi.fn();
+      render(<_AmountField {...defaultProps} onChange={onChangeMock} />);
+
+      const input = screen.getByRole('textbox', { name: 'Amount' });
+
+      fireEvent.change(input, { target: { value: '999,99' } });
+
+      await waitFor(() => {
+        expect(onChangeMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            target: expect.objectContaining({
+              value: '999.99'
+            })
+          })
+        );
+      });
+    });
+
+    it('should preserve dots in onChange event value', async () => {
+      const onChangeMock = vi.fn();
+      render(<_AmountField {...defaultProps} onChange={onChangeMock} />);
+
+      const input = screen.getByRole('textbox', { name: 'Amount' });
+
+      fireEvent.change(input, { target: { value: '888.88' } });
+
+      await waitFor(() => {
+        expect(onChangeMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            target: expect.objectContaining({
+              value: '888.88'
+            })
+          })
+        );
+      });
+    });
+  });
+
+  describe('Integration with _TextField', () => {
+    it('should pass through additional props to _TextField', () => {
+      render(
+        <_AmountField
+          {...defaultProps}
+          disabled
+          helperText="Enter amount"
+          error
+        />
+      );
+
+      const input = screen.getByRole('textbox', { name: 'Amount' });
+
+      expect(input).toBeDisabled();
+      expect(screen.getByText('Enter amount')).toBeInTheDocument();
+    });
+
+    it('should maintain focus behavior during input changes', async () => {
+      render(<_AmountField {...defaultProps} />);
+
+      const input = screen.getByRole('textbox', { name: 'Amount' });
+
+      input.focus();
+      expect(input).toHaveFocus();
+
+      fireEvent.change(input, { target: { value: '123,45' } });
+
+      await waitFor(() => {
+        expect(input).toHaveFocus();
+      });
+    });
+
+    it('should support all _TextField props through spreading', () => {
+      render(
+        <_AmountField
+          {...defaultProps}
+          size="small"
+          variant="outlined"
+          fullWidth
+          required
+          className="custom-class"
+        />
+      );
+
+      const input = screen.getByRole('textbox', { name: 'Amount' });
+
+      expect(input).toBeRequired();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle rapid successive inputs correctly', async () => {
+      const onChangeMock = vi.fn();
+      render(<_AmountField {...defaultProps} onChange={onChangeMock} />);
+
+      const input = screen.getByRole('textbox', { name: 'Amount' });
+
+      const rapidInputs = ['1', '12', '123', '123,', '123,4', '123,45'];
+
+      rapidInputs.forEach((value) => {
+        fireEvent.change(input, { target: { value } });
+      });
+
+      await waitFor(() => {
+        expect(input).toHaveValue('123,45');
+        expect(onChangeMock).toHaveBeenCalledTimes(rapidInputs.length);
+      });
+    });
+
+    it('should handle component with no initial value', () => {
+      render(<_AmountField {...defaultProps} />);
+
+      const input = screen.getByRole('textbox', { name: 'Amount' });
+
+      expect(input).toHaveValue('');
+      expect(input).toHaveAttribute('placeholder', '0,00');
+    });
+
+    it('should handle very large numbers within validation limits', async () => {
+      const onChangeMock = vi.fn();
+      render(<_AmountField {...defaultProps} onChange={onChangeMock} />);
+
+      const input = screen.getByRole('textbox', { name: 'Amount' });
+
+      fireEvent.change(input, { target: { value: '999999,99' } });
+
+      await waitFor(() => {
+        expect(input).toHaveValue('999999,99');
+        expect(onChangeMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            target: expect.objectContaining({
+              value: '999999.99'
+            })
+          })
+        );
+      });
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should be accessible via keyboard navigation', () => {
+      render(<_AmountField {...defaultProps} />);
+
+      const input = screen.getByRole('textbox', { name: 'Amount' });
+
+      input.focus();
+      expect(input).toHaveFocus();
+
+      expect(input).toHaveAccessibleName('Amount');
+    });
+
+    it('should have proper role and input type for screen readers', () => {
+      render(<_AmountField {...defaultProps} />);
+
+      const input = screen.getByRole('textbox', { name: 'Amount' });
+
+      expect(input).toHaveAttribute('inputMode', 'decimal');
+      expect(input).toHaveAttribute('pattern', '[0-9]*[,.]?[0-9]*');
+    });
+  });
+
+  describe('Mock Verification', () => {
+    it('should call all formatter utilities with correct parameters', async () => {
+      const onChangeMock = vi.fn();
+      render(
+        <_AmountField {...defaultProps} value={100} onChange={onChangeMock} />
+      );
+
+      expect(mockFormatAmountForDisplay).toHaveBeenCalledWith(100);
+
+      const input = screen.getByRole('textbox', { name: 'Amount' });
+      fireEvent.change(input, { target: { value: '12€3,45' } });
+
+      await waitFor(() => {
+        expect(mockSanitizeAmountInput).toHaveBeenCalledWith('12€3,45');
+        expect(mockIsValidAmountInput).toHaveBeenCalledWith('123,45');
+      });
+    });
+  });
+
+  describe('Debug Tests', () => {
+    it('should verify mock functions are working', () => {
+      expect(vi.isMockFunction(mockFormatAmountForDisplay)).toBe(true);
+      expect(vi.isMockFunction(mockIsValidAmountInput)).toBe(true);
+      expect(vi.isMockFunction(mockSanitizeAmountInput)).toBe(true);
+    });
+
+    it('should test formatAmountForDisplay directly', () => {
+      const result = mockFormatAmountForDisplay(123.45);
+      expect(result).toBe('123,45');
+      expect(mockFormatAmountForDisplay).toHaveBeenCalledWith(123.45);
+    });
+  });
+});

--- a/src/components/FormComponent/__tests__/_Button.test.tsx
+++ b/src/components/FormComponent/__tests__/_Button.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen, render, fireEvent } from '../../../__tests__/renderers';
+import { i18nTestSetup } from '../../../__tests__/i18nTestSetup';
+import { _Button } from '../_Button';
+
+i18nTestSetup({});
+
+describe('_Button', () => {
+  it('renders label when children are absent', () => {
+    render(<_Button label="Submit" />);
+
+    const btn = screen.getByRole('button', { name: 'Submit' });
+    expect(btn).toBeInTheDocument();
+  });
+
+  it('children take precedence over label', () => {
+    render(
+      <_Button label="Label fallback">
+        <span>Real Child</span>
+      </_Button>
+    );
+
+    expect(screen.queryByText('Label fallback')).toBeNull();
+    expect(
+      screen.getByRole('button', { name: 'Real Child' })
+    ).toBeInTheDocument();
+  });
+
+  it('calls onClick handler', () => {
+    const onClick = vi.fn();
+    render(<_Button label="Click me" onClick={onClick} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Click me' }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects disabled prop', () => {
+    render(<_Button label="Disabled" disabled />);
+
+    const btn = screen.getByRole('button', { name: 'Disabled' });
+    expect(btn).toBeDisabled();
+  });
+
+  it('has sane defaults: fullWidth, size="small", variant="contained"', () => {
+    render(<_Button label="Defaults" />);
+
+    const btn = screen.getByRole('button', { name: 'Defaults' });
+
+    expect(btn).toHaveClass('MuiButton-root');
+    expect(btn).toHaveClass('MuiButton-sizeSmall');
+    expect(btn).toHaveClass('MuiButton-contained');
+    expect(btn).toHaveClass('MuiButton-fullWidth');
+  });
+
+  it('allows overriding size/variant/fullWidth via props', () => {
+    render(
+      <_Button
+        label="Overrides"
+        size="medium"
+        variant="outlined"
+        fullWidth={false}
+      />
+    );
+
+    const btn = screen.getByRole('button', { name: 'Overrides' });
+    expect(btn).toHaveClass('MuiButton-sizeMedium');
+    expect(btn).toHaveClass('MuiButton-outlined');
+    expect(btn).not.toHaveClass('MuiButton-fullWidth');
+  });
+
+  it('passes arbitrary props through to MUI Button', () => {
+    render(
+      <_Button
+        label="Aria"
+        id="custom-id"
+        className="custom-class"
+        aria-label="explicit-aria"
+        data-testid="btn-testid"
+      />
+    );
+
+    const btn = screen.getByTestId('btn-testid');
+    expect(btn).toHaveAttribute('id', 'custom-id');
+    expect(btn).toHaveClass('custom-class');
+    expect(btn).toHaveAttribute('aria-label', 'explicit-aria');
+  });
+
+  it('is focusable and accessible via role=button', () => {
+    render(<_Button label="Focusable" />);
+
+    const btn = screen.getByRole('button', { name: 'Focusable' });
+    btn.focus();
+    expect(btn).toHaveFocus();
+  });
+});

--- a/src/components/FormComponent/__tests__/_ControlledCheckbox.test.tsx
+++ b/src/components/FormComponent/__tests__/_ControlledCheckbox.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor
+} from '../../../__tests__/renderers';
+import { i18nTestSetup } from '../../../__tests__/i18nTestSetup';
+import { useForm } from 'react-hook-form';
+import { _ControlledCheckbox } from '../_ControlledCheckbox';
+
+i18nTestSetup({});
+
+type FormValues = { accepted: boolean };
+
+describe('_ControlledCheckbox', () => {
+  it('renders with label and description', () => {
+    const Form = () => {
+      const { control } = useForm<FormValues>({
+        defaultValues: { accepted: false }
+      });
+      return (
+        <_ControlledCheckbox<FormValues>
+          name="accepted"
+          control={control}
+          label="Accept Terms"
+          description="Required to continue"
+        />
+      );
+    };
+
+    render(<Form />);
+
+    expect(screen.getByText('Accept Terms')).toBeInTheDocument();
+    expect(screen.getByText('Required to continue')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
+  });
+
+  it('respects defaultValues from react-hook-form', () => {
+    const Form = () => {
+      const { control } = useForm<FormValues>({
+        defaultValues: { accepted: true }
+      });
+      return (
+        <_ControlledCheckbox<FormValues>
+          name="accepted"
+          control={control}
+          label="Subscribed"
+        />
+      );
+    };
+
+    render(<Form />);
+    expect(screen.getByRole('checkbox')).toBeChecked();
+  });
+
+  it('toggles value on click', () => {
+    const Form = () => {
+      const { control } = useForm<FormValues>({
+        defaultValues: { accepted: false }
+      });
+      return (
+        <_ControlledCheckbox<FormValues>
+          name="accepted"
+          control={control}
+          label="Check me"
+        />
+      );
+    };
+
+    render(<Form />);
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).not.toBeChecked();
+
+    fireEvent.click(checkbox);
+    expect(checkbox).toBeChecked();
+
+    fireEvent.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it('submits correct value via react-hook-form', async () => {
+    const handleSubmit = vi.fn();
+
+    const Form = () => {
+      const { control, handleSubmit: rhfSubmit } = useForm<FormValues>({
+        defaultValues: { accepted: false }
+      });
+      return (
+        <form onSubmit={rhfSubmit(handleSubmit)}>
+          <_ControlledCheckbox<FormValues>
+            name="accepted"
+            control={control}
+            label="Submit me"
+          />
+          <button type="submit">submit</button>
+        </form>
+      );
+    };
+
+    render(<Form />);
+
+    const checkbox = screen.getByRole('checkbox');
+    fireEvent.click(checkbox);
+
+    const submitBtn = screen.getByRole('button', { name: 'submit' });
+    const form = submitBtn.closest('form')!;
+    fireEvent.submit(form);
+
+    await waitFor(() => expect(handleSubmit).toHaveBeenCalledTimes(1));
+    expect(handleSubmit).toHaveBeenCalledWith(
+      { accepted: true },
+      expect.anything()
+    );
+  });
+
+  it('respects disabled prop', () => {
+    const Form = () => {
+      const { control } = useForm<FormValues>({
+        defaultValues: { accepted: false }
+      });
+      return (
+        <_ControlledCheckbox<FormValues>
+          name="accepted"
+          control={control}
+          label="Disabled box"
+          description="extra"
+          disabled
+        />
+      );
+    };
+
+    render(<Form />);
+
+    const checkbox = screen.getByRole('checkbox', { name: /disabled box/i });
+    expect(checkbox).toBeDisabled();
+    expect(screen.getByText('extra')).toBeInTheDocument();
+  });
+
+  it('is accessible via role=checkbox and focusable', () => {
+    const Form = () => {
+      const { control } = useForm<FormValues>({
+        defaultValues: { accepted: false }
+      });
+      return (
+        <_ControlledCheckbox<FormValues>
+          name="accepted"
+          control={control}
+          label="Accessible"
+        />
+      );
+    };
+
+    render(<Form />);
+
+    const checkbox = screen.getByRole('checkbox', { name: /accessible/i });
+    checkbox.focus();
+    expect(checkbox).toHaveFocus();
+  });
+});

--- a/src/components/FormComponent/__tests__/_ControlledDateRange.test.tsx
+++ b/src/components/FormComponent/__tests__/_ControlledDateRange.test.tsx
@@ -1,0 +1,418 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '../../../__tests__/renderers';
+import { useForm } from 'react-hook-form';
+import { i18nTestSetup } from '../../../__tests__/i18nTestSetup';
+import { _ControlledDateRange } from '../_ControlledDateRange';
+
+const mockTranslations = {
+  'dates.from': 'Da',
+  'dates.to': 'A',
+  'dates.validations.from': 'Data di inizio non valida',
+  'dates.validations.to': 'Data di fine non valida',
+  'dates.validations.insertFrom': 'Inserire data di inizio',
+  'dates.validations.insertTo': 'Inserire data di fine'
+};
+
+type TestFormData = {
+  dateRange: {
+    from: Date | null;
+    to: Date | null;
+  };
+};
+
+const TestForm = ({
+  children,
+  defaultValues
+}: {
+  children: (props: any) => React.ReactNode;
+  defaultValues?: Partial<TestFormData>;
+}) => {
+  const methods = useForm<TestFormData>({
+    defaultValues: {
+      dateRange: { from: null, to: null },
+      ...defaultValues
+    }
+  });
+
+  return <form>{children(methods)}</form>;
+};
+
+describe('_ControlledDateRange', () => {
+  beforeEach(() => {
+    i18nTestSetup(mockTranslations);
+    vi.clearAllMocks();
+  });
+
+  const defaultProps = {
+    name: 'dateRange' as const,
+    from: {
+      label: 'Data inizio'
+    },
+    to: {
+      label: 'Data fine'
+    }
+  };
+
+  it('should render with default values from react-hook-form', () => {
+    render(
+      <TestForm>
+        {({ control }) => (
+          <_ControlledDateRange {...defaultProps} control={control} />
+        )}
+      </TestForm>
+    );
+
+    expect(screen.getByLabelText('Data inizio')).toBeInTheDocument();
+    const toField =
+      screen.queryByLabelText('Data fine') || screen.getByLabelText('A');
+    expect(toField).toBeInTheDocument();
+  });
+
+  it('should display initial values when provided', () => {
+    const initialFromDate = new Date('2024-01-01');
+    const initialToDate = new Date('2024-01-31');
+    const defaultValues = {
+      dateRange: {
+        from: initialFromDate,
+        to: initialToDate
+      }
+    };
+
+    render(
+      <TestForm defaultValues={defaultValues}>
+        {({ control }) => (
+          <_ControlledDateRange {...defaultProps} control={control} />
+        )}
+      </TestForm>
+    );
+
+    const fromInput = screen.getByLabelText('Data inizio');
+    const toInput =
+      screen.queryByLabelText('Data fine') || screen.getByLabelText('A');
+
+    expect(fromInput).toBeInTheDocument();
+    expect(toInput).toBeInTheDocument();
+
+    expect(fromInput).toHaveValue('01/01/2024');
+    expect(toInput).toHaveValue('31/01/2024');
+  });
+
+  it('should update form values when dates change', async () => {
+    let formMethods: any;
+
+    render(
+      <TestForm>
+        {(methods) => {
+          formMethods = methods;
+          return (
+            <_ControlledDateRange {...defaultProps} control={methods.control} />
+          );
+        }}
+      </TestForm>
+    );
+
+    formMethods.setValue('dateRange.from', new Date('2024-01-01'));
+
+    await waitFor(() => {
+      const formValues = formMethods.getValues();
+      expect(formValues.dateRange.from).toEqual(new Date('2024-01-01'));
+    });
+  });
+
+  it('should preserve existing to value when from changes', async () => {
+    const defaultValues = {
+      dateRange: {
+        from: null,
+        to: new Date('2024-01-31')
+      }
+    };
+
+    let formMethods: any;
+
+    render(
+      <TestForm defaultValues={defaultValues}>
+        {(methods) => {
+          formMethods = methods;
+          return (
+            <_ControlledDateRange {...defaultProps} control={methods.control} />
+          );
+        }}
+      </TestForm>
+    );
+
+    formMethods.setValue('dateRange.from', new Date('2024-01-01'));
+
+    await waitFor(() => {
+      const formValues = formMethods.getValues();
+      expect(formValues.dateRange.from).toEqual(new Date('2024-01-01'));
+      expect(formValues.dateRange.to).toEqual(new Date('2024-01-31'));
+    });
+  });
+
+  it('should preserve existing from value when to changes', async () => {
+    const defaultValues = {
+      dateRange: {
+        from: new Date('2024-01-01'),
+        to: null
+      }
+    };
+
+    let formMethods: any;
+
+    render(
+      <TestForm defaultValues={defaultValues}>
+        {(methods) => {
+          formMethods = methods;
+          return (
+            <_ControlledDateRange {...defaultProps} control={methods.control} />
+          );
+        }}
+      </TestForm>
+    );
+
+    formMethods.setValue('dateRange.to', new Date('2024-01-31'));
+
+    await waitFor(() => {
+      const formValues = formMethods.getValues();
+      expect(formValues.dateRange.from).toEqual(new Date('2024-01-01'));
+      expect(formValues.dateRange.to).toEqual(new Date('2024-01-31'));
+    });
+  });
+
+  it('should pass validatePartialRange prop correctly', () => {
+    render(
+      <TestForm>
+        {({ control }) => (
+          <_ControlledDateRange
+            {...defaultProps}
+            control={control}
+            validatePartialRange={false}
+          />
+        )}
+      </TestForm>
+    );
+
+    expect(screen.getByLabelText('Data inizio')).toBeInTheDocument();
+  });
+
+  it('should default validatePartialRange to true', () => {
+    render(
+      <TestForm>
+        {({ control }) => (
+          <_ControlledDateRange {...defaultProps} control={control} />
+        )}
+      </TestForm>
+    );
+
+    expect(screen.getByLabelText('Data inizio')).toBeInTheDocument();
+  });
+
+  it('should handle form validation errors', async () => {
+    let formMethods: any;
+
+    render(
+      <TestForm>
+        {(methods) => {
+          formMethods = methods;
+          return (
+            <_ControlledDateRange {...defaultProps} control={methods.control} />
+          );
+        }}
+      </TestForm>
+    );
+
+    formMethods.setError('dateRange', {
+      type: 'required',
+      message: 'Date range is required'
+    });
+
+    await waitFor(() => {
+      const errorMessages = screen.getAllByText('Date range is required');
+      expect(errorMessages.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it('should not show validation when field has no error', () => {
+    render(
+      <TestForm>
+        {({ control }) => (
+          <_ControlledDateRange {...defaultProps} control={control} />
+        )}
+      </TestForm>
+    );
+
+    expect(
+      screen.queryByText('Date range is required')
+    ).not.toBeInTheDocument();
+  });
+
+  it('should render range label when provided', () => {
+    render(
+      <TestForm>
+        {({ control }) => (
+          <_ControlledDateRange
+            {...defaultProps}
+            control={control}
+            rangeLabel="Custom Range Label"
+          />
+        )}
+      </TestForm>
+    );
+
+    expect(screen.getByText('Custom Range Label')).toBeInTheDocument();
+  });
+
+  it('should mark fields as required when required prop is true', () => {
+    render(
+      <TestForm>
+        {({ control }) => (
+          <_ControlledDateRange
+            {...defaultProps}
+            control={control}
+            required={true}
+          />
+        )}
+      </TestForm>
+    );
+
+    const fromInput = screen.getByLabelText(/Data inizio/);
+    const toInput =
+      // eslint-disable-next-line sonarjs/slow-regex
+      screen.queryByLabelText(/Data fine/) || screen.getByLabelText(/A.*\*/);
+
+    expect(fromInput).toHaveAttribute('required');
+    expect(toInput).toHaveAttribute('required');
+  });
+
+  it('should handle year mode correctly', () => {
+    render(
+      <TestForm>
+        {({ control }) => (
+          <_ControlledDateRange
+            {...defaultProps}
+            control={control}
+            isYear={true}
+          />
+        )}
+      </TestForm>
+    );
+
+    const fromInput = screen.getByLabelText('Data inizio');
+    expect(fromInput).toHaveAttribute('placeholder', 'YYYY');
+  });
+
+  it('should handle null field value gracefully', async () => {
+    let formMethods: any;
+
+    render(
+      <TestForm>
+        {(methods) => {
+          formMethods = methods;
+          return (
+            <_ControlledDateRange {...defaultProps} control={methods.control} />
+          );
+        }}
+      </TestForm>
+    );
+
+    formMethods.setValue('dateRange', null);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Data inizio')).toBeInTheDocument();
+      const toField =
+        screen.queryByLabelText('Data fine') || screen.getByLabelText('A');
+      expect(toField).toBeInTheDocument();
+    });
+  });
+
+  it('should work with only from prop provided', () => {
+    const propsWithOnlyFrom = {
+      name: 'dateRange' as const,
+      from: {
+        label: 'Data inizio'
+      }
+    };
+
+    render(
+      <TestForm>
+        {({ control }) => (
+          <_ControlledDateRange {...propsWithOnlyFrom} control={control} />
+        )}
+      </TestForm>
+    );
+
+    expect(screen.getByLabelText('Data inizio')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Data fine')).not.toBeInTheDocument();
+  });
+
+  it('should work with only to prop provided', () => {
+    const propsWithOnlyTo = {
+      name: 'dateRange' as const,
+      to: {
+        label: 'Data fine'
+      }
+    };
+
+    render(
+      <TestForm>
+        {({ control }) => (
+          <_ControlledDateRange {...propsWithOnlyTo} control={control} />
+        )}
+      </TestForm>
+    );
+
+    expect(screen.getByLabelText('Da')).toBeInTheDocument();
+    const toField =
+      screen.queryByLabelText('Data fine') || screen.getByLabelText('A');
+    expect(toField).toBeInTheDocument();
+  });
+
+  it('should handle partial validation correctly', async () => {
+    const defaultValues = {
+      dateRange: {
+        from: new Date('2024-01-01'),
+        to: null
+      }
+    };
+
+    render(
+      <TestForm defaultValues={defaultValues}>
+        {({ control }) => (
+          <_ControlledDateRange
+            {...defaultProps}
+            control={control}
+            validatePartialRange={true}
+          />
+        )}
+      </TestForm>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Inserire data di fine')).toBeInTheDocument();
+    });
+  });
+
+  it('should not show partial validation when disabled', async () => {
+    const defaultValues = {
+      dateRange: {
+        from: new Date('2024-01-01'),
+        to: null
+      }
+    };
+
+    render(
+      <TestForm defaultValues={defaultValues}>
+        {({ control }) => (
+          <_ControlledDateRange
+            {...defaultProps}
+            control={control}
+            validatePartialRange={false}
+          />
+        )}
+      </TestForm>
+    );
+
+    expect(screen.queryByText('Inserire data di fine')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/FormComponent/__tests__/_ControlledFileUploader.test.tsx
+++ b/src/components/FormComponent/__tests__/_ControlledFileUploader.test.tsx
@@ -1,0 +1,198 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '../../../__tests__/renderers';
+import { i18nTestSetup } from '../../../__tests__/i18nTestSetup';
+import { useForm } from 'react-hook-form';
+import { _ControlledFileUploader } from '../_ControlledFileUploader';
+
+i18nTestSetup({});
+
+type FormValues = { doc: File | null };
+
+vi.mock('../../FileUploader/FileUploader', () => {
+  const MockFileUploader = (props: any) => {
+    const {
+      description,
+      disabled,
+      file,
+      fileExtensionsAllowed,
+      setFile,
+      setUploading,
+      setProgress
+    } = props;
+
+    return (
+      <div
+        data-testid="mock-file-uploader"
+        aria-disabled={disabled ? 'true' : 'false'}
+      >
+        <div data-testid="desc">{description}</div>
+        <div data-testid="exts">{JSON.stringify(fileExtensionsAllowed)}</div>
+        <div data-testid="current-file">
+          {file ? (file as File).name : 'none'}
+        </div>
+        <button
+          type="button"
+          data-testid="select-file"
+          onClick={() =>
+            setFile(
+              new File(['content'], 'new-file.pdf', { type: 'application/pdf' })
+            )
+          }
+        >
+          setFile
+        </button>
+        <button
+          type="button"
+          data-testid="start-upload"
+          onClick={() => setUploading(true)}
+        >
+          startUpload
+        </button>
+        <button
+          type="button"
+          data-testid="set-progress"
+          onClick={() => setProgress(50)}
+        >
+          setProgress
+        </button>
+      </div>
+    );
+  };
+
+  return { default: MockFileUploader };
+});
+
+vi.mock('../ErrorMessage', () => ({
+  ErrorMessage: ({ messageKey }: { messageKey?: string }) => (
+    <span data-testid="error-msg">{messageKey ?? ''}</span>
+  )
+}));
+
+describe('_ControlledFileUploader', () => {
+  it('renders description, allowed extensions, and disabled state', () => {
+    const Form = () => {
+      const { control } = useForm<FormValues>({ defaultValues: { doc: null } });
+      return (
+        <_ControlledFileUploader<FormValues>
+          name="doc"
+          control={control}
+          description="Upload a PDF"
+          fileExtensionsAllowed={['pdf', 'png']}
+          disabled
+        />
+      );
+    };
+
+    render(<Form />);
+
+    expect(screen.getByTestId('mock-file-uploader')).toBeInTheDocument();
+    expect(screen.getByTestId('desc')).toHaveTextContent('Upload a PDF');
+    expect(screen.getByTestId('exts')).toHaveTextContent('["pdf","png"]');
+    expect(screen.getByTestId('mock-file-uploader')).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+  });
+
+  it('shows initial file value from RHF defaultValues', () => {
+    const initial = new File(['x'], 'initial.png', { type: 'image/png' });
+
+    const Form = () => {
+      const { control } = useForm<FormValues>({
+        defaultValues: { doc: initial }
+      });
+      return (
+        <_ControlledFileUploader<FormValues>
+          name="doc"
+          control={control}
+          description="desc"
+          fileExtensionsAllowed={['png']}
+        />
+      );
+    };
+
+    render(<Form />);
+
+    expect(screen.getByTestId('current-file')).toHaveTextContent('initial.png');
+  });
+
+  it('updates value when setFile is called', () => {
+    const Form = () => {
+      const { control } = useForm<FormValues>({ defaultValues: { doc: null } });
+      return (
+        <_ControlledFileUploader<FormValues>
+          name="doc"
+          control={control}
+          description="desc"
+          fileExtensionsAllowed={['pdf']}
+        />
+      );
+    };
+
+    render(<Form />);
+
+    expect(screen.getByTestId('current-file')).toHaveTextContent('none');
+    fireEvent.click(screen.getByTestId('select-file'));
+    expect(screen.getByTestId('current-file')).toHaveTextContent(
+      'new-file.pdf'
+    );
+  });
+
+  it('shows ErrorMessage when fieldState.error is set', () => {
+    const Form = () => {
+      const { control, setError } = useForm<FormValues>({
+        defaultValues: { doc: null }
+      });
+
+      return (
+        <div>
+          <_ControlledFileUploader<FormValues>
+            name="doc"
+            control={control}
+            description="desc"
+            fileExtensionsAllowed={['pdf']}
+          />
+          <button
+            type="button"
+            onClick={() =>
+              setError('doc', { type: 'manual', message: 'upload.required' })
+            }
+          >
+            trigger-error
+          </button>
+        </div>
+      );
+    };
+
+    render(<Form />);
+
+    expect(screen.getByTestId('error-msg')).toHaveTextContent('');
+    fireEvent.click(screen.getByText('trigger-error'));
+    expect(screen.getByTestId('error-msg')).toHaveTextContent(
+      'upload.required'
+    );
+  });
+
+  it('provides setUploading and setProgress without crashing', () => {
+    // eslint-disable-next-line sonarjs/no-identical-functions
+    const Form = () => {
+      const { control } = useForm<FormValues>({ defaultValues: { doc: null } });
+      return (
+        <_ControlledFileUploader<FormValues>
+          name="doc"
+          control={control}
+          description="desc"
+          fileExtensionsAllowed={['pdf']}
+        />
+      );
+    };
+
+    render(<Form />);
+
+    fireEvent.click(screen.getByTestId('start-upload'));
+    fireEvent.click(screen.getByTestId('set-progress'));
+
+    expect(screen.getByTestId('mock-file-uploader')).toBeInTheDocument();
+  });
+});

--- a/src/components/FormComponent/__tests__/_ControlledRadioGroup.test.tsx
+++ b/src/components/FormComponent/__tests__/_ControlledRadioGroup.test.tsx
@@ -1,0 +1,143 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '../../../__tests__/renderers';
+import { i18nTestSetup } from '../../../__tests__/i18nTestSetup';
+import { useForm } from 'react-hook-form';
+import { _ControlledRadioGroup } from '../_ControlledRadioGroup';
+
+vi.mock('../ErrorMessage', () => ({
+  ErrorMessage: ({ messageKey }: { messageKey?: string }) => (
+    <span data-testid="error-msg">{messageKey ?? ''}</span>
+  )
+}));
+
+i18nTestSetup({});
+
+type FormValues = {
+  choice: 'a' | 'b' | 'c';
+};
+
+const OPTIONS = [
+  { value: 'a', label: 'Option A' },
+  { value: 'b', label: 'Option B' },
+  { value: 'c', label: 'Option C' }
+] as const;
+
+describe('_ControlledRadioGroup', () => {
+  it('renders label and options, uses RHF default value when provided', () => {
+    const Form = () => {
+      const { control } = useForm<FormValues>({
+        defaultValues: { choice: 'b' }
+      });
+      return (
+        <_ControlledRadioGroup<FormValues>
+          name="choice"
+          control={control}
+          label="Pick one"
+          options={OPTIONS as any}
+        />
+      );
+    };
+
+    render(<Form />);
+
+    expect(screen.getByText('Pick one')).toBeInTheDocument();
+
+    const a = screen.getByLabelText('Option A') as HTMLInputElement;
+    const b = screen.getByLabelText('Option B') as HTMLInputElement;
+    const c = screen.getByLabelText('Option C') as HTMLInputElement;
+
+    expect(a.checked).toBe(false);
+    expect(b.checked).toBe(true);
+    expect(c.checked).toBe(false);
+  });
+
+  it('defaults to first option when no RHF default value is provided', () => {
+    const Form = () => {
+      const { control } = useForm<FormValues>();
+      return (
+        <_ControlledRadioGroup<FormValues>
+          name="choice"
+          control={control}
+          label="Pick one"
+          options={OPTIONS as any}
+        />
+      );
+    };
+
+    render(<Form />);
+
+    const a = screen.getByLabelText('Option A') as HTMLInputElement;
+    const b = screen.getByLabelText('Option B') as HTMLInputElement;
+    const c = screen.getByLabelText('Option C') as HTMLInputElement;
+
+    expect(a.checked).toBe(true);
+    expect(b.checked).toBe(false);
+    expect(c.checked).toBe(false);
+  });
+
+  it('updates selection when another option is clicked', () => {
+    // eslint-disable-next-line sonarjs/no-identical-functions
+    const Form = () => {
+      const { control } = useForm<FormValues>();
+      return (
+        <_ControlledRadioGroup<FormValues>
+          name="choice"
+          control={control}
+          label="Pick one"
+          options={OPTIONS as any}
+        />
+      );
+    };
+
+    render(<Form />);
+
+    const a = screen.getByLabelText('Option A') as HTMLInputElement;
+    const b = screen.getByLabelText('Option B') as HTMLInputElement;
+
+    expect(a.checked).toBe(true);
+    fireEvent.click(b);
+    expect(b.checked).toBe(true);
+    expect(a.checked).toBe(false);
+  });
+
+  it('disables the entire group and all radios when disabled is true', () => {
+    const Form = () => {
+      const { control } = useForm<FormValues>();
+      return (
+        <_ControlledRadioGroup<FormValues>
+          name="choice"
+          control={control}
+          label="Disabled group"
+          options={OPTIONS as any}
+          disabled
+        />
+      );
+    };
+
+    render(<Form />);
+
+    expect(screen.getByLabelText('Option A')).toBeDisabled();
+    expect(screen.getByLabelText('Option B')).toBeDisabled();
+    expect(screen.getByLabelText('Option C')).toBeDisabled();
+  });
+
+  it('marks the FormControl as required when required prop is set', () => {
+    const Form = () => {
+      const { control } = useForm<FormValues>();
+      return (
+        <_ControlledRadioGroup<FormValues>
+          name="choice"
+          control={control}
+          label="Required group"
+          options={OPTIONS as any}
+          required
+        />
+      );
+    };
+
+    render(<Form />);
+
+    expect(screen.getByText('Required group')).toBeInTheDocument();
+  });
+});

--- a/src/components/FormComponent/__tests__/_ControlledSelect.test.tsx
+++ b/src/components/FormComponent/__tests__/_ControlledSelect.test.tsx
@@ -1,0 +1,179 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '../../../__tests__/renderers';
+import userEvent from '@testing-library/user-event';
+import { useForm } from 'react-hook-form';
+import { _ControlledSelect } from '../_ControlledSelect';
+import type { SelectOptions } from '../_Select';
+import type { UseQueryResult } from '@tanstack/react-query';
+import utils from '../../../utils';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k })
+}));
+vi.mock('../../../utils', () => ({ default: { notify: { emit: vi.fn() } } }));
+
+type FormValues = { status: null | 'OPEN' | 'CLOSED' };
+
+const OPTIONS: SelectOptions = [
+  { label: 'All', value: null },
+  { label: 'Open', value: 'OPEN' },
+  { label: 'Closed', value: 'CLOSED' }
+];
+
+function FormShell({
+  children,
+  defaultValues = { status: null } as FormValues
+}: Readonly<{
+  children: (
+    ctx: ReturnType<typeof useForm<FormValues, any, FormValues>>
+  ) => React.ReactNode;
+  defaultValues?: FormValues;
+}>) {
+  const methods = useForm<FormValues, any, FormValues>({ defaultValues });
+  return <>{children(methods)}</>;
+}
+
+describe('_ControlledSelect', () => {
+  it('renders with provided options and label', () => {
+    render(
+      <FormShell>
+        {({ control }) => (
+          <_ControlledSelect<FormValues>
+            name="status"
+            control={control}
+            label="Status"
+            options={OPTIONS}
+          />
+        )}
+      </FormShell>
+    );
+    expect(screen.getByLabelText('Status')).toBeInTheDocument();
+  });
+
+  it('selects an option and reflects the value in the input', async () => {
+    render(
+      <FormShell>
+        {({ control }) => (
+          <_ControlledSelect<FormValues>
+            name="status"
+            control={control}
+            label="Status"
+            options={OPTIONS}
+          />
+        )}
+      </FormShell>
+    );
+
+    const input = screen.getByLabelText('Status') as HTMLInputElement;
+    const user = userEvent.setup();
+
+    await user.click(input);
+    const option = await screen.findByRole('option', { name: 'Open' });
+    await user.click(option);
+
+    await waitFor(() => expect(input.value).toBe('Open'));
+  });
+
+  it('is disabled when props.disabled is true', () => {
+    render(
+      <FormShell>
+        {({ control }) => (
+          <_ControlledSelect<FormValues>
+            name="status"
+            control={control}
+            label="Status"
+            options={OPTIONS}
+            disabled
+          />
+        )}
+      </FormShell>
+    );
+    expect(screen.getByLabelText('Status')).toBeDisabled();
+  });
+
+  it('is disabled while fetchFn is loading', () => {
+    const fetchFn = (): UseQueryResult<SelectOptions> =>
+      ({ data: undefined, isLoading: true, isError: false }) as any;
+
+    render(
+      <FormShell>
+        {({ control }) => (
+          <_ControlledSelect<FormValues>
+            name="status"
+            control={control}
+            label="Status"
+            fetchFn={fetchFn}
+          />
+        )}
+      </FormShell>
+    );
+    expect(screen.getByLabelText('Status')).toBeDisabled();
+  });
+
+  it('is disabled when fetchFn returns no options', () => {
+    const fetchFn = (): UseQueryResult<SelectOptions> =>
+      ({ data: [], isLoading: false, isError: false }) as any;
+
+    render(
+      <FormShell>
+        {({ control }) => (
+          <_ControlledSelect<FormValues>
+            name="status"
+            control={control}
+            label="Status"
+            fetchFn={fetchFn}
+          />
+        )}
+      </FormShell>
+    );
+    expect(screen.getByLabelText('Status')).toBeDisabled();
+  });
+
+  it('emits a notification when fetchFn errors', () => {
+    const fetchFn = (): UseQueryResult<SelectOptions> =>
+      ({ data: undefined, isLoading: false, isError: true }) as any;
+
+    render(
+      <FormShell>
+        {({ control }) => (
+          <_ControlledSelect<FormValues>
+            name="status"
+            control={control}
+            label="Status"
+            fetchFn={fetchFn}
+          />
+        )}
+      </FormShell>
+    );
+    expect(utils.notify.emit).toHaveBeenCalledWith(
+      'commons.genericError',
+      'error'
+    );
+  });
+
+  it('renders ErrorMessage when field has an error in fieldState', async () => {
+    render(
+      <FormShell>
+        {({ control, setError }) => {
+          setTimeout(() => {
+            setError('status', { type: 'manual', message: 'requiredField' });
+          }, 0);
+
+          return (
+            <_ControlledSelect<FormValues>
+              name="status"
+              control={control}
+              label="Status"
+              options={OPTIONS}
+              required
+            />
+          );
+        }}
+      </FormShell>
+    );
+
+    expect(await screen.findByText(/requiredField/)).toBeInTheDocument();
+  });
+});

--- a/src/components/FormComponent/__tests__/_DateRange.test.tsx
+++ b/src/components/FormComponent/__tests__/_DateRange.test.tsx
@@ -1,0 +1,272 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen } from '../../../__tests__/renderers';
+import { i18nTestSetup } from '../../../__tests__/i18nTestSetup';
+import { _DateRange, _DateRangeProps } from '../_DateRange';
+
+const mockTranslations = {
+  'dates.from': 'Da',
+  'dates.to': 'A',
+  'dates.validations.from': 'Data di inizio non valida',
+  'dates.validations.to': 'Data di fine non valida',
+  'dates.validations.insertFrom': 'Inserire data di inizio',
+  'dates.validations.insertTo': 'Inserire data di fine'
+};
+
+describe('_DateRange', () => {
+  beforeEach(() => {
+    i18nTestSetup(mockTranslations);
+  });
+
+  const defaultProps: _DateRangeProps = {
+    from: {
+      label: 'Data inizio',
+      onChange: vi.fn(),
+      value: null
+    },
+    to: {
+      label: 'Data fine',
+      onChange: vi.fn(),
+      value: null
+    }
+  };
+
+  it('should render both date pickers with correct labels', () => {
+    render(<_DateRange {...defaultProps} />);
+
+    expect(screen.getByLabelText('Data inizio')).toBeInTheDocument();
+    expect(screen.getByLabelText('A')).toBeInTheDocument();
+  });
+
+  it('should render only from date picker when to is not provided', () => {
+    const { from } = defaultProps;
+    render(<_DateRange from={from} />);
+
+    expect(screen.getByLabelText('Data inizio')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Data fine')).not.toBeInTheDocument();
+  });
+
+  it('should display range label when provided', () => {
+    render(
+      <_DateRange {...defaultProps} rangeLabel="Periodo di riferimento" />
+    );
+
+    expect(screen.getByText('Periodo di riferimento')).toBeInTheDocument();
+  });
+
+  it('should call onChange when from date is changed', async () => {
+    const mockOnChange = vi.fn();
+    const props = {
+      ...defaultProps,
+      from: { ...defaultProps.from!, onChange: mockOnChange }
+    };
+
+    render(<_DateRange {...props} />);
+
+    const fromInput = screen.getByLabelText('Data inizio');
+    fireEvent.change(fromInput, { target: { value: '01/01/2024' } });
+    expect(mockOnChange).toHaveBeenCalled();
+  });
+
+  it('should clear to date when from date is set to a later date', async () => {
+    const mockFromChange = vi.fn();
+    const mockToChange = vi.fn();
+
+    const props = {
+      from: {
+        label: 'Data inizio',
+        onChange: mockFromChange,
+        value: null
+      },
+      to: {
+        label: 'Data fine',
+        onChange: mockToChange,
+        value: new Date('2024-01-01')
+      }
+    };
+
+    render(<_DateRange {...props} />);
+    const fromPicker = screen.getByLabelText('Data inizio');
+    fireEvent.change(fromPicker, { target: { value: '01/02/2024' } });
+  });
+
+  describe('Partial range validation', () => {
+    it('should show error when only from date is set and validatePartialRange is true', () => {
+      const props = {
+        ...defaultProps,
+        from: { ...defaultProps.from!, value: new Date('2024-01-01') },
+        to: { ...defaultProps.to!, value: null },
+        validatePartialRange: true
+      };
+
+      render(<_DateRange {...props} />);
+
+      expect(screen.getByText('Inserire data di fine')).toBeInTheDocument();
+    });
+
+    it('should show error when only to date is set and validatePartialRange is true', () => {
+      const props = {
+        ...defaultProps,
+        from: { ...defaultProps.from!, value: null },
+        to: { ...defaultProps.to!, value: new Date('2024-01-01') },
+        validatePartialRange: true
+      };
+
+      render(<_DateRange {...props} />);
+
+      expect(screen.getByText('Inserire data di inizio')).toBeInTheDocument();
+    });
+
+    it('should not show partial errors when validatePartialRange is false', () => {
+      const props = {
+        ...defaultProps,
+        from: { ...defaultProps.from!, value: new Date('2024-01-01') },
+        to: { ...defaultProps.to!, value: null },
+        validatePartialRange: false
+      };
+
+      render(<_DateRange {...props} />);
+
+      expect(
+        screen.queryByText('Inserire data di fine')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should not show partial errors when both dates are set', () => {
+      const props = {
+        ...defaultProps,
+        from: { ...defaultProps.from!, value: new Date('2024-01-01') },
+        to: { ...defaultProps.to!, value: new Date('2024-01-31') },
+        validatePartialRange: true
+      };
+
+      render(<_DateRange {...props} />);
+
+      expect(
+        screen.queryByText('Inserire data di fine')
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('Inserire data di inizio')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Validation on submit', () => {
+    it('should show validation error when shouldValidate is true and dates are missing', () => {
+      const props = {
+        ...defaultProps,
+        shouldValidate: true,
+        validationErrorMessage: 'Campo obbligatorio'
+      };
+
+      render(<_DateRange {...props} />);
+
+      const errorMessages = screen.getAllByText('Campo obbligatorio');
+      expect(errorMessages).toHaveLength(2);
+    });
+
+    it('should show validation error only on missing from date', () => {
+      const props = {
+        ...defaultProps,
+        from: { ...defaultProps.from!, value: null },
+        to: { ...defaultProps.to!, value: new Date('2024-01-01') },
+        shouldValidate: true,
+        validationErrorMessage: 'Campo obbligatorio'
+      };
+
+      render(<_DateRange {...props} />);
+
+      const fromInput = screen.getByLabelText('Data inizio');
+      const toInput = screen.getByLabelText('A');
+
+      expect(fromInput).toHaveAttribute('aria-invalid', 'true');
+      expect(toInput).toHaveAttribute('aria-invalid', 'false');
+    });
+  });
+
+  describe('Year mode', () => {
+    it('should render year picker when isYear is true', () => {
+      const props = {
+        ...defaultProps,
+        isYear: true
+      };
+
+      render(<_DateRange {...props} />);
+      const fromInput = screen.getByLabelText('Data inizio');
+      expect(fromInput).toBeInTheDocument();
+    });
+  });
+
+  describe('Error callbacks', () => {
+    it('should call onFromErrorChange when from date has error', () => {
+      const mockOnFromErrorChange = vi.fn();
+      const props = {
+        ...defaultProps,
+        onFromErrorChange: mockOnFromErrorChange
+      };
+
+      render(<_DateRange {...props} />);
+    });
+
+    it('should call onToErrorChange when to date has error', () => {
+      const mockOnToErrorChange = vi.fn();
+      const props = {
+        ...defaultProps,
+        onToErrorChange: mockOnToErrorChange
+      };
+
+      render(<_DateRange {...props} />);
+    });
+  });
+
+  describe('Required field', () => {
+    it('should mark inputs as required when required prop is true', () => {
+      const props = {
+        ...defaultProps,
+        required: true
+      };
+
+      render(<_DateRange {...props} />);
+
+      const fromInput = screen.getByLabelText(/Data inizio./);
+      const toInput = screen.getByLabelText(/A/);
+
+      expect(fromInput).toBeInTheDocument();
+      expect(toInput).toBeInTheDocument();
+    });
+  });
+
+  describe('Custom error messages', () => {
+    it('should display custom error message for from date', () => {
+      const props = {
+        ...defaultProps,
+        from: {
+          ...defaultProps.from!,
+          errorMessage: 'Errore personalizzato inizio'
+        }
+      };
+
+      render(<_DateRange {...props} />);
+    });
+
+    it('should display custom error message for to date', () => {
+      const props = {
+        ...defaultProps,
+        to: {
+          ...defaultProps.to!,
+          errorMessage: 'Errore personalizzato fine'
+        }
+      };
+
+      render(<_DateRange {...props} />);
+    });
+  });
+
+  describe('Dialog behavior', () => {
+    it('should open to dialog after from date is accepted', async () => {
+      render(<_DateRange {...defaultProps} />);
+
+      const fromInput = screen.getByLabelText('Data inizio');
+      fireEvent.click(fromInput);
+    });
+  });
+});

--- a/src/components/FormComponent/__tests__/_Select.test.tsx
+++ b/src/components/FormComponent/__tests__/_Select.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, within } from '../../../__tests__/renderers';
+import userEvent from '@testing-library/user-event';
+import { _Select, SelectOptions } from '../_Select';
+
+const OPTIONS: SelectOptions = [
+  { label: 'All', value: null },
+  { label: 'Open', value: 'OPEN' },
+  { label: 'Closed', value: 'CLOSED' },
+  { label: 'Locked', value: 'LOCKED', disabled: true }
+];
+
+const setup = (props?: Partial<React.ComponentProps<typeof _Select>>) => {
+  const onChange = vi.fn();
+  render(
+    <_Select
+      id="status-select"
+      label="Status"
+      options={OPTIONS}
+      onChange={onChange}
+      {...props}
+    />
+  );
+  const input = screen.getByLabelText('Status');
+  return { input: input as HTMLInputElement, onChange };
+};
+
+describe('_Select', () => {
+  it('renders input with label and no initial selection', () => {
+    const { input } = setup();
+    expect(input).toBeInTheDocument();
+    expect(input.value).toBe('');
+  });
+
+  it('opens the menu and selects an option, calling onChange with the value', async () => {
+    const { input, onChange } = setup();
+    const user = userEvent.setup();
+
+    await user.click(input);
+    const option = await screen.findByRole('option', { name: 'Open' });
+    await user.click(option);
+
+    expect(onChange).toHaveBeenCalledWith('OPEN');
+    expect(input.value).toBe('Open');
+  });
+
+  it('respects the value prop by setting initial selection', () => {
+    const { input } = setup({ value: 'CLOSED' });
+    expect(input.value).toBe('Closed');
+  });
+
+  it('updates selection when value prop changes', async () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <_Select
+        id="status-select"
+        label="Status"
+        options={OPTIONS}
+        value={'OPEN'}
+        onChange={onChange}
+      />
+    );
+    const input = screen.getByLabelText('Status') as HTMLInputElement;
+    expect(input.value).toBe('Open');
+
+    rerender(
+      <_Select
+        id="status-select"
+        label="Status"
+        options={OPTIONS}
+        value={'CLOSED'}
+        onChange={onChange}
+      />
+    );
+    expect(input.value).toBe('Closed');
+  });
+
+  it('marks disabled options as not selectable', async () => {
+    const { input, onChange } = setup();
+    const user = userEvent.setup();
+
+    await user.click(input);
+
+    const disabledOption = await screen.findByRole('option', {
+      name: 'Locked'
+    });
+    expect(disabledOption).toHaveAttribute('aria-disabled', 'true');
+    await user.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}{Enter}');
+
+    expect(onChange).not.toHaveBeenCalledWith('LOCKED');
+    expect(input.value).toBe('All');
+  });
+
+  it('applies disabled prop to input', () => {
+    const { input } = setup({ disabled: true });
+    expect(input).toBeDisabled();
+  });
+
+  it('allows clearing the selection and calls onChange(null)', async () => {
+    const { onChange } = setup({ value: 'OPEN' });
+    const input = screen.getByLabelText('Status') as HTMLInputElement;
+    expect(input.value).toBe('Open');
+
+    const root = screen.getByTestId('status-select');
+    const clearBtn = within(root).getByTitle('Clear');
+    const user = userEvent.setup();
+    await user.click(clearBtn);
+
+    expect(onChange).toHaveBeenCalledWith(null);
+    expect(input.value).toBe('');
+  });
+
+  it('updates inputValue when typing in the field', async () => {
+    const { input } = setup();
+    const user = userEvent.setup();
+    await user.type(input, 'Op');
+    expect(input.value).toBe('Op');
+  });
+
+  it('uses id as data-testid on the Autocomplete', () => {
+    setup();
+    expect(screen.getByTestId('status-select')).toBeInTheDocument();
+  });
+});

--- a/src/components/FormComponent/__tests__/_TextField.test.tsx
+++ b/src/components/FormComponent/__tests__/_TextField.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '../../../__tests__/renderers';
+import userEvent from '@testing-library/user-event';
+import { _TextField } from '../_TextField';
+import { createRef } from 'react';
+
+describe('_TextField', () => {
+  it('renders with id as data-testid and label', () => {
+    render(<_TextField id="search" label="Search" />);
+    const root = screen.getByTestId('search');
+    expect(root).toBeInTheDocument();
+    expect(screen.getByLabelText('Search')).toBeInTheDocument();
+  });
+
+  it('shows default endAdornment (SearchRoundedIcon) when not disabled', () => {
+    render(<_TextField id="search" label="Search" />);
+    expect(screen.getByTestId('SearchRoundedIcon')).toBeInTheDocument();
+  });
+
+  it('hides endAdornment when noAdornment=true', () => {
+    render(<_TextField id="search" label="Search" noAdornment />);
+    expect(screen.queryByTestId('SearchRoundedIcon')).not.toBeInTheDocument();
+  });
+
+  it('renders a custom adornment when provided', () => {
+    render(
+      <_TextField
+        id="search"
+        label="Search"
+        adornment={<span data-testid="custom-adornment">%</span>}
+      />
+    );
+    expect(screen.getByTestId('custom-adornment')).toBeInTheDocument();
+    expect(screen.queryByTestId('SearchRoundedIcon')).not.toBeInTheDocument();
+  });
+
+  it('updates value and calls onChange when typing', async () => {
+    const onChange = vi.fn();
+    render(<_TextField id="search" label="Search" onChange={onChange} />);
+    const input = screen.getByLabelText('Search') as HTMLInputElement;
+
+    const user = userEvent.setup();
+    await user.type(input, 'in');
+
+    expect(input.value).toBe('in');
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('applies small size classes to the input', () => {
+    render(<_TextField id="search" label="Search" />);
+    const input = screen.getByLabelText('Search');
+    expect(input).toHaveClass('MuiInputBase-inputSizeSmall');
+  });
+
+  it('forwardRef points to the root element which contains the input', () => {
+    const ref = createRef<HTMLInputElement>();
+    render(<_TextField id="search" label="Search" forwardRef={ref} />);
+
+    expect(ref.current).not.toBeNull();
+
+    const root = ref.current as unknown as HTMLElement;
+    expect(root.tagName).toBe('DIV');
+
+    const input = root.querySelector('input');
+    expect(input).toBeTruthy();
+    expect(input!.id).toBe('search');
+
+    const byTestId = screen.getByTestId('search');
+    expect(root).toBe(byTestId);
+  });
+});

--- a/src/components/ShowSecretValue/index.test.tsx
+++ b/src/components/ShowSecretValue/index.test.tsx
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { screen, render, fireEvent } from '../../__tests__/renderers';
+import { copyToClipboard } from '../../utils/clipboard';
+import ShowSecretValue from '.';
+
+vi.mock('../../utils/clipboard', () => ({
+  copyToClipboard: vi.fn()
+}));
+
+describe('ShowSecretValue Component', () => {
+  const secret = 'secret-value';
+  const label = 'Api Key';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('show middott as default', () => {
+    render(<ShowSecretValue secretValue={secret} label={label} />);
+    expect(screen.getByText(/••••••/)).toBeInTheDocument();
+  });
+
+  it('show value when the visible-button-toggle is clicked', () => {
+    render(<ShowSecretValue secretValue={secret} label={label} />);
+    const toggleButton = screen.getByTestId('show-secret-value');
+    fireEvent.click(toggleButton);
+    expect(screen.getByText(secret)).toBeInTheDocument();
+  });
+
+  it('use copyToClipboard when copy-button is clicked', () => {
+    render(<ShowSecretValue secretValue={secret} label={label} />);
+    const copyButton = screen.getByTestId('specific-params-copy-button');
+    fireEvent.click(copyButton);
+    expect(copyToClipboard).toHaveBeenCalledWith(secret, expect.any(Function));
+  });
+});

--- a/src/components/ShowSecretValue/index.tsx
+++ b/src/components/ShowSecretValue/index.tsx
@@ -1,0 +1,115 @@
+import {
+  Box,
+  Button,
+  Grid,
+  Stack,
+  Tooltip,
+  Typography,
+  useTheme
+} from '@mui/material';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
+import { useState } from 'react';
+import { copyToClipboard } from '../../utils/clipboard';
+import { ContentCopy } from '@mui/icons-material';
+import { useTranslation } from 'react-i18next';
+
+type ShowSecretValueProps = {
+  label: string;
+  secretValue?: string;
+};
+
+const ShowSecretValue = ({
+  label,
+  secretValue,
+}: ShowSecretValueProps) => {
+  const theme = useTheme();
+  const { t } = useTranslation();
+  const [showSecret, setShowSecret] = useState<boolean>(false);
+  const [tooltipTriggered, setTooltipTriggered] = useState<boolean>(false);
+
+  const toggleValue = () => {
+    setShowSecret(!showSecret);
+  };
+
+  const handleCopy = () => {
+    copyToClipboard(secretValue || '', () => setTooltipTriggered(true));
+  };
+
+  return (
+    <>
+      <Grid container>
+        <Grid item xs={3}>
+            <Stack spacing={1} direction={'row'} alignItems={'center'}>
+        <Typography variant="body2" color={theme.palette.action.active}>
+          {label}
+        </Typography>
+        { secretValue && <Button
+          size="small"
+          onClick={toggleValue}
+          data-testid="show-secret-value"
+        >
+          {!showSecret ? (
+            <VisibilityIcon color="primary" />
+          ) : (
+            <VisibilityOffIcon color="primary" />
+          )}
+        </Button> }
+      </Stack>
+        </Grid>
+        <Grid item xs={9}>
+          {secretValue && <Stack
+            spacing={2}
+            direction={'row'}
+            display={'inline-flex'}
+            alignItems={'center'}
+            bgcolor={theme.palette.grey[50]}
+          >
+            {showSecret ? (
+              <Typography
+                fontFamily={'monospace'}
+                pl={2}
+                sx={{
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden'
+                }}
+              >
+                {secretValue}
+              </Typography>
+            ) : (
+              <Typography pl={2} overflow={'hidden'}>
+                ••••••••••••••••••••••••••
+              </Typography>
+            )}
+
+            <Box>
+              <Tooltip
+                title={t('commons.copied')}
+                open={tooltipTriggered}
+                onClose={() => setTooltipTriggered(false)}
+              >
+                <Button
+                  onClick={handleCopy}
+                  size="small"
+                  sx={{
+                    minWidth: 'auto',
+                    padding: 0.5,
+                    flexShrink: 0
+                  }}
+                  data-testid="specific-params-copy-button"
+                >
+                  <ContentCopy
+                    fontSize="small"
+                    sx={{ color: 'primary.main' }}
+                  />
+                </Button>
+              </Tooltip>
+            </Box>
+          </Stack> }
+        </Grid>
+      </Grid>
+    </>
+  );
+};
+export default ShowSecretValue;

--- a/src/components/ShowSecretValue/index.tsx
+++ b/src/components/ShowSecretValue/index.tsx
@@ -19,10 +19,7 @@ type ShowSecretValueProps = {
   secretValue?: string;
 };
 
-const ShowSecretValue = ({
-  label,
-  secretValue,
-}: ShowSecretValueProps) => {
+const ShowSecretValue = ({ label, secretValue }: ShowSecretValueProps) => {
   const theme = useTheme();
   const { t } = useTranslation();
   const [showSecret, setShowSecret] = useState<boolean>(false);
@@ -40,73 +37,77 @@ const ShowSecretValue = ({
     <>
       <Grid container>
         <Grid item xs={3}>
-            <Stack spacing={1} direction={'row'} alignItems={'center'}>
-        <Typography variant="body2" color={theme.palette.action.active}>
-          {label}
-        </Typography>
-        { secretValue && <Button
-          size="small"
-          onClick={toggleValue}
-          data-testid="show-secret-value"
-        >
-          {!showSecret ? (
-            <VisibilityIcon color="primary" />
-          ) : (
-            <VisibilityOffIcon color="primary" />
-          )}
-        </Button> }
-      </Stack>
+          <Stack spacing={1} direction={'row'} alignItems={'center'}>
+            <Typography variant="body2" color={theme.palette.action.active}>
+              {label}
+            </Typography>
+            {secretValue && (
+              <Button
+                size="small"
+                onClick={toggleValue}
+                data-testid="show-secret-value"
+              >
+                {!showSecret ? (
+                  <VisibilityIcon color="primary" />
+                ) : (
+                  <VisibilityOffIcon color="primary" />
+                )}
+              </Button>
+            )}
+          </Stack>
         </Grid>
         <Grid item xs={9}>
-          {secretValue && <Stack
-            spacing={2}
-            direction={'row'}
-            display={'inline-flex'}
-            alignItems={'center'}
-            bgcolor={theme.palette.grey[50]}
-          >
-            {showSecret ? (
-              <Typography
-                fontFamily={'monospace'}
-                pl={2}
-                sx={{
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                  overflow: 'hidden'
-                }}
-              >
-                {secretValue}
-              </Typography>
-            ) : (
-              <Typography pl={2} overflow={'hidden'}>
-                ••••••••••••••••••••••••••
-              </Typography>
-            )}
-
-            <Box>
-              <Tooltip
-                title={t('commons.copied')}
-                open={tooltipTriggered}
-                onClose={() => setTooltipTriggered(false)}
-              >
-                <Button
-                  onClick={handleCopy}
-                  size="small"
+          {secretValue && (
+            <Stack
+              spacing={2}
+              direction={'row'}
+              display={'inline-flex'}
+              alignItems={'center'}
+              bgcolor={theme.palette.grey[50]}
+            >
+              {showSecret ? (
+                <Typography
+                  fontFamily={'monospace'}
+                  pl={2}
                   sx={{
-                    minWidth: 'auto',
-                    padding: 0.5,
-                    flexShrink: 0
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden'
                   }}
-                  data-testid="specific-params-copy-button"
                 >
-                  <ContentCopy
-                    fontSize="small"
-                    sx={{ color: 'primary.main' }}
-                  />
-                </Button>
-              </Tooltip>
-            </Box>
-          </Stack> }
+                  {secretValue}
+                </Typography>
+              ) : (
+                <Typography pl={2} overflow={'hidden'}>
+                  ••••••••••••••••••••••••••
+                </Typography>
+              )}
+
+              <Box>
+                <Tooltip
+                  title={t('commons.copied')}
+                  open={tooltipTriggered}
+                  onClose={() => setTooltipTriggered(false)}
+                >
+                  <Button
+                    onClick={handleCopy}
+                    size="small"
+                    sx={{
+                      minWidth: 'auto',
+                      padding: 0.5,
+                      flexShrink: 0
+                    }}
+                    data-testid="specific-params-copy-button"
+                  >
+                    <ContentCopy
+                      fontSize="small"
+                      sx={{ color: 'primary.main' }}
+                    />
+                  </Button>
+                </Tooltip>
+              </Box>
+            </Stack>
+          )}
         </Grid>
       </Grid>
     </>

--- a/src/components/TelematicReceipt/TelematicReceipt.tsx
+++ b/src/components/TelematicReceipt/TelematicReceipt.tsx
@@ -7,7 +7,10 @@ import { generatePath, useNavigate } from 'react-router';
 import { PageRoutes } from '../../routes';
 import TitleComponent from '../TitleComponent/TitleComponent';
 import { useCallback, useState } from 'react';
-import { noFilterSetted } from '../../utils/filtersValidation';
+import {
+  noFilterSetted,
+  shouldShowGeneralError
+} from '../../utils/filtersValidation';
 import { ErrorMessage } from '../ErrorMessage/ErrorMessage';
 import utils from '../../utils';
 import useTelematicReceiptsFilters from '../../hooks/useTelematicReceiptsFilters';
@@ -22,7 +25,7 @@ export const TelematicReceipt = () => {
 
   const navigateToResults = useCallback(() => {
     if (noFilterSetted(filters)) {
-      setError(true);
+      setError(shouldShowGeneralError(filters));
     } else {
       setError(false);
       const params = utils.URI.encode(filters);

--- a/src/components/Treasury/Treasury.tsx
+++ b/src/components/Treasury/Treasury.tsx
@@ -10,6 +10,7 @@ import { useState } from 'react';
 import { useMultiFilters, FilterCategory } from '../../hooks/useMultiFilters';
 import { ErrorMessage } from '../ErrorMessage/ErrorMessage';
 import { useAppNavigate } from '../../hooks/useAppNavigation';
+import { shouldShowGeneralError } from '../../utils/filtersValidation';
 
 export const Treasury = () => {
   const { t } = useTranslation();
@@ -23,11 +24,12 @@ export const Treasury = () => {
 
   function submitSearch() {
     if (isValid) {
+      setError(false);
       navigate(PageRoutes.TREASURY_SEARCH_RESULTS, {
         hashObject: filterValues
       });
     } else {
-      setError(true);
+      setError(shouldShowGeneralError(filterValues));
     }
   }
 

--- a/src/components/TreasurySearchResults/index.tsx
+++ b/src/components/TreasurySearchResults/index.tsx
@@ -17,6 +17,7 @@ import { useSearch } from '../../hooks/useSearch';
 import { useStore } from '../../store/GlobalStore';
 import { getTreasuries } from '../../api/treasuries';
 import { ErrorMessage } from '../ErrorMessage/ErrorMessage';
+import { shouldShowGeneralError } from '../../utils/filtersValidation';
 
 export type LocationState = {
   category: string;
@@ -59,7 +60,7 @@ const TreasurySearchResults = () => {
       treasury.applyFilters(filterValues);
       setDrawerOpen(false);
     } else {
-      setError(true);
+      setError(shouldShowGeneralError(filterValues));
     }
   };
 

--- a/src/hooks/useMultiFilters.tsx
+++ b/src/hooks/useMultiFilters.tsx
@@ -181,6 +181,6 @@ export const useMultiFilters = (props?: {
     validationErrors,
     isValid:
       !noFilterIsSelected.peek() &&
-      !Object.values(validationErrors).some((value) => value)
+      !Object.values(validationErrors).some((value) => value !== null)
   };
 };

--- a/src/routes/AssessmentSearchResults/index.tsx
+++ b/src/routes/AssessmentSearchResults/index.tsx
@@ -19,6 +19,7 @@ import { ErrorMessage } from '../../components/ErrorMessage/ErrorMessage';
 import { useSearch } from '../../hooks/useSearch';
 import { useStore } from '../../store/GlobalStore';
 import { getAssessments } from '../../api/assessments';
+import { shouldShowGeneralError } from '../../utils/filtersValidation';
 
 export type LocationState = {
   category: string;
@@ -65,7 +66,7 @@ const AssessmentSearchResults = () => {
       assessments.applyFilters(filterValues);
       setDrawerOpen(false);
     } else {
-      setError(true);
+      setError(shouldShowGeneralError(filterValues));
     }
   };
 

--- a/src/routes/ClassificationExport/ClassificationExport.tsx
+++ b/src/routes/ClassificationExport/ClassificationExport.tsx
@@ -78,37 +78,12 @@ const ClassificationExportPage = () => {
     []
   );
 
-  const getDateRangeValidation = useCallback(
-    (rangeName: keyof typeof dateRanges) => {
-      const range = dateRanges[rangeName];
-      const hasOnlyOne =
-        (!!range.from && !range.to) || (!range.from && !!range.to);
-
-      if (hasOnlyOne) {
-        return {
-          hasError: true,
-          errorMessage: t(
-            'classificationsExport.errorMessages.singleInstanceBothDates'
-          )
-        };
-      }
-
-      return {
-        hasError: false,
-        errorMessage: ''
-      };
-    },
-    [dateRanges, t]
-  );
-
   const renderValidatedDateRange = useCallback(
     (
       rangeName: keyof typeof dateRanges,
       rangeLabel: string,
       required = false
     ) => {
-      const validation = getDateRangeValidation(rangeName);
-
       return (
         <Box sx={{ mb: 2 }}>
           <FormComponent.DateRange
@@ -116,40 +91,18 @@ const ClassificationExportPage = () => {
             required={required}
             from={{
               value: dateRanges[rangeName].from,
-              onChange: (date) => updateDateRange(rangeName, 'from', date),
-              errorMessage: validation.hasError
-                ? validation.errorMessage
-                : undefined
+              onChange: (date) => updateDateRange(rangeName, 'from', date)
             }}
             to={{
               value: dateRanges[rangeName].to,
-              onChange: (date) => updateDateRange(rangeName, 'to', date),
-              errorMessage: validation.hasError
-                ? validation.errorMessage
-                : undefined
+              onChange: (date) => updateDateRange(rangeName, 'to', date)
             }}
           />
-          {validation.hasError && (
-            <Typography
-              variant="caption"
-              color="error.dark"
-              sx={{ mt: 1, display: 'block' }}
-            >
-              {validation.errorMessage}
-            </Typography>
-          )}
         </Box>
       );
     },
-    [dateRanges, updateDateRange, getDateRangeValidation]
+    [dateRanges, updateDateRange]
   );
-
-  const areDatePairsValid = useCallback((): boolean => {
-    return Object.keys(dateRanges).every((key) => {
-      const validation = getDateRangeValidation(key as keyof typeof dateRanges);
-      return !validation.hasError;
-    });
-  }, [dateRanges, getDateRangeValidation]);
 
   const handleSubmit = useCallback(() => {
     const formData = formMethods.getValues();
@@ -166,11 +119,6 @@ const ClassificationExportPage = () => {
       return;
     }
 
-    if (!areDatePairsValid()) {
-      utils.notify.emit(t('classificationsExport.errorMessages.bothDates'));
-      return;
-    }
-
     const payload = buildApiPayload(processedFormData, dateRanges);
 
     createClassificationsExport.mutate(
@@ -184,7 +132,6 @@ const ClassificationExportPage = () => {
       }
     );
   }, [
-    areDatePairsValid,
     formMethods,
     validateForm,
     buildApiPayload,

--- a/src/routes/DebtPositions/DebtPositionsResults.tsx
+++ b/src/routes/DebtPositions/DebtPositionsResults.tsx
@@ -18,7 +18,10 @@ import debtPositions from '../../api/debtPositions';
 import { PageRoutes } from '../../routes';
 import { useSearch } from '../../hooks/useSearch';
 import { useStore } from '../../store/GlobalStore';
-import { noFilterSetted } from '../../utils/filtersValidation';
+import {
+  noFilterSetted,
+  shouldShowGeneralError
+} from '../../utils/filtersValidation';
 import { ErrorMessage } from '../../components/ErrorMessage/ErrorMessage';
 import utils from '../../utils';
 
@@ -70,7 +73,7 @@ export const DebtPositionResults = () => {
       debtPosition.applyFilters(filterValues);
       setError(false);
     } else {
-      setError(true);
+      setError(shouldShowGeneralError(filterValues));
     }
   };
 

--- a/src/routes/DebtPositions/components/DebtPositionIUVDataGrid.tsx
+++ b/src/routes/DebtPositions/components/DebtPositionIUVDataGrid.tsx
@@ -78,6 +78,7 @@ export const IUVDataGrid = ({ data }: DataGridProps) => {
       renderCell: (params: GridRenderCellParams<InstallmentView>) => (
         <ChipTruncateTooltip
           label={t(`commons.status.${params.value}`)}
+          tooltipLabel={t(`DebtPositions.installment.tooltip.${params.value}`)}
           color={stateColors[params.value as InstallmentStatus]}
           variant="outlined"
         />

--- a/src/routes/DebtPositions/components/DebtPositionsDataGrid.tsx
+++ b/src/routes/DebtPositions/components/DebtPositionsDataGrid.tsx
@@ -72,6 +72,7 @@ export const DebtPositionsDataGrid = ({ data }: DataGridProps) => {
       renderCell: (params: GridRenderCellParams<ResultDataRow>) => (
         <ChipTruncateTooltip
           label={t(`commons.status.${params.value}`)}
+          tooltipLabel={t(`DebtPositions.status.tooltip.${params.value}`)}
           color={stateColors[params.value as DebtPositionStatus]}
         />
       )

--- a/src/routes/Events/List/index.tsx
+++ b/src/routes/Events/List/index.tsx
@@ -23,7 +23,10 @@ import { useTranslation } from 'react-i18next';
 import { Stack } from '@mui/material';
 import { ErrorMessage } from '../../../components/ErrorMessage/ErrorMessage';
 import utils from '../../../utils';
-import { noFilterSetted } from '../../../utils/filtersValidation';
+import {
+  noFilterSetted,
+  shouldShowGeneralError
+} from '../../../utils/filtersValidation';
 import { useSearch } from '../../../hooks/useSearch';
 import {
   PagedPagoPaRegistry,
@@ -64,7 +67,7 @@ export const EventList = () => {
 
   const onSubmit = () => {
     if (noFilterSetted(filters)) {
-      setError(true);
+      setError(shouldShowGeneralError(filters));
     } else {
       setError(false);
       applyFilters(filters);

--- a/src/routes/Events/Search/index.tsx
+++ b/src/routes/Events/Search/index.tsx
@@ -7,7 +7,10 @@ import { PageRoutes } from '../..';
 import { RegistryType } from '../configs';
 import { useCallback, useState } from 'react';
 import { ErrorMessage } from '../../../components/ErrorMessage/ErrorMessage';
-import { noFilterSetted } from '../../../utils/filtersValidation';
+import {
+  noFilterSetted,
+  shouldShowGeneralError
+} from '../../../utils/filtersValidation';
 import utils from '../../../utils';
 import { FilterFieldValue } from '../../../models/Filters';
 
@@ -35,7 +38,7 @@ export const EventPage = () => {
 
   const navigateToResults = useCallback(() => {
     if (noFilterSetted(filters)) {
-      setError(true);
+      setError(shouldShowGeneralError(filters));
     } else {
       setError(false);
       const params = utils.URI.encode(filters);
@@ -47,7 +50,7 @@ export const EventPage = () => {
       );
       navigate(`${route}#${params}`);
     }
-  }, [filters, navigate]);
+  }, [filters, navigate, activeTabIndex]);
 
   return (
     <>

--- a/src/routes/Organizations/OrganizationDetail.tsx
+++ b/src/routes/Organizations/OrganizationDetail.tsx
@@ -21,7 +21,7 @@ export const OrganizationDetail = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
-  const {language} = useLanguage();
+  const { language } = useLanguage();
 
   const displayNames = new Intl.DisplayNames(language, { type: 'language' });
 
@@ -91,20 +91,20 @@ export const OrganizationDetail = () => {
                 display={'flex'}
                 justifyContent={'center'}
               >
-                {organizationDetailData?.orgLogo && 
-                <Box
-                  sx={{
-                    border: `1px solid ${theme.palette.grey[300]}`,
-                    borderRadius: 2,
-                    display: 'inline-block',
-                    fontSize: 0,
-                    padding: 2,
-                    width: '150px'
-                  }}
-                >
-                  <img src={organizationDetailData.orgLogo} width={'100%'} />
-                </Box>
-                }
+                {organizationDetailData?.orgLogo && (
+                  <Box
+                    sx={{
+                      border: `1px solid ${theme.palette.grey[300]}`,
+                      borderRadius: 2,
+                      display: 'inline-block',
+                      fontSize: 0,
+                      padding: 2,
+                      width: '150px'
+                    }}
+                  >
+                    <img src={organizationDetailData.orgLogo} width={'100%'} />
+                  </Box>
+                )}
               </Box>
             </Grid>
           </Grid>

--- a/src/routes/Organizations/OrganizationDetail.tsx
+++ b/src/routes/Organizations/OrganizationDetail.tsx
@@ -15,10 +15,15 @@ import {
   paymentInfo
 } from './components/OrganizationDetailSections';
 import { theme } from '@pagopa/mui-italia';
+import { useLanguage } from '../../hooks/useLanguage';
 
 export const OrganizationDetail = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+
+  const {language} = useLanguage();
+
+  const displayNames = new Intl.DisplayNames(language, { type: 'language' });
 
   const { organizationId: organizationIdByURL } = useParams<{
     organizationId: string;
@@ -86,6 +91,7 @@ export const OrganizationDetail = () => {
                 display={'flex'}
                 justifyContent={'center'}
               >
+                {organizationDetailData?.orgLogo && 
                 <Box
                   sx={{
                     border: `1px solid ${theme.palette.grey[300]}`,
@@ -96,8 +102,9 @@ export const OrganizationDetail = () => {
                     width: '150px'
                   }}
                 >
-                  <img src={organizationDetailData?.orgLogo} width={'100%'} />
+                  <img src={organizationDetailData.orgLogo} width={'100%'} />
                 </Box>
+                }
               </Box>
             </Grid>
           </Grid>
@@ -136,7 +143,7 @@ export const OrganizationDetail = () => {
                     fontSize: '14px',
                     label: t('commons.payments')
                   },
-                  data: paymentInfo(organizationDetailData, t)
+                  data: paymentInfo(organizationDetailData, t, displayNames)
                 }
               ]}
             />

--- a/src/routes/Organizations/components/OrganizationDetailSections.tsx
+++ b/src/routes/Organizations/components/OrganizationDetailSections.tsx
@@ -4,8 +4,8 @@ import { Box, Divider, Stack, Typography } from '@mui/material';
 import { TFunction } from 'i18next';
 import Appio from '../../../assets/appio.svg';
 import Send from '../../../assets/send.svg';
+import ShowSecretValue from '../../../components/ShowSecretValue';
 
-const displayNames = new Intl.DisplayNames(['it'], { type: 'language' });
 
 export const accountingInfo = (
   organizationDetailData: OrganizationDetailDTO,
@@ -30,7 +30,8 @@ export const accountingInfo = (
 ];
 export const paymentInfo = (
   organizationDetailData: OrganizationDetailDTO,
-  t: TFunction
+  t: TFunction, 
+  displayNames: Intl.DisplayNames
 ): Array<DetailData> => [
   {
     label: t('commons.segregationCode'),
@@ -53,8 +54,12 @@ export const paymentInfo = (
     value: organizationDetailData?.flagPaymentNotification
       ? t('commons.enabled')
       : '-'
+  },
+  {
+    childrenComponent: <ShowSecretValue label={t('organizations.printKeyAPI')} secretValue={organizationDetailData.generateNoticeApiKey} />
   }
 ];
+
 export const info = (
   organizationDetailData: OrganizationDetailDTO,
   t: TFunction
@@ -109,6 +114,9 @@ export const integrationBox = (
     value: organizationDetailData?.flagNotifyIo ? t('commons.enabled') : '-'
   },
   {
+    childrenComponent: <ShowSecretValue label={t('commons.apiKey')} secretValue={organizationDetailData.ioApiKey} />
+  },
+  {
     childrenComponent: <Divider></Divider>
   },
   {
@@ -126,5 +134,8 @@ export const integrationBox = (
   {
     label: t('organizations.pdndIntegration'),
     value: organizationDetailData?.pdndEnabled ? t('commons.enabled') : '-'
-  }
+  },
+  {
+    childrenComponent: <ShowSecretValue label={t('commons.apiKey')} secretValue={organizationDetailData.sendApiKey} />
+  },
 ];

--- a/src/routes/Organizations/components/OrganizationDetailSections.tsx
+++ b/src/routes/Organizations/components/OrganizationDetailSections.tsx
@@ -6,7 +6,6 @@ import Appio from '../../../assets/appio.svg';
 import Send from '../../../assets/send.svg';
 import ShowSecretValue from '../../../components/ShowSecretValue';
 
-
 export const accountingInfo = (
   organizationDetailData: OrganizationDetailDTO,
   t: TFunction
@@ -30,7 +29,7 @@ export const accountingInfo = (
 ];
 export const paymentInfo = (
   organizationDetailData: OrganizationDetailDTO,
-  t: TFunction, 
+  t: TFunction,
   displayNames: Intl.DisplayNames
 ): Array<DetailData> => [
   {
@@ -56,7 +55,12 @@ export const paymentInfo = (
       : '-'
   },
   {
-    childrenComponent: <ShowSecretValue label={t('organizations.printKeyAPI')} secretValue={organizationDetailData.generateNoticeApiKey} />
+    childrenComponent: (
+      <ShowSecretValue
+        label={t('organizations.printKeyAPI')}
+        secretValue={organizationDetailData.generateNoticeApiKey}
+      />
+    )
   }
 ];
 
@@ -114,7 +118,12 @@ export const integrationBox = (
     value: organizationDetailData?.flagNotifyIo ? t('commons.enabled') : '-'
   },
   {
-    childrenComponent: <ShowSecretValue label={t('commons.apiKey')} secretValue={organizationDetailData.ioApiKey} />
+    childrenComponent: (
+      <ShowSecretValue
+        label={t('commons.apiKey')}
+        secretValue={organizationDetailData.ioApiKey}
+      />
+    )
   },
   {
     childrenComponent: <Divider></Divider>
@@ -136,6 +145,11 @@ export const integrationBox = (
     value: organizationDetailData?.pdndEnabled ? t('commons.enabled') : '-'
   },
   {
-    childrenComponent: <ShowSecretValue label={t('commons.apiKey')} secretValue={organizationDetailData.sendApiKey} />
-  },
+    childrenComponent: (
+      <ShowSecretValue
+        label={t('commons.apiKey')}
+        secretValue={organizationDetailData.sendApiKey}
+      />
+    )
+  }
 ];

--- a/src/routes/Reporting/ReportingPage/index.tsx
+++ b/src/routes/Reporting/ReportingPage/index.tsx
@@ -12,7 +12,10 @@ import SearchCard from '../../../components/SearchCard/SearchCard';
 import TitleComponent from '../../../components/TitleComponent/TitleComponent';
 import { FilterFieldIds } from '../../../models/SearchCardFields';
 import { useAppNavigate } from '../../../hooks/useAppNavigation';
-import { noFilterSetted } from '../../../utils/filtersValidation';
+import {
+  noFilterSetted,
+  shouldShowGeneralError
+} from '../../../utils/filtersValidation';
 
 export const Reporting = () => {
   const { t } = useTranslation();
@@ -31,11 +34,11 @@ export const Reporting = () => {
   });
   const [error, setError] = useState<boolean>(false);
 
-  // Reporting.tsx
   const navigateToResults = (filters: FieldValues) => {
     if (noFilterSetted(filters)) {
-      setError(true);
+      setError(shouldShowGeneralError(filters));
     } else {
+      setError(false);
       navigate(PageRoutes.REPORTING_SEARCH_RESULTS, { hashObject: filters });
     }
   };

--- a/src/routes/Reporting/ReportingSearchResults/index.tsx
+++ b/src/routes/Reporting/ReportingSearchResults/index.tsx
@@ -4,7 +4,10 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { getPaymentsReporting } from '../../../api/getPaymentsReporting';
-import { noFilterSetted } from '../../../utils/filtersValidation';
+import {
+  noFilterSetted,
+  shouldShowGeneralError
+} from '../../../utils/filtersValidation';
 import { PagedPaymentsReportingView } from '../../../../generated/data-contracts';
 import { ReportingFilters } from '../components/ReportingFilters';
 import SearchResultsDataGrid from './ReportingDataGrid';
@@ -37,7 +40,7 @@ const ReportingSearchResults = () => {
 
   const applyFilters = (filters: FieldValues) => {
     if (noFilterSetted(filters)) {
-      setError(true);
+      setError(shouldShowGeneralError(filters));
     } else {
       setError(false);
       reporting.applyFilters(filters);

--- a/src/routes/TelematicReceiptSearchResults/index.tsx
+++ b/src/routes/TelematicReceiptSearchResults/index.tsx
@@ -5,7 +5,10 @@ import { BaseFilterValues } from '../../models/Filters';
 import useTelematicReceiptsFilters from '../../hooks/useTelematicReceiptsFilters';
 import { PagedReceiptView } from '../../../generated/data-contracts';
 import { useState } from 'react';
-import { noFilterSetted } from '../../utils/filtersValidation';
+import {
+  noFilterSetted,
+  shouldShowGeneralError
+} from '../../utils/filtersValidation';
 import { getReceipts } from '../../api/receipts';
 import { useStore } from '../../store/GlobalStore';
 import { useSearch } from '../../hooks/useSearch';
@@ -43,9 +46,10 @@ const TelematicReceiptSearchResults = () => {
       telematicReceipt.applyFilters(filterValues);
       setError(false);
     } else {
-      setError(true);
+      setError(shouldShowGeneralError(filterValues));
     }
   };
+
   const { filters } = useTelematicReceiptsFilters({
     onFilter: applyFilters
   });

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -594,6 +594,7 @@
     "amount": "Importo",
     "anonymousFiscalCode": "Codice Fiscale Anonimo",
     "appName": "Piattaforma Unitaria",
+    "apiKey": "API Key",
     "auditor": "Gestore della transazione (PSP)",
     "back": "Indietro",
     "behavior": "Comportamento",

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -1028,7 +1028,9 @@
     "to": "Al",
     "validations": {
       "from": "Data non valida",
-      "to": "Data non valida"
+      "to": "Data non valida",
+      "insertFrom": "Seleziona una data di inizio",
+      "insertTo": "Seleziona una data di fine"
     },
     "year": "Anno"
   },

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -66,6 +66,30 @@
       "titleIUV": "Avvisi (IUV)",
       "accessibleTitleIUV": "Risultato ricerca Avvisi",
       "accessibleTitleDP": "Risultato ricerca posizioni debitorie"
+    },
+    "status": {
+      "tooltip": {
+        "DRAFT": "Non ci sono ancora avvisi di pagamento per questa posizione debitoria.",
+        "TO_SYNC": "La posizione debitoria è stata creata ma non è ancora pagabile.",
+        "UNPAID": "La posizione debitoria è stata creata ed è pagabile.",
+        "PARTIALLY_PAID": "È stato effettuato solo una parte del pagamento.",
+        "PAID": "Tutti i pagamenti sono stati completati.",
+        "REPORTED": "Tutti i pagamenti sono stati rendicontati.",
+        "EXPIRED": "I pagamenti non sono stati effettuati entro la data di scadenza prevista.",
+        "CANCELLED": "La posizione debitoria è stata rimossa da un operatore."
+      }
+    },
+    "installment": {
+      "tooltip": {
+        "DRAFT": "L'avviso di pagamento non è stato ancora emesso.",
+        "TO_SYNC": "L'avviso di pagamento è stato registrato ma non è ancora pagabile.",
+        "UNPAID": "L'avviso di pagamento è stato emesso ed è pagabile.",
+        "PAID": "Il pagamento è stato completato.",
+        "REPORTED": "L'avviso di pagamento è stato rendicontato.",
+        "EXPIRED": "Il pagamento non è stato completato entro la data di scadenza stabilita.",
+        "INVALID": "L'avviso è stato invalidato perché il debitore ha avviato il pagamento con un'altra opzione.",
+        "CANCELLED": "L'avviso di pagamento è stato rimosso da un operatore."
+      }
     }
   },
   "FileUploaderFlowImport": {

--- a/src/utils/__tests__/loaders.test.tsx
+++ b/src/utils/__tests__/loaders.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   OperatorRole,
-  OrganizationDTO
+  OrganizationDTO,
+  OrganizationStatus
 } from '../../../generated/data-contracts';
 import { AxiosResponse } from 'axios';
 import { renderHook, waitFor } from '../../__tests__/renderers';
@@ -43,7 +44,8 @@ describe('loaders', () => {
           orgFiscalCode: '123456789',
           flagNotifyIo: false,
           flagNotifyOutcomePush: false,
-          flagPaymentNotification: false
+          flagPaymentNotification: false,
+          status: OrganizationStatus.ACTIVE
         }
       ];
 

--- a/src/utils/filtersValidation.test.tsx
+++ b/src/utils/filtersValidation.test.tsx
@@ -1,5 +1,11 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect } from 'vitest';
-import { noFilterSetted } from './filtersValidation';
+import {
+  canPerformSearch,
+  hasOnlyPartialDateRangeErrors,
+  noFilterSetted,
+  shouldShowGeneralError
+} from './filtersValidation';
 
 describe('noFilterSetted', () => {
   it('should return true when filters object is empty', () => {
@@ -100,5 +106,247 @@ describe('noFilterSetted', () => {
         date: { from: new Date(), to: null }
       })
     ).toBe(true);
+  });
+});
+
+describe('canPerformSearch', () => {
+  it('should return false when filters object is empty', () => {
+    expect(canPerformSearch({})).toBe(false);
+  });
+
+  it('should return false when all filters are empty or falsy', () => {
+    expect(
+      canPerformSearch({
+        name: '',
+        city: '   ',
+        active: false,
+        count: 0
+      })
+    ).toBe(false);
+  });
+
+  it('should return true when at least one filter has a valid value', () => {
+    expect(
+      canPerformSearch({
+        name: 'Mario',
+        city: ''
+      })
+    ).toBe(true);
+  });
+
+  it('should return true when boolean filter is true', () => {
+    expect(
+      canPerformSearch({
+        active: true,
+        count: 0
+      })
+    ).toBe(true);
+  });
+
+  it('should return true when number filter is non-zero', () => {
+    expect(
+      canPerformSearch({
+        active: false,
+        count: 5
+      })
+    ).toBe(true);
+  });
+
+  it('should return true when date range is complete', () => {
+    expect(
+      canPerformSearch({
+        name: '',
+        date: { from: new Date(), to: new Date() }
+      })
+    ).toBe(true);
+  });
+
+  it('should return false when date range is incomplete', () => {
+    expect(
+      canPerformSearch({
+        name: '',
+        date: { from: new Date(), to: null }
+      })
+    ).toBe(false);
+  });
+});
+
+describe('hasOnlyPartialDateRangeErrors', () => {
+  it('should return false when filters object is empty', () => {
+    expect(hasOnlyPartialDateRangeErrors({})).toBe(false);
+  });
+
+  it('should return false when filters is null or undefined', () => {
+    expect(hasOnlyPartialDateRangeErrors(null as any)).toBe(false);
+    expect(hasOnlyPartialDateRangeErrors(undefined as any)).toBe(false);
+  });
+
+  it('should return true when only partial date range exists (only from)', () => {
+    expect(
+      hasOnlyPartialDateRangeErrors({
+        name: '',
+        active: false,
+        count: 0,
+        date: { from: new Date(), to: null }
+      })
+    ).toBe(true);
+  });
+
+  it('should return true when only partial date range exists (only to)', () => {
+    expect(
+      hasOnlyPartialDateRangeErrors({
+        name: '',
+        active: false,
+        count: 0,
+        date: { from: null, to: new Date() }
+      })
+    ).toBe(true);
+  });
+
+  it('should return false when date range is complete', () => {
+    expect(
+      hasOnlyPartialDateRangeErrors({
+        name: '',
+        active: false,
+        count: 0,
+        date: { from: new Date(), to: new Date() }
+      })
+    ).toBe(false);
+  });
+
+  it('should return false when there are valid non-date filters', () => {
+    expect(
+      hasOnlyPartialDateRangeErrors({
+        name: 'Mario',
+        active: false,
+        count: 0,
+        date: { from: new Date(), to: null }
+      })
+    ).toBe(false);
+  });
+
+  it('should return false when there are valid boolean filters', () => {
+    expect(
+      hasOnlyPartialDateRangeErrors({
+        name: '',
+        active: true,
+        count: 0,
+        date: { from: new Date(), to: null }
+      })
+    ).toBe(false);
+  });
+
+  it('should return false when there are valid numeric filters', () => {
+    expect(
+      hasOnlyPartialDateRangeErrors({
+        name: '',
+        active: false,
+        count: 42,
+        date: { from: new Date(), to: null }
+      })
+    ).toBe(false);
+  });
+
+  it('should return false when both date fields are null', () => {
+    expect(
+      hasOnlyPartialDateRangeErrors({
+        name: '',
+        active: false,
+        count: 0,
+        date: { from: null, to: null }
+      })
+    ).toBe(false);
+  });
+
+  it('should ignore error fields in the check', () => {
+    expect(
+      hasOnlyPartialDateRangeErrors({
+        name: '',
+        active: false,
+        count: 0,
+        date: { from: new Date(), to: null },
+        date_fromError: 'Some error',
+        date_toError: 'Another error'
+      })
+    ).toBe(true);
+  });
+});
+
+describe('shouldShowGeneralError', () => {
+  it('should return true when no filters are set', () => {
+    expect(shouldShowGeneralError({})).toBe(true);
+  });
+
+  it('should return true when all filters are empty/falsy', () => {
+    expect(
+      shouldShowGeneralError({
+        name: '',
+        city: '   ',
+        active: false,
+        count: 0
+      })
+    ).toBe(true);
+  });
+
+  it('should return false when there are valid filters', () => {
+    expect(
+      shouldShowGeneralError({
+        name: 'Mario',
+        city: ''
+      })
+    ).toBe(false);
+  });
+
+  it('should return false when there are only partial date range errors', () => {
+    expect(
+      shouldShowGeneralError({
+        name: '',
+        active: false,
+        count: 0,
+        date: { from: new Date(), to: null }
+      })
+    ).toBe(false);
+  });
+
+  it('should return true when no filters are set and no partial date errors', () => {
+    expect(
+      shouldShowGeneralError({
+        name: '',
+        active: false,
+        count: 0,
+        date: { from: null, to: null }
+      })
+    ).toBe(true);
+  });
+
+  it('should return false when date range is complete', () => {
+    expect(
+      shouldShowGeneralError({
+        name: '',
+        active: false,
+        count: 0,
+        date: { from: new Date(), to: new Date() }
+      })
+    ).toBe(false);
+  });
+
+  it('should return true when filters are invalid but not partial date errors', () => {
+    expect(
+      shouldShowGeneralError({
+        name: '   ',
+        active: false,
+        count: 0
+      })
+    ).toBe(true);
+  });
+
+  it('should handle mixed scenarios with multiple date ranges', () => {
+    expect(
+      shouldShowGeneralError({
+        name: '',
+        startDate: { from: new Date(), to: null },
+        endDate: { from: null, to: new Date() }
+      })
+    ).toBe(false);
   });
 });

--- a/src/utils/filtersValidation.tsx
+++ b/src/utils/filtersValidation.tsx
@@ -81,4 +81,88 @@ export const noFilterSetted = (filters: BaseFilterValues): boolean => {
   });
 };
 
-export default { noFilterSetted };
+export const canPerformSearch = (filters: BaseFilterValues): boolean => {
+  return !noFilterSetted(filters);
+};
+
+/**
+ * Checks if there are only partial errors on date ranges (e.g., only 'from' or only 'to')
+ * without any other valid filters set.
+ */
+export const hasOnlyPartialDateRangeErrors = (
+  filters: BaseFilterValues
+): boolean => {
+  if (!filters || typeof filters !== 'object') return false;
+
+  const entries = Object.entries(filters);
+  if (entries.length === 0) return false;
+
+  const hasValidNonDateFilters = entries.some(([key, value]) => {
+    if (key.endsWith('_fromError') || key.endsWith('_toError')) {
+      return false;
+    }
+
+    if (isDateFilter(value)) {
+      return false;
+    }
+
+    if (typeof value === 'string') {
+      return !!value.trim();
+    }
+
+    if (typeof value === 'boolean') {
+      return value;
+    }
+
+    if (typeof value === 'number') {
+      return value !== 0;
+    }
+
+    if (value instanceof Date) {
+      return true;
+    }
+
+    return value != null;
+  });
+
+  if (hasValidNonDateFilters) {
+    return false;
+  }
+
+  const hasPartialDateRange = entries.some(([key, value]) => {
+    if (key.endsWith('_fromError') || key.endsWith('_toError')) {
+      return false;
+    }
+
+    if (isDateFilter(value)) {
+      const dateRange = value as { from?: Date | null; to?: Date | null };
+      const hasFrom = Boolean(dateRange.from);
+      const hasTo = Boolean(dateRange.to);
+
+      return (hasFrom && !hasTo) || (!hasFrom && hasTo);
+    }
+
+    return false;
+  });
+
+  return hasPartialDateRange;
+};
+
+/**
+ * Determines whether to display the general ErrorMessage.
+ * Does not show the error if there are only partial issues with date ranges,
+ * which are already visually handled by the individual components.
+ */
+export const shouldShowGeneralError = (filters: BaseFilterValues): boolean => {
+  const noFilters = noFilterSetted(filters);
+  const onlyPartialErrors = hasOnlyPartialDateRangeErrors(filters);
+
+  return noFilters && !onlyPartialErrors;
+};
+
+export default {
+  noFilterSetted,
+  canPerformSearch,
+  hasOnlyPartialDateRangeErrors,
+  shouldShowGeneralError
+};


### PR DESCRIPTION
This PR is the second part of [this](https://github.com/pagopa/p4pa-pu-fe/pull/414).
Adds copy/past buttons for API and set a more stylish way to show additional language.

#### List of Changes
- create a new component to show secret
- add unit test
- add stylish component to the page

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
