### PR TITLE
fix: [P4ADEV-3855] due types set label overlap

### DIFF
--- a/src/routes/DebtTypeOrgCreate/steps/Step3Accounting/index.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step3Accounting/index.tsx
@@ -31,6 +31,7 @@ export const Step3Accounting = () => {
           label={t('debtTypeOrgCreate.accounting.postalIban')}
           disabled={!!iban}
           required={false}
+          InputLabelProps={{ shrink: true }}
         />
         <FormComponent.ControlledTextField
           name="iban"
@@ -39,6 +40,7 @@ export const Step3Accounting = () => {
           label={t('debtTypeOrgCreate.accounting.pspIban')}
           disabled={!!postalIban}
           required={false}
+          InputLabelProps={{ shrink: true }}
         />
         <FormComponent.ControlledTextField
           name="postalAccountCode"
@@ -46,6 +48,7 @@ export const Step3Accounting = () => {
           control={control}
           label={t('debtTypeOrgCreate.accounting.postalAccount')}
           required={false}
+          InputLabelProps={{ shrink: true }}
         />
         <FormComponent.ControlledTextField
           name="holderPostalCc"
@@ -53,6 +56,7 @@ export const Step3Accounting = () => {
           control={control}
           label={t('debtTypeOrgCreate.accounting.postalAccountHolder')}
           required={false}
+          InputLabelProps={{ shrink: true }}
         />
       </SectionBox>
       <SectionBox
@@ -75,6 +79,7 @@ export const Step3Accounting = () => {
           control={control}
           label={t('debtTypeOrgCreate.accounting.entitySector')}
           required={false}
+          InputLabelProps={{ shrink: true }}
         />
       </SectionBox>
     </WizardStepWrapper>


### PR DESCRIPTION
This PR fixes the bug where the label was overlapping with the field data in the "types due" step during edit mode.


#### How Has This Been Tested?

-visual testing
-unit tests


#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
