### PR TITLE
fix: [P4ADEV-3900] orgdetail route also for EC admin

### DIFF
--- a/src/routes/organizations.tsx
+++ b/src/routes/organizations.tsx
@@ -1,5 +1,7 @@
-import { Outlet } from 'react-router';
-import { SuperAdminRouteGuard } from '../components/RouteGuard/RouteGuard';
+import {
+  AdminRouteGuard,
+  SuperAdminRouteGuard
+} from '../components/RouteGuard/RouteGuard';
 import Organizations from './Organizations/Organizations';
 import OrganizationDetail from './Organizations/OrganizationDetail';
 
@@ -7,15 +9,14 @@ export const organizationsRoutes = [
   {
     id: 'ORGANIZATIONS',
     path: 'organizations/',
-    element: (
-      <SuperAdminRouteGuard>
-        <Outlet />
-      </SuperAdminRouteGuard>
-    ),
     children: [
       {
         id: 'ORGANIZATIONS_INDEX',
-        element: <Organizations />,
+        element: (
+          <SuperAdminRouteGuard>
+            <Organizations />
+          </SuperAdminRouteGuard>
+        ),
         index: true,
         handle: {
           hideBreadcrumbs: true,
@@ -24,7 +25,11 @@ export const organizationsRoutes = [
       },
       {
         id: 'ORGANIZATIONS_DETAIL',
-        element: <OrganizationDetail />,
+        element: (
+          <AdminRouteGuard>
+            <OrganizationDetail />
+          </AdminRouteGuard>
+        ),
         path: `:organizationId?`,
         handle: {
           backButton: false,


### PR DESCRIPTION
This PR fixes a unwanted check on "super admin" triggered on the org detail view. This view must be visible also for the EC admin.

#### List of Changes
- change route permission check: organizations for superadmin, organizations/<id> for admin

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
