### PR TITLE
feat: [P4ADEV-3619] Add receiptOrigins values

### DIFF
--- a/src/api/receipts/mappings.ts
+++ b/src/api/receipts/mappings.ts
@@ -25,7 +25,11 @@ export const buildQueryParams = ({
   pagination,
   sort
 }: TelematicReceiptsFilteredRequest): TelematicReceiptsFiltered => ({
-  receiptOrigins: [ReceiptOriginType.RECEIPT_PAGOPA],
+  receiptOrigins: [
+    ReceiptOriginType.RECEIPT_PAGOPA,
+    ReceiptOriginType.PAYMENTS_REPORTING,
+    ReceiptOriginType.RECEIPT_FILE
+  ],
   iuv: filters.iuv,
   paymentDateTimeFrom: utils.formatters.date.code(filters?.dateRange?.from),
   paymentDateTimeTo: utils.formatters.date.code(filters?.dateRange?.to),

--- a/src/api/receipts/receipts.test.ts
+++ b/src/api/receipts/receipts.test.ts
@@ -100,7 +100,11 @@ describe('getReceipts', () => {
     const mockError = new Error('API Error');
 
     vi.mocked(buildQueryParams).mockReturnValue({
-      receiptOrigins: [ReceiptOriginType.RECEIPT_PAGOPA],
+      receiptOrigins: [
+        ReceiptOriginType.RECEIPT_PAGOPA,
+        ReceiptOriginType.PAYMENTS_REPORTING,
+        ReceiptOriginType.RECEIPT_FILE
+      ],
       page: 1,
       size: 20
     });
@@ -127,7 +131,11 @@ describe('getReceipts', () => {
     };
 
     vi.mocked(buildQueryParams).mockReturnValue({
-      receiptOrigins: [ReceiptOriginType.RECEIPT_PAGOPA],
+      receiptOrigins: [
+        ReceiptOriginType.RECEIPT_PAGOPA,
+        ReceiptOriginType.PAYMENTS_REPORTING,
+        ReceiptOriginType.RECEIPT_FILE
+      ],
       debtPositionTypeOrgId: 789,
       sort: ['date:desc'],
       page: 2,


### PR DESCRIPTION
This PR adds two new values for receiptOrigins on the GET api:
- PAYMENTS_REPORTING
- RECEIPT_FILE

as requested on Jira

#### List of Changes
- Add two new (enum) values to receiptOrigins when on getReceipts
- mod unit test accordly

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
