### PR TITLE
feat: [P4ADEV-3650]  qa debt position incorrect error message

### DIFF
--- a/src/hooks/useBeneficiaryManagement.tsx
+++ b/src/hooks/useBeneficiaryManagement.tsx
@@ -185,6 +185,10 @@ export function useBeneficiaryManagement<T extends FieldValues>(
 
     setExistingBeneficiaries({});
 
+    // Reset also wasSubmittedRef to avoid premature errors
+    // being shown when changing payment mode
+    wasSubmittedRef.current = false;
+
     if (onBeneficiariesChange) {
       onBeneficiariesChange([]);
     }

--- a/src/hooks/useInstallmentManagement.test.tsx
+++ b/src/hooks/useInstallmentManagement.test.tsx
@@ -50,7 +50,9 @@ vi.mock('../utils/formatters', async () => {
       const stringVal = String(value);
       // Format with two decimal places and replace dot with comma
       const numValue = parseFloat(stringVal);
-      return isNaN(numValue) ? stringVal : numValue.toFixed(2).replace('.', ',');
+      return isNaN(numValue)
+        ? stringVal
+        : numValue.toFixed(2).replace('.', ',');
     })
   };
 });
@@ -492,7 +494,9 @@ describe('useInstallmentManagement', () => {
     expect(installmentsData[1].isMultibeneficiary).toBe(true);
 
     // Verify that formatAmountForDisplay was called
-    expect(vi.mocked(formattersModule.formatAmountForDisplay)).toHaveBeenCalled();
+    expect(
+      vi.mocked(formattersModule.formatAmountForDisplay)
+    ).toHaveBeenCalled();
   });
 
   it('should store existing installments after submit', () => {

--- a/src/hooks/useInstallmentManagement.test.tsx
+++ b/src/hooks/useInstallmentManagement.test.tsx
@@ -44,6 +44,13 @@ vi.mock('../utils/formatters', async () => {
     moneyFormat: vi.fn((amount: number) => `€ ${(amount / 100).toFixed(2)}`),
     formatDate: vi.fn((dateString: string) => {
       return dateString ? '01/01/2023' : '';
+    }),
+    formatAmountForDisplay: vi.fn((value: unknown) => {
+      if (!value && value !== 0) return '';
+      const stringVal = String(value);
+      // Format with two decimal places and replace dot with comma
+      const numValue = parseFloat(stringVal);
+      return isNaN(numValue) ? stringVal : numValue.toFixed(2).replace('.', ',');
     })
   };
 });
@@ -476,7 +483,7 @@ describe('useInstallmentManagement', () => {
     const installmentsData = result.current.getInstallmentsData();
 
     expect(installmentsData.length).toBe(2);
-    expect(installmentsData[0].amount).toBe('100.00');
+    expect(installmentsData[0].amount).toBe('100,00');
     expect(installmentsData[0].dueDate).toBe('01/01/2023');
     expect(installmentsData[0].remittance).toBe('Rata 1');
     expect(installmentsData[0].isMultibeneficiary).toBe(false);
@@ -484,8 +491,8 @@ describe('useInstallmentManagement', () => {
     expect(installmentsData[1].remittance).toBe('Rata 2');
     expect(installmentsData[1].isMultibeneficiary).toBe(true);
 
-    // Verify that moneyFormat was called
-    expect(vi.mocked(formattersModule.moneyFormat)).toHaveBeenCalled();
+    // Verify that formatAmountForDisplay was called
+    expect(vi.mocked(formattersModule.formatAmountForDisplay)).toHaveBeenCalled();
   });
 
   it('should store existing installments after submit', () => {

--- a/src/hooks/useInstallmentManagement.tsx
+++ b/src/hooks/useInstallmentManagement.tsx
@@ -6,7 +6,11 @@ import { useReducer, useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFieldArray, Path, FieldValues, PathValue } from 'react-hook-form';
 import { createAmountValidator } from '../utils/fieldValidation';
-import { formatDate, moneyFormat } from '../utils/formatters';
+import {
+  formatDate,
+  parseAmountToNumber,
+  formatAmountForDisplay
+} from '../utils/formatters';
 import {
   Installment,
   InstallmentManagementProps,
@@ -174,11 +178,7 @@ export function useInstallmentManagement<T extends FieldValues>(
 
       // Get amount and format it if present
       const amount = installmentData?.amount;
-      const formattedAmount = amount
-        ? moneyFormat(parseFloat(amount) * 100)
-            .replace('€', '')
-            .trim()
-        : '';
+      const formattedAmount = amount ? formatAmountForDisplay(amount) : '';
 
       return {
         ...installmentData,
@@ -206,7 +206,7 @@ export function useInstallmentManagement<T extends FieldValues>(
           `${fieldNamePrefix}.${index}` as Path<T>
         );
         const amount = installmentData?.amount as string | undefined;
-        const amountValue = amount ? parseFloat(amount.replace(',', '.')) : 0;
+        const amountValue = amount ? parseAmountToNumber(amount) || 0 : 0;
         return total + amountValue;
       }, 0)
       .toFixed(2);

--- a/src/hooks/useInstallmentManagement.tsx
+++ b/src/hooks/useInstallmentManagement.tsx
@@ -22,6 +22,8 @@ type InstallmentState = {
   existingInstallments: Record<string, boolean>;
   /** Flag indicating if form was submitted */
   wasSubmitted: boolean;
+  /** Last submission count when installments were registered */
+  lastSubmissionCount: number;
   /** Flag indicating if initialization is in progress */
   isInitializing: boolean;
   /** Flag indicating if initialization is complete */
@@ -37,7 +39,11 @@ type InstallmentState = {
  */
 type InstallmentAction =
   | { type: 'MARK_SUBMITTED' }
-  | { type: 'SET_EXISTING_INSTALLMENTS'; installments: Record<string, boolean> }
+  | {
+      type: 'SET_EXISTING_INSTALLMENTS';
+      installments: Record<string, boolean>;
+      submissionCount: number;
+    }
   | { type: 'START_INITIALIZING' }
   | { type: 'FINISH_INITIALIZING' }
   | { type: 'MARK_INITIALIZED' }
@@ -61,7 +67,8 @@ function installmentReducer(
     case 'SET_EXISTING_INSTALLMENTS':
       return {
         ...state,
-        existingInstallments: action.installments
+        existingInstallments: action.installments,
+        lastSubmissionCount: action.submissionCount
       };
     case 'START_INITIALIZING':
       return {
@@ -112,7 +119,8 @@ export function useInstallmentManagement<T extends FieldValues>(
     getValues,
     trigger,
     flagMandatoryDueDate = true,
-    onInstallmentsChange
+    onInstallmentsChange,
+    submissionCount = 0
   } = props;
 
   const MIN_INSTALLMENTS = 2;
@@ -121,6 +129,7 @@ export function useInstallmentManagement<T extends FieldValues>(
   const [state, dispatch] = useReducer(installmentReducer, {
     existingInstallments: {},
     wasSubmitted: false,
+    lastSubmissionCount: 0,
     isInitializing: false,
     hasInitialized: false,
     lastTotalAmount: '',
@@ -270,9 +279,15 @@ export function useInstallmentManagement<T extends FieldValues>(
     ]
   );
 
-  // Register existing installments on first submit
+  // Register existing installments on every new submit
   useEffect(() => {
-    if (isSubmitted && !state.wasSubmitted) {
+    // Register installments if:
+    // 1. Form is submitted AND
+    // 2. (First submit OR submission count has increased since last registration)
+    if (
+      isSubmitted &&
+      (!state.wasSubmitted || submissionCount > state.lastSubmissionCount)
+    ) {
       // Store current state of installments
       const currentInstallments = fields.reduce<Record<string, boolean>>(
         (acc, field) => {
@@ -285,11 +300,18 @@ export function useInstallmentManagement<T extends FieldValues>(
       // Update state
       dispatch({
         type: 'SET_EXISTING_INSTALLMENTS',
-        installments: currentInstallments
+        installments: currentInstallments,
+        submissionCount
       });
       dispatch({ type: 'MARK_SUBMITTED' });
     }
-  }, [isSubmitted, fields, state.wasSubmitted]);
+  }, [
+    isSubmitted,
+    fields,
+    state.wasSubmitted,
+    submissionCount,
+    state.lastSubmissionCount
+  ]);
 
   // Update validation when amounts change
   useEffect(() => {

--- a/src/hooks/useStep3ApiOperations.test.tsx
+++ b/src/hooks/useStep3ApiOperations.test.tsx
@@ -1,0 +1,616 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { useStep3ApiOperations } from './useStep3ApiOperations';
+import { UseMutationResult } from '@tanstack/react-query';
+import {
+  DebtPositionDTO,
+  DebtPositionDetailDTO,
+  ManageDebtPositionDTO,
+  DebtPositionStatus,
+  DebtPositionOrigin,
+  PaymentOptionTypeEnum
+} from '../../generated/data-contracts';
+import {
+  Step1Data,
+  Step2Data,
+  Step3Data,
+  DebtPositionTypeEnum
+} from '../models/DebtPositionType';
+import { Step3FormValues } from '../models/Step3Schema';
+import { PageRoutes } from '../routes';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key
+  })
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router')>();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate
+  };
+});
+
+vi.mock('../utils', async () => {
+  const actual = await vi.importActual<typeof import('../utils')>('../utils');
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      notify: {
+        emit: vi.fn()
+      },
+      formatters: {
+        ...actual.default.formatters,
+        euroToCents: vi.fn(
+          (value: string) => parseFloat(value.replace(',', '.')) * 100
+        )
+      }
+    }
+  };
+});
+
+vi.mock('../models/Step3Schema', () => ({
+  convertFormDataToManageDebtPositionDTO: vi.fn()
+}));
+
+vi.mock('../utils/paymentUtility', () => ({
+  DEFAULT_VALUES: {
+    FLAG_IUV_VOLATILE: false,
+    MULTI_DEBTOR: false,
+    FLAG_PAGO_PA_PU_PAYMENT: true,
+    PAYMENT_OPTION_INDEX: 0
+  },
+  createInstallmentObject: vi.fn(() => ({
+    installmentIndex: 1,
+    amount: 100,
+    dueDate: '2023-12-31'
+  })),
+  createSingleInstallmentObject: vi.fn(() => ({
+    installmentIndex: 0,
+    amount: 100,
+    dueDate: '2023-12-31'
+  }))
+}));
+
+describe('useStep3ApiOperations', () => {
+  const mockStep1Data: Step1Data = {
+    description: { value: 'Test Description', readonly: false },
+    debtPositionType: {
+      value: '123',
+      flagMandatoryDueDate: false,
+      readonly: false
+    }
+  };
+
+  const mockStep2Data: Step2Data = {
+    subjectType: { value: 'individual', readonly: false },
+    taxCode: { value: 'RSSMRA85M01H501Z', readonly: false },
+    fullName: { value: 'Mario Rossi', readonly: false },
+    address: { value: 'Via Roma 1', readonly: false },
+    civicNumber: { value: '1', readonly: false },
+    zipCode: { value: '00100', readonly: false },
+    country: { value: 'Italia', readonly: false },
+    province: { value: 'RM', readonly: false },
+    city: { value: 'Roma', readonly: false }
+  };
+
+  const mockDebtPositionDetail: DebtPositionDetailDTO = {
+    debtor: {
+      taxCode: 'RSSMRA85M01H501Z',
+      fullName: 'Mario Rossi'
+    },
+    debtPositionTypeOrgDescription: 'Test Type',
+    debtPositionTypeOrgCode: 'TEST',
+    status: DebtPositionStatus.DRAFT,
+    paymentOptions: [
+      {
+        paymentOptionId: 1,
+        totalAmountCents: 10000,
+        paymentOptionType: PaymentOptionTypeEnum.SINGLE_INSTALLMENT,
+        installments: []
+      }
+    ]
+  } as unknown as DebtPositionDetailDTO;
+
+  const mockFormValues: Step3FormValues = {
+    paymentObject: { value: 'Test Payment Object', readonly: false },
+    paymentOption: { value: DebtPositionTypeEnum.SINGLE, readonly: false },
+    amount: { value: '100.00', readonly: false },
+    dueDate: { value: null, readonly: false },
+    isMultibeneficiary: { value: false, readonly: false },
+    installments: []
+  };
+
+  const mockFormattedData: Step3Data = {
+    paymentObject: { value: 'Test Payment Object', readonly: false },
+    paymentOption: { value: DebtPositionTypeEnum.SINGLE, readonly: false },
+    amount: { value: '100.00', readonly: false },
+    dueDate: { value: null, readonly: false },
+    flagMandatoryDueDate: false,
+    isMultibeneficiary: { value: false, readonly: false },
+    installments: []
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('handleEditModeFlow', () => {
+    it('should successfully handle edit mode flow with publish', async () => {
+      const mockMutateAsync = vi.fn().mockResolvedValue({
+        debtPositionId: 1,
+        status: DebtPositionStatus.UNPAID
+      });
+
+      const mockManageInstallmentsMutation = {
+        mutateAsync: mockMutateAsync
+      } as unknown as UseMutationResult<
+        DebtPositionDTO,
+        Error,
+        {
+          organizationId: number;
+          debtPositionId: number;
+          body: ManageDebtPositionDTO;
+          publish?: boolean;
+        }
+      >;
+
+      const { convertFormDataToManageDebtPositionDTO } = await import(
+        '../models/Step3Schema'
+      );
+      vi.mocked(convertFormDataToManageDebtPositionDTO).mockReturnValue({
+        paymentOptionId: 1,
+        installments: []
+      } as ManageDebtPositionDTO);
+
+      const { result } = renderHook(() => useStep3ApiOperations());
+
+      await act(async () => {
+        await result.current.handleEditModeFlow({
+          values: mockFormValues,
+          step1Data: mockStep1Data,
+          step2Data: mockStep2Data,
+          debtPositionId: '1',
+          debtPositionDetail: mockDebtPositionDetail,
+          shouldPublish: true,
+          isDraftInEdit: true,
+          organizationId: 123,
+          manageInstallmentsMutation: mockManageInstallmentsMutation
+        });
+      });
+
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        organizationId: 123,
+        debtPositionId: 1,
+        body: { paymentOptionId: 1, installments: [] },
+        publish: true
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        PageRoutes.DEBT_POSITION_CREATE_WIZARD_COMPLETED,
+        {
+          state: {
+            debtPositionId: 1,
+            status: DebtPositionStatus.UNPAID,
+            isEditing: true,
+            wasPublished: true
+          },
+          replace: true
+        }
+      );
+    });
+
+    it('should handle missing payment option error', async () => {
+      const utils = await import('../utils');
+
+      const invalidDebtPositionDetail: DebtPositionDetailDTO = {
+        debtor: {
+          taxCode: 'RSSMRA85M01H501Z',
+          fullName: 'Mario Rossi'
+        },
+        debtPositionTypeOrgDescription: 'Test Type',
+        debtPositionTypeOrgCode: 'TEST',
+        status: DebtPositionStatus.DRAFT,
+        paymentOptions: []
+      } as unknown as DebtPositionDetailDTO;
+
+      const mockManageInstallmentsMutation = {
+        mutateAsync: vi.fn()
+      } as unknown as UseMutationResult<
+        DebtPositionDTO,
+        Error,
+        {
+          organizationId: number;
+          debtPositionId: number;
+          body: ManageDebtPositionDTO;
+          publish?: boolean;
+        }
+      >;
+
+      const { result } = renderHook(() => useStep3ApiOperations());
+
+      await act(async () => {
+        await result.current.handleEditModeFlow({
+          values: mockFormValues,
+          step1Data: mockStep1Data,
+          step2Data: mockStep2Data,
+          debtPositionId: '1',
+          debtPositionDetail: invalidDebtPositionDetail,
+          shouldPublish: false,
+          isDraftInEdit: false,
+          organizationId: 123,
+          manageInstallmentsMutation: mockManageInstallmentsMutation
+        });
+      });
+
+      expect(utils.default.notify.emit).toHaveBeenCalledWith(
+        'debtPositionCreateWizard.step3.error.missingPaymentOption',
+        'error'
+      );
+    });
+
+    it('should handle invalid debt position ID', async () => {
+      const utils = await import('../utils');
+
+      const mockManageInstallmentsMutation = {
+        mutateAsync: vi.fn()
+      } as unknown as UseMutationResult<
+        DebtPositionDTO,
+        Error,
+        {
+          organizationId: number;
+          debtPositionId: number;
+          body: ManageDebtPositionDTO;
+          publish?: boolean;
+        }
+      >;
+
+      const { result } = renderHook(() => useStep3ApiOperations());
+
+      await act(async () => {
+        await result.current.handleEditModeFlow({
+          values: mockFormValues,
+          step1Data: mockStep1Data,
+          step2Data: mockStep2Data,
+          debtPositionId: 'invalid-id',
+          debtPositionDetail: mockDebtPositionDetail,
+          shouldPublish: false,
+          isDraftInEdit: false,
+          organizationId: 123,
+          manageInstallmentsMutation: mockManageInstallmentsMutation
+        });
+      });
+
+      expect(utils.default.notify.emit).toHaveBeenCalledWith(
+        'debtPositionCreateWizard.errorMissingId',
+        'error'
+      );
+    });
+
+    it('should navigate to error page on mutation failure', async () => {
+      const mockMutateAsync = vi.fn().mockRejectedValue(new Error('API Error'));
+
+      const mockManageInstallmentsMutation = {
+        mutateAsync: mockMutateAsync
+      } as unknown as UseMutationResult<
+        DebtPositionDTO,
+        Error,
+        {
+          organizationId: number;
+          debtPositionId: number;
+          body: ManageDebtPositionDTO;
+          publish?: boolean;
+        }
+      >;
+
+      const { convertFormDataToManageDebtPositionDTO } = await import(
+        '../models/Step3Schema'
+      );
+      vi.mocked(convertFormDataToManageDebtPositionDTO).mockReturnValue({
+        paymentOptionId: 1,
+        installments: []
+      } as ManageDebtPositionDTO);
+
+      const { result } = renderHook(() => useStep3ApiOperations());
+
+      await act(async () => {
+        await result.current.handleEditModeFlow({
+          values: mockFormValues,
+          step1Data: mockStep1Data,
+          step2Data: mockStep2Data,
+          debtPositionId: '1',
+          debtPositionDetail: mockDebtPositionDetail,
+          shouldPublish: false,
+          isDraftInEdit: false,
+          organizationId: 123,
+          manageInstallmentsMutation: mockManageInstallmentsMutation
+        });
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(PageRoutes.RESPONSES_ERROR);
+    });
+  });
+
+  describe('handleCreateModeFlow', () => {
+    it('should successfully create a single installment debt position', async () => {
+      const mockMutateAsync = vi.fn().mockResolvedValue({
+        response: {
+          debtPositionId: 1,
+          status: DebtPositionStatus.UNPAID
+        },
+        paymentObject: 'Test Payment Object'
+      });
+
+      const mockCreateDebtPositionMutation = {
+        mutateAsync: mockMutateAsync
+      } as unknown as UseMutationResult<
+        { response: DebtPositionDTO; paymentObject?: string },
+        Error,
+        { body: DebtPositionDTO; paymentObject?: string }
+      >;
+
+      const { result } = renderHook(() => useStep3ApiOperations());
+
+      await act(async () => {
+        await result.current.handleCreateModeFlow({
+          formattedData: mockFormattedData,
+          step1Data: mockStep1Data,
+          step2Data: mockStep2Data,
+          isInstallment: false,
+          isDraft: false,
+          organizationId: 123,
+          createDebtPositionMutation: mockCreateDebtPositionMutation
+        });
+      });
+
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        body: expect.objectContaining({
+          description: 'Test Description',
+          status: DebtPositionStatus.UNPAID,
+          organizationId: 123,
+          debtPositionTypeOrgId: 123,
+          debtPositionOrigin: DebtPositionOrigin.ORDINARY,
+          paymentOptions: expect.arrayContaining([
+            expect.objectContaining({
+              totalAmountCents: 10000,
+              paymentOptionType: PaymentOptionTypeEnum.SINGLE_INSTALLMENT
+            })
+          ])
+        }),
+        paymentObject: 'Test Description'
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        PageRoutes.DEBT_POSITION_CREATE_WIZARD_COMPLETED,
+        {
+          state: {
+            description: 'Test Payment Object',
+            status: DebtPositionStatus.UNPAID,
+            debtPositionId: 1,
+            isEditing: false,
+            wasPublished: true
+          },
+          replace: true
+        }
+      );
+    });
+
+    it('should successfully create an installment debt position as draft', async () => {
+      const mockInstallmentData: Step3Data = {
+        paymentObject: { value: 'Test Payment Object', readonly: false },
+        paymentOption: {
+          value: DebtPositionTypeEnum.INSTALLMENTS,
+          readonly: false
+        },
+        amount: { value: '300.00', readonly: false },
+        dueDate: { value: null, readonly: false },
+        flagMandatoryDueDate: false,
+        isMultibeneficiary: { value: false, readonly: false },
+        installments: [
+          {
+            amount: '100.00',
+            dueDate: '2023-12-31',
+            remittance: 'Rata 1',
+            isMultibeneficiary: false,
+            beneficiaries: []
+          },
+          {
+            amount: '200.00',
+            dueDate: '2024-01-31',
+            remittance: 'Rata 2',
+            isMultibeneficiary: false,
+            beneficiaries: []
+          }
+        ]
+      };
+
+      const mockMutateAsync = vi.fn().mockResolvedValue({
+        response: {
+          debtPositionId: 2,
+          status: DebtPositionStatus.DRAFT
+        },
+        paymentObject: 'Test Installment Payment Object'
+      });
+
+      const mockCreateDebtPositionMutation = {
+        mutateAsync: mockMutateAsync
+      } as unknown as UseMutationResult<
+        { response: DebtPositionDTO; paymentObject?: string },
+        Error,
+        { body: DebtPositionDTO; paymentObject?: string }
+      >;
+
+      const { result } = renderHook(() => useStep3ApiOperations());
+
+      await act(async () => {
+        await result.current.handleCreateModeFlow({
+          formattedData: mockInstallmentData,
+          step1Data: mockStep1Data,
+          step2Data: mockStep2Data,
+          isInstallment: true,
+          isDraft: true,
+          organizationId: 123,
+          createDebtPositionMutation: mockCreateDebtPositionMutation
+        });
+      });
+
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        body: expect.objectContaining({
+          status: DebtPositionStatus.DRAFT,
+          paymentOptions: expect.arrayContaining([
+            expect.objectContaining({
+              paymentOptionType: PaymentOptionTypeEnum.INSTALLMENTS,
+              description:
+                'debtPositionCreateWizard.step3.paymentOption.installments'
+            })
+          ])
+        }),
+        paymentObject: 'Test Description'
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        PageRoutes.DEBT_POSITION_CREATE_WIZARD_COMPLETED,
+        {
+          state: {
+            description: 'Test Installment Payment Object',
+            status: DebtPositionStatus.DRAFT,
+            debtPositionId: 2,
+            isEditing: false,
+            wasPublished: false
+          },
+          replace: true
+        }
+      );
+    });
+
+    it('should navigate to error page on creation failure', async () => {
+      const mockMutateAsync = vi
+        .fn()
+        .mockRejectedValue(new Error('Creation Error'));
+
+      const mockCreateDebtPositionMutation = {
+        mutateAsync: mockMutateAsync
+      } as unknown as UseMutationResult<
+        { response: DebtPositionDTO; paymentObject?: string },
+        Error,
+        { body: DebtPositionDTO; paymentObject?: string }
+      >;
+
+      const { result } = renderHook(() => useStep3ApiOperations());
+
+      await act(async () => {
+        await result.current.handleCreateModeFlow({
+          formattedData: mockFormattedData,
+          step1Data: mockStep1Data,
+          step2Data: mockStep2Data,
+          isInstallment: false,
+          isDraft: false,
+          organizationId: 123,
+          createDebtPositionMutation: mockCreateDebtPositionMutation
+        });
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(PageRoutes.RESPONSES_ERROR);
+    });
+  });
+
+  describe('lastActionWasPublish ref', () => {
+    it('should track if the last action was publish in edit mode', async () => {
+      const mockMutateAsync = vi.fn().mockResolvedValue({
+        debtPositionId: 1,
+        status: DebtPositionStatus.UNPAID
+      });
+
+      const mockManageInstallmentsMutation = {
+        mutateAsync: mockMutateAsync
+      } as unknown as UseMutationResult<
+        DebtPositionDTO,
+        Error,
+        {
+          organizationId: number;
+          debtPositionId: number;
+          body: ManageDebtPositionDTO;
+          publish?: boolean;
+        }
+      >;
+
+      const { convertFormDataToManageDebtPositionDTO } = await import(
+        '../models/Step3Schema'
+      );
+      vi.mocked(convertFormDataToManageDebtPositionDTO).mockReturnValue({
+        paymentOptionId: 1,
+        installments: []
+      } as ManageDebtPositionDTO);
+
+      const { result } = renderHook(() => useStep3ApiOperations());
+
+      expect(result.current.lastActionWasPublish.current).toBe(false);
+
+      await act(async () => {
+        await result.current.handleEditModeFlow({
+          values: mockFormValues,
+          step1Data: mockStep1Data,
+          step2Data: mockStep2Data,
+          debtPositionId: '1',
+          debtPositionDetail: mockDebtPositionDetail,
+          shouldPublish: true,
+          isDraftInEdit: true,
+          organizationId: 123,
+          manageInstallmentsMutation: mockManageInstallmentsMutation
+        });
+      });
+
+      expect(result.current.lastActionWasPublish.current).toBe(true);
+    });
+
+    it('should not set lastActionWasPublish when not publishing or not editing draft', async () => {
+      const mockMutateAsync = vi.fn().mockResolvedValue({
+        debtPositionId: 1,
+        status: DebtPositionStatus.UNPAID
+      });
+
+      const mockManageInstallmentsMutation = {
+        mutateAsync: mockMutateAsync
+      } as unknown as UseMutationResult<
+        DebtPositionDTO,
+        Error,
+        {
+          organizationId: number;
+          debtPositionId: number;
+          body: ManageDebtPositionDTO;
+          publish?: boolean;
+        }
+      >;
+
+      const { convertFormDataToManageDebtPositionDTO } = await import(
+        '../models/Step3Schema'
+      );
+      vi.mocked(convertFormDataToManageDebtPositionDTO).mockReturnValue({
+        paymentOptionId: 1,
+        installments: []
+      } as ManageDebtPositionDTO);
+
+      const { result } = renderHook(() => useStep3ApiOperations());
+
+      await act(async () => {
+        await result.current.handleEditModeFlow({
+          values: mockFormValues,
+          step1Data: mockStep1Data,
+          step2Data: mockStep2Data,
+          debtPositionId: '1',
+          debtPositionDetail: mockDebtPositionDetail,
+          shouldPublish: false,
+          isDraftInEdit: false,
+          organizationId: 123,
+          manageInstallmentsMutation: mockManageInstallmentsMutation
+        });
+      });
+
+      expect(result.current.lastActionWasPublish.current).toBe(false);
+    });
+  });
+});

--- a/src/hooks/useStep3ApiOperations.tsx
+++ b/src/hooks/useStep3ApiOperations.tsx
@@ -1,0 +1,235 @@
+import { useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router';
+import { UseMutationResult } from '@tanstack/react-query';
+import {
+  DebtPositionDTO,
+  DebtPositionDetailDTO,
+  ManageDebtPositionDTO,
+  DebtPositionStatus,
+  DebtPositionOrigin,
+  PaymentOptionTypeEnum
+} from '../../generated/data-contracts';
+import { PageRoutes } from '../routes';
+import {
+  Step3FormValues,
+  convertFormDataToManageDebtPositionDTO
+} from '../models/Step3Schema';
+import { Step1Data, Step2Data, Step3Data } from '../models/DebtPositionType';
+import {
+  DEFAULT_VALUES,
+  createInstallmentObject,
+  createSingleInstallmentObject
+} from '../utils/paymentUtility';
+import utils from '../utils';
+
+/**
+ * Parameters for the edit operation
+ */
+export type EditModeFlowParams = {
+  values: Step3FormValues;
+  step1Data: Step1Data;
+  step2Data: Step2Data;
+  debtPositionId: string | number;
+  debtPositionDetail: DebtPositionDetailDTO;
+  shouldPublish: boolean;
+  isDraftInEdit: boolean;
+  organizationId: number;
+  manageInstallmentsMutation: UseMutationResult<
+    DebtPositionDTO,
+    Error,
+    {
+      organizationId: number;
+      debtPositionId: number;
+      body: ManageDebtPositionDTO;
+      publish?: boolean;
+    }
+  >;
+};
+
+/**
+ * Parameters for the creation operation
+ */
+export type CreateModeFlowParams = {
+  formattedData: Step3Data;
+  step1Data: Step1Data;
+  step2Data: Step2Data;
+  isInstallment: boolean;
+  isDraft: boolean;
+  organizationId: number;
+  createDebtPositionMutation: UseMutationResult<
+    { response: DebtPositionDTO; paymentObject?: string },
+    Error,
+    { body: DebtPositionDTO; paymentObject?: string }
+  >;
+};
+
+/**
+ * Result of the custom hook
+ */
+export type UseStep3ApiOperationsResult = {
+  handleEditModeFlow: (params: EditModeFlowParams) => Promise<void>;
+  handleCreateModeFlow: (params: CreateModeFlowParams) => Promise<void>;
+  lastActionWasPublish: React.MutableRefObject<boolean>;
+};
+
+/**
+ * Custom hook to manage the API operations of the Step3 component
+ * Extracts the logic for creating and modifying debt positions
+ */
+export const useStep3ApiOperations = (): UseStep3ApiOperationsResult => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  // Ref to track if the last action was publish (for the correct title in the completed page)
+  const lastActionWasPublish = useRef(false);
+
+  /**
+   * Handles the edit flow for managing the installments of the debt position
+   */
+  const handleEditModeFlow = async (
+    params: EditModeFlowParams
+  ): Promise<void> => {
+    const {
+      values,
+      step1Data,
+      step2Data,
+      debtPositionId,
+      debtPositionDetail,
+      shouldPublish,
+      isDraftInEdit,
+      organizationId,
+      manageInstallmentsMutation
+    } = params;
+
+    const firstPaymentOption = debtPositionDetail.paymentOptions?.[0];
+    if (!firstPaymentOption?.paymentOptionId) {
+      utils.notify.emit(
+        t('debtPositionCreateWizard.step3.error.missingPaymentOption'),
+        'error'
+      );
+      return;
+    }
+
+    // Validate debtPositionId
+    if (!debtPositionId || isNaN(Number(debtPositionId))) {
+      console.error('Invalid debtPositionId:', debtPositionId);
+      utils.notify.emit(t('debtPositionCreateWizard.errorMissingId'), 'error');
+      return;
+    }
+
+    try {
+      const manageBody = convertFormDataToManageDebtPositionDTO(
+        values,
+        step2Data,
+        firstPaymentOption.paymentOptionId,
+        debtPositionDetail,
+        step1Data
+      );
+
+      const shouldPublishPosition = shouldPublish;
+      lastActionWasPublish.current = shouldPublishPosition && isDraftInEdit;
+
+      try {
+        const response = await manageInstallmentsMutation.mutateAsync({
+          organizationId,
+          debtPositionId: Number(debtPositionId),
+          body: manageBody,
+          publish: shouldPublishPosition
+        });
+
+        navigate(PageRoutes.DEBT_POSITION_CREATE_WIZARD_COMPLETED, {
+          state: {
+            ...response,
+            isEditing: true,
+            wasPublished: lastActionWasPublish.current
+          },
+          replace: true
+        });
+      } catch (error) {
+        console.error(error);
+        navigate(PageRoutes.RESPONSES_ERROR);
+      }
+    } catch (error) {
+      console.error('Error converting form data:', error);
+      utils.notify.emit(
+        t('debtPositionCreateWizard.step3.error.conversionError'),
+        'error'
+      );
+    }
+  };
+
+  /**
+   * Handles the creation flow for the debt position
+   */
+  const handleCreateModeFlow = async (
+    params: CreateModeFlowParams
+  ): Promise<void> => {
+    const {
+      formattedData,
+      step1Data,
+      step2Data,
+      isInstallment,
+      isDraft,
+      organizationId,
+      createDebtPositionMutation
+    } = params;
+
+    const postBody: DebtPositionDTO = {
+      description: step1Data?.description.value || '',
+      status: isDraft ? DebtPositionStatus.DRAFT : DebtPositionStatus.UNPAID,
+      organizationId: organizationId,
+      debtPositionTypeOrgId: Number(step1Data?.debtPositionType.value || 0),
+      flagIuvVolatile: DEFAULT_VALUES.FLAG_IUV_VOLATILE,
+      debtPositionOrigin: DebtPositionOrigin.ORDINARY,
+      multiDebtor: DEFAULT_VALUES.MULTI_DEBTOR,
+      flagPuPagoPaPayment: DEFAULT_VALUES.FLAG_PAGO_PA_PU_PAYMENT,
+      paymentOptions: [
+        {
+          totalAmountCents: utils.formatters.euroToCents(
+            formattedData.amount.value || '0'
+          ),
+          description: isInstallment
+            ? t('debtPositionCreateWizard.step3.paymentOption.installments')
+            : t('debtPositionCreateWizard.step3.paymentOption.single'),
+          paymentOptionType: isInstallment
+            ? PaymentOptionTypeEnum.INSTALLMENTS
+            : PaymentOptionTypeEnum.SINGLE_INSTALLMENT,
+          paymentOptionIndex: DEFAULT_VALUES.PAYMENT_OPTION_INDEX,
+          installments: isInstallment
+            ? formattedData.installments?.map((installment) =>
+                createInstallmentObject(installment, step2Data, formattedData)
+              ) || []
+            : [createSingleInstallmentObject(formattedData, step2Data)]
+        }
+      ]
+    };
+
+    try {
+      const response = await createDebtPositionMutation.mutateAsync({
+        body: postBody,
+        paymentObject: postBody.description
+      });
+
+      navigate(PageRoutes.DEBT_POSITION_CREATE_WIZARD_COMPLETED, {
+        state: {
+          description: response.paymentObject,
+          status: response.response?.status,
+          debtPositionId: response.response?.debtPositionId,
+          isEditing: false,
+          wasPublished: !isDraft
+        },
+        replace: true
+      });
+    } catch (error) {
+      console.error(error);
+      navigate(PageRoutes.RESPONSES_ERROR);
+    }
+  };
+
+  return {
+    handleEditModeFlow,
+    handleCreateModeFlow,
+    lastActionWasPublish
+  };
+};

--- a/src/hooks/useStep3FormHandlers.test.tsx
+++ b/src/hooks/useStep3FormHandlers.test.tsx
@@ -24,8 +24,7 @@ describe('useStep3FormHandlers', () => {
   const mockTrigger = vi.fn();
   const mockReset = vi.fn();
   const mockGetValues = vi.fn();
-  const mockSetHasClickedFinalCTA = vi.fn();
-  const mockSetSubmissionCount = vi.fn();
+  const mockResetValidationState = vi.fn();
   const mockBeneficiaryFieldRef = {
     current: {
       resetAllBeneficiaries: vi.fn()
@@ -51,8 +50,7 @@ describe('useStep3FormHandlers', () => {
     beneficiaries: [],
     paymentOption: DebtPositionTypeEnum.SINGLE,
     beneficiaryFieldRef: mockBeneficiaryFieldRef,
-    setHasClickedFinalCTA: mockSetHasClickedFinalCTA,
-    setSubmissionCount: mockSetSubmissionCount
+    resetValidationState: mockResetValidationState
   };
 
   beforeEach(() => {
@@ -207,8 +205,7 @@ describe('useStep3FormHandlers', () => {
       expect(mockField.onChange).toHaveBeenCalledWith(
         DebtPositionTypeEnum.INSTALLMENTS
       );
-      expect(mockSetHasClickedFinalCTA).toHaveBeenCalledWith(false);
-      expect(mockSetSubmissionCount).toHaveBeenCalledWith(0);
+      expect(mockResetValidationState).toHaveBeenCalled();
     });
 
     it('should reset fields when changing to installments', () => {

--- a/src/hooks/useStep3FormHandlers.test.tsx
+++ b/src/hooks/useStep3FormHandlers.test.tsx
@@ -1,0 +1,379 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { useStep3FormHandlers } from './useStep3FormHandlers';
+import { Step3FormValues } from '../models/Step3Schema';
+import { DebtPositionTypeEnum } from '../models/DebtPositionType';
+import { PaymentOptionTypeEnum } from '../../generated/data-contracts';
+import { triggerValidationForAllBeneficiaries } from '../utils/paymentUtility';
+import type { Beneficiary } from '../models/paymentTypes';
+
+vi.mock('../utils', () => ({
+  default: {
+    formatters: {
+      parseAmountToNumber: vi.fn()
+    }
+  }
+}));
+
+vi.mock('../utils/paymentUtility', () => ({
+  triggerValidationForAllBeneficiaries: vi.fn()
+}));
+
+describe('useStep3FormHandlers', () => {
+  const mockSetValue = vi.fn();
+  const mockTrigger = vi.fn();
+  const mockReset = vi.fn();
+  const mockGetValues = vi.fn();
+  const mockSetHasClickedFinalCTA = vi.fn();
+  const mockSetSubmissionCount = vi.fn();
+  const mockBeneficiaryFieldRef = {
+    current: {
+      resetAllBeneficiaries: vi.fn()
+    }
+  };
+
+  const mockInitialData: Step3FormValues = {
+    paymentObject: { value: '', readonly: false },
+    paymentOption: { value: DebtPositionTypeEnum.SINGLE, readonly: false },
+    amount: { value: '', readonly: false },
+    dueDate: { value: null, readonly: false },
+    isMultibeneficiary: { value: false, readonly: false },
+    installments: []
+  };
+
+  const baseProps = {
+    setValue: mockSetValue,
+    trigger: mockTrigger,
+    reset: mockReset,
+    getValues: mockGetValues,
+    initialData: mockInitialData,
+    isMultibeneficiary: false,
+    beneficiaries: [],
+    paymentOption: DebtPositionTypeEnum.SINGLE,
+    beneficiaryFieldRef: mockBeneficiaryFieldRef,
+    setHasClickedFinalCTA: mockSetHasClickedFinalCTA,
+    setSubmissionCount: mockSetSubmissionCount
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('handleAmountChange', () => {
+    it('should filter non-numeric characters and normalize commas to dots', () => {
+      const { result } = renderHook(() => useStep3FormHandlers(baseProps));
+      const mockOnChange = vi.fn();
+      const mockEvent = {
+        target: { value: '123,45abc' }
+      } as React.ChangeEvent<HTMLInputElement>;
+
+      act(() => {
+        result.current.handleAmountChange(mockEvent, mockOnChange);
+      });
+
+      expect(mockOnChange).toHaveBeenCalledWith('123.45');
+    });
+
+    it('should trigger validation for beneficiaries when multibeneficiary is active', async () => {
+      const mockBeneficiaries: Array<Beneficiary> = [
+        {
+          id: '1',
+          entityName: 'Test Entity 1',
+          amount: '50.00',
+          taxCode: 'TSTCOD01',
+          remittance: 'Test remittance 1',
+          iban: 'IT60X0542811101000000123456',
+          taxonomyCode: '01'
+        },
+        {
+          id: '2',
+          entityName: 'Test Entity 2',
+          amount: '50.00',
+          taxCode: 'TSTCOD02',
+          remittance: 'Test remittance 2',
+          iban: 'IT60X0542811101000000654321',
+          taxonomyCode: '02'
+        }
+      ];
+
+      const propsWithMultibeneficiary = {
+        ...baseProps,
+        isMultibeneficiary: true,
+        beneficiaries: mockBeneficiaries
+      };
+
+      const { result } = renderHook(() =>
+        useStep3FormHandlers(propsWithMultibeneficiary)
+      );
+      const mockOnChange = vi.fn();
+      const mockEvent = {
+        target: { value: '100' }
+      } as React.ChangeEvent<HTMLInputElement>;
+
+      act(() => {
+        result.current.handleAmountChange(mockEvent, mockOnChange);
+      });
+
+      expect(mockOnChange).toHaveBeenCalledWith('100');
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(triggerValidationForAllBeneficiaries).toHaveBeenCalledWith(
+        propsWithMultibeneficiary.beneficiaries,
+        mockTrigger
+      );
+    });
+
+    it('should not trigger validation when multibeneficiary is disabled', () => {
+      const { result } = renderHook(() => useStep3FormHandlers(baseProps));
+      const mockOnChange = vi.fn();
+      const mockEvent = {
+        target: { value: '100' }
+      } as React.ChangeEvent<HTMLInputElement>;
+
+      act(() => {
+        result.current.handleAmountChange(mockEvent, mockOnChange);
+      });
+
+      expect(triggerValidationForAllBeneficiaries).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleAmountBlur', () => {
+    it('should format valid numeric value with two decimal places', async () => {
+      const mockUtils = await import('../utils');
+      vi.mocked(
+        mockUtils.default.formatters.parseAmountToNumber
+      ).mockReturnValue(123.4);
+
+      const { result } = renderHook(() => useStep3FormHandlers(baseProps));
+      const mockField = {
+        onChange: vi.fn(),
+        onBlur: vi.fn()
+      };
+      const mockEvent = {
+        target: { value: '123.4' }
+      } as React.FocusEvent<HTMLInputElement>;
+
+      act(() => {
+        result.current.handleAmountBlur(mockEvent, mockField);
+      });
+
+      expect(
+        mockUtils.default.formatters.parseAmountToNumber
+      ).toHaveBeenCalledWith('123.4');
+      expect(mockField.onChange).toHaveBeenCalledWith('123.40');
+      expect(mockField.onBlur).toHaveBeenCalled();
+    });
+
+    it('should not format invalid numeric value', async () => {
+      const mockUtils = await import('../utils');
+      vi.mocked(
+        mockUtils.default.formatters.parseAmountToNumber
+      ).mockReturnValue(null);
+
+      const { result } = renderHook(() => useStep3FormHandlers(baseProps));
+      const mockField = {
+        onChange: vi.fn(),
+        onBlur: vi.fn()
+      };
+      const mockEvent = {
+        target: { value: 'invalid' }
+      } as React.FocusEvent<HTMLInputElement>;
+
+      act(() => {
+        result.current.handleAmountBlur(mockEvent, mockField);
+      });
+
+      expect(mockField.onChange).not.toHaveBeenCalled();
+      expect(mockField.onBlur).toHaveBeenCalled();
+    });
+  });
+
+  describe('handlePaymentOptionChange', () => {
+    it('should call onChange and reset states when payment option changes', () => {
+      const { result } = renderHook(() => useStep3FormHandlers(baseProps));
+      const mockField = {
+        onChange: vi.fn()
+      };
+      const mockEvent = {
+        target: { value: DebtPositionTypeEnum.INSTALLMENTS }
+      } as React.ChangeEvent<HTMLInputElement>;
+
+      act(() => {
+        result.current.handlePaymentOptionChange(mockEvent, mockField);
+      });
+
+      expect(mockField.onChange).toHaveBeenCalledWith(
+        DebtPositionTypeEnum.INSTALLMENTS
+      );
+      expect(mockSetHasClickedFinalCTA).toHaveBeenCalledWith(false);
+      expect(mockSetSubmissionCount).toHaveBeenCalledWith(0);
+    });
+
+    it('should reset fields when changing to installments', () => {
+      const { result } = renderHook(() => useStep3FormHandlers(baseProps));
+      const mockField = {
+        onChange: vi.fn()
+      };
+      const mockEvent = {
+        target: { value: DebtPositionTypeEnum.INSTALLMENTS }
+      } as React.ChangeEvent<HTMLInputElement>;
+
+      act(() => {
+        result.current.handlePaymentOptionChange(mockEvent, mockField);
+      });
+
+      expect(mockReset).toHaveBeenCalledWith({
+        ...mockInitialData,
+        paymentOption: {
+          ...mockInitialData.paymentOption,
+          value: DebtPositionTypeEnum.INSTALLMENTS
+        },
+        isMultibeneficiary: {
+          ...mockInitialData.isMultibeneficiary,
+          value: false
+        },
+        beneficiaries: [],
+        installments: []
+      });
+    });
+
+    it('should reset fields when changing from installments to single', () => {
+      const propsWithInstallments = {
+        ...baseProps,
+        paymentOption: DebtPositionTypeEnum.INSTALLMENTS
+      };
+
+      const { result } = renderHook(() =>
+        useStep3FormHandlers(propsWithInstallments)
+      );
+      const mockField = {
+        onChange: vi.fn()
+      };
+      const mockEvent = {
+        target: { value: PaymentOptionTypeEnum.SINGLE_INSTALLMENT }
+      } as React.ChangeEvent<HTMLInputElement>;
+
+      act(() => {
+        result.current.handlePaymentOptionChange(mockEvent, mockField);
+      });
+
+      expect(mockReset).toHaveBeenCalledWith({
+        ...mockInitialData,
+        paymentOption: {
+          ...mockInitialData.paymentOption,
+          value: DebtPositionTypeEnum.SINGLE
+        },
+        isMultibeneficiary: {
+          ...mockInitialData.isMultibeneficiary,
+          value: false
+        },
+        beneficiaries: [],
+        installments: []
+      });
+    });
+
+    it('should reset beneficiaries after timeout', async () => {
+      const { result } = renderHook(() => useStep3FormHandlers(baseProps));
+      const mockField = {
+        onChange: vi.fn()
+      };
+      const mockEvent = {
+        target: { value: DebtPositionTypeEnum.INSTALLMENTS }
+      } as React.ChangeEvent<HTMLInputElement>;
+
+      act(() => {
+        result.current.handlePaymentOptionChange(mockEvent, mockField);
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(
+        mockBeneficiaryFieldRef.current.resetAllBeneficiaries
+      ).toHaveBeenCalled();
+    });
+  });
+
+  describe('handleMultibeneficiaryToggle', () => {
+    it('should enable multibeneficiary and reset beneficiaries', () => {
+      const { result } = renderHook(() => useStep3FormHandlers(baseProps));
+
+      act(() => {
+        result.current.handleMultibeneficiaryToggle(true);
+      });
+
+      expect(
+        mockBeneficiaryFieldRef.current.resetAllBeneficiaries
+      ).toHaveBeenCalledTimes(1);
+      expect(mockSetValue).toHaveBeenCalledWith(
+        'isMultibeneficiary.value',
+        true,
+        {
+          shouldValidate: false
+        }
+      );
+    });
+
+    it('should disable multibeneficiary and reset beneficiaries', () => {
+      const { result } = renderHook(() => useStep3FormHandlers(baseProps));
+
+      act(() => {
+        result.current.handleMultibeneficiaryToggle(false);
+      });
+
+      expect(mockSetValue).toHaveBeenCalledWith(
+        'isMultibeneficiary.value',
+        false,
+        {
+          shouldValidate: false
+        }
+      );
+      expect(
+        mockBeneficiaryFieldRef.current.resetAllBeneficiaries
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle missing resetAllBeneficiaries method gracefully', () => {
+      const propsWithoutRef = {
+        ...baseProps,
+        beneficiaryFieldRef: { current: {} }
+      };
+
+      const { result } = renderHook(() =>
+        useStep3FormHandlers(propsWithoutRef)
+      );
+
+      // Test that the function doesn't throw when resetAllBeneficiaries is missing
+      act(() => {
+        result.current.handleMultibeneficiaryToggle(true);
+      });
+
+      expect(mockSetValue).toHaveBeenCalledWith(
+        'isMultibeneficiary.value',
+        true,
+        {
+          shouldValidate: false
+        }
+      );
+    });
+  });
+
+  describe('return object', () => {
+    it('should return all handler functions', () => {
+      const { result } = renderHook(() => useStep3FormHandlers(baseProps));
+
+      expect(result.current).toHaveProperty('handleAmountChange');
+      expect(result.current).toHaveProperty('handleAmountBlur');
+      expect(result.current).toHaveProperty('handlePaymentOptionChange');
+      expect(result.current).toHaveProperty('handleMultibeneficiaryToggle');
+
+      expect(typeof result.current.handleAmountChange).toBe('function');
+      expect(typeof result.current.handleAmountBlur).toBe('function');
+      expect(typeof result.current.handlePaymentOptionChange).toBe('function');
+      expect(typeof result.current.handleMultibeneficiaryToggle).toBe(
+        'function'
+      );
+    });
+  });
+});

--- a/src/hooks/useStep3FormHandlers.tsx
+++ b/src/hooks/useStep3FormHandlers.tsx
@@ -26,8 +26,8 @@ export type UseStep3FormHandlersProps = {
   beneficiaries: Array<Beneficiary>;
   paymentOption: PaymentOption;
   beneficiaryFieldRef: React.MutableRefObject<BeneficiaryFieldRef>;
-  setHasClickedFinalCTA: (value: boolean) => void;
-  setSubmissionCount: (value: number | ((prev: number) => number)) => void;
+  /** Function to reset validation state when changing payment options */
+  resetValidationState: () => void;
 };
 
 /**
@@ -65,8 +65,7 @@ export const useStep3FormHandlers = (
     beneficiaries,
     paymentOption,
     beneficiaryFieldRef,
-    setHasClickedFinalCTA,
-    setSubmissionCount
+    resetValidationState
   } = props;
 
   /**
@@ -116,10 +115,9 @@ export const useStep3FormHandlers = (
     const value = e.target.value;
     field.onChange(value);
 
-    // Reset hasClickedFinalCTA and submissionCount when changing the payment mode
+    // Reset validation state when changing the payment mode
     // Each mode should start "clean" without premature errors
-    setHasClickedFinalCTA(false);
-    setSubmissionCount(0);
+    resetValidationState();
 
     // Reset the fields based on the selected mode
     resetFieldsForPaymentOption(value);

--- a/src/hooks/useStep3FormHandlers.tsx
+++ b/src/hooks/useStep3FormHandlers.tsx
@@ -1,0 +1,208 @@
+import React from 'react';
+import {
+  UseFormSetValue,
+  UseFormTrigger,
+  UseFormReset,
+  UseFormGetValues
+} from 'react-hook-form';
+import { Step3FormValues } from '../models/Step3Schema';
+import { DebtPositionTypeEnum } from '../models/DebtPositionType';
+import { PaymentOptionTypeEnum } from '../../generated/data-contracts';
+import type { PaymentOption, Beneficiary } from '../models/paymentTypes';
+import { BeneficiaryFieldRef } from '../routes/DebtPositionCreateWizard/components/Beneficiary/BeneficiaryField';
+import { triggerValidationForAllBeneficiaries } from '../utils/paymentUtility';
+import utils from '../utils';
+
+/**
+ * Parameters for the custom hook
+ */
+export type UseStep3FormHandlersProps = {
+  setValue: UseFormSetValue<Step3FormValues>;
+  trigger: UseFormTrigger<Step3FormValues>;
+  reset: UseFormReset<Step3FormValues>;
+  getValues: UseFormGetValues<Step3FormValues>;
+  initialData: Step3FormValues;
+  isMultibeneficiary: boolean;
+  beneficiaries: Array<Beneficiary>;
+  paymentOption: PaymentOption;
+  beneficiaryFieldRef: React.MutableRefObject<BeneficiaryFieldRef>;
+  setHasClickedFinalCTA: (value: boolean) => void;
+  setSubmissionCount: (value: number | ((prev: number) => number)) => void;
+};
+
+/**
+ * Result of the custom hook
+ */
+export type UseStep3FormHandlersResult = {
+  handleAmountChange: (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    onChange: (...event: Array<unknown>) => void
+  ) => void;
+  handleAmountBlur: (
+    e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>,
+    field: { onChange: (...event: Array<unknown>) => void; onBlur: () => void }
+  ) => void;
+  handlePaymentOptionChange: (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    field: { onChange: (...event: Array<unknown>) => void }
+  ) => void;
+  handleMultibeneficiaryToggle: (value: boolean) => void;
+};
+
+/**
+ * Custom hook to manage all the event handlers of the Step3 form
+ * Extracts the event handling logic to improve testability and maintainability
+ */
+export const useStep3FormHandlers = (
+  props: UseStep3FormHandlersProps
+): UseStep3FormHandlersResult => {
+  const {
+    setValue,
+    trigger,
+    reset,
+    initialData,
+    isMultibeneficiary,
+    beneficiaries,
+    paymentOption,
+    beneficiaryFieldRef,
+    setHasClickedFinalCTA,
+    setSubmissionCount
+  } = props;
+
+  /**
+   * Handles the change of the amount field
+   * Normalize the value and activate the validation for the beneficiaries if necessary
+   */
+  const handleAmountChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    onChange: (...event: Array<unknown>) => void
+  ): void => {
+    const filteredValue = e.target.value.replace(/[^0-9.,]/g, '');
+    const normalizedValue = filteredValue.replace(',', '.');
+    onChange(normalizedValue);
+
+    if (isMultibeneficiary && beneficiaries.length > 0) {
+      setTimeout(() => {
+        triggerValidationForAllBeneficiaries(beneficiaries, trigger);
+      }, 0);
+    }
+  };
+
+  /**
+   * Handles the blur event of the amount field
+   * Format the value with two decimal places when the field loses focus
+   */
+  const handleAmountBlur = (
+    e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>,
+    field: { onChange: (...event: Array<unknown>) => void; onBlur: () => void }
+  ): void => {
+    const value = e.target.value;
+    const numericValue = utils.formatters.parseAmountToNumber(value);
+    if (numericValue !== null) {
+      const formatted = numericValue.toFixed(2);
+      field.onChange(formatted);
+    }
+    field.onBlur();
+  };
+
+  /**
+   * Handles the change of the payment option
+   * Reset the fields when changing from one payment mode to another
+   */
+  const handlePaymentOptionChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    field: { onChange: (...event: Array<unknown>) => void }
+  ): void => {
+    const value = e.target.value;
+    field.onChange(value);
+
+    // Reset hasClickedFinalCTA and submissionCount when changing the payment mode
+    // Each mode should start "clean" without premature errors
+    setHasClickedFinalCTA(false);
+    setSubmissionCount(0);
+
+    // Reset the fields based on the selected mode
+    resetFieldsForPaymentOption(value);
+
+    // Reset the beneficiaries after a short delay
+    setTimeout(() => {
+      resetBeneficiariesIfNeeded();
+    }, 0);
+  };
+
+  /**
+   * Handles the toggle of the multi-beneficiary
+   */
+  const handleMultibeneficiaryToggle = (value: boolean): void => {
+    // Before resetting the validation state, reset the beneficiaries
+    if (value && beneficiaryFieldRef.current?.resetAllBeneficiaries) {
+      beneficiaryFieldRef.current.resetAllBeneficiaries();
+    }
+
+    // Then set the new value
+    setValue('isMultibeneficiary.value', value, { shouldValidate: false });
+
+    // If the multi-beneficiary is disabled, reset the beneficiaries
+    if (!value && beneficiaryFieldRef.current?.resetAllBeneficiaries) {
+      beneficiaryFieldRef.current.resetAllBeneficiaries();
+    }
+  };
+
+  /**
+   * Reset the fields based on the selected payment option
+   * @private
+   */
+  const resetFieldsForPaymentOption = (paymentOptionValue: string): void => {
+    switch (paymentOptionValue) {
+      case DebtPositionTypeEnum.INSTALLMENTS:
+        reset({
+          ...initialData,
+          paymentOption: {
+            ...initialData.paymentOption,
+            value: DebtPositionTypeEnum.INSTALLMENTS as PaymentOption
+          },
+          isMultibeneficiary: {
+            ...initialData.isMultibeneficiary,
+            value: false
+          },
+          beneficiaries: [],
+          installments: []
+        });
+        break;
+      case PaymentOptionTypeEnum.SINGLE_INSTALLMENT:
+        if (paymentOption === DebtPositionTypeEnum.INSTALLMENTS) {
+          reset({
+            ...initialData,
+            paymentOption: {
+              ...initialData.paymentOption,
+              value: DebtPositionTypeEnum.SINGLE as PaymentOption
+            },
+            isMultibeneficiary: {
+              ...initialData.isMultibeneficiary,
+              value: false
+            },
+            beneficiaries: [],
+            installments: []
+          });
+        }
+        break;
+    }
+  };
+
+  /**
+   * Reset the beneficiaries if necessary
+   * @private
+   */
+  const resetBeneficiariesIfNeeded = (): void => {
+    if (beneficiaryFieldRef.current?.resetAllBeneficiaries) {
+      beneficiaryFieldRef.current.resetAllBeneficiaries();
+    }
+  };
+
+  return {
+    handleAmountChange,
+    handleAmountBlur,
+    handlePaymentOptionChange,
+    handleMultibeneficiaryToggle
+  };
+};

--- a/src/hooks/useStep3Validation.test.tsx
+++ b/src/hooks/useStep3Validation.test.tsx
@@ -1,0 +1,256 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { useStep3Validation } from './useStep3Validation';
+import { Step3FormValues } from '../models/Step3Schema';
+import { DebtPositionTypeEnum } from '../models/DebtPositionType';
+import type { Installment } from '../models/paymentTypes';
+import type {
+  UseFormGetValues,
+  UseFormSetValue,
+  UseFormTrigger
+} from 'react-hook-form';
+import type { Path } from 'react-hook-form';
+
+vi.mock('../utils/step3ValidationUtils', () => ({
+  validateFormFields: vi.fn(),
+  validateBusinessLogic: vi.fn(),
+  createValidateInstallmentsData: vi.fn()
+}));
+
+describe('useStep3Validation', () => {
+  let mockSetValue: UseFormSetValue<Step3FormValues>;
+  let mockTrigger: UseFormTrigger<Step3FormValues>;
+  let mockGetValues: UseFormGetValues<Step3FormValues>;
+
+  const baseFormValues: Step3FormValues = {
+    paymentObject: { value: 'Test', readonly: false },
+    paymentOption: { value: DebtPositionTypeEnum.SINGLE, readonly: false },
+    amount: { value: '100.00', readonly: false },
+    dueDate: { value: null, readonly: false },
+    isMultibeneficiary: { value: false, readonly: false },
+    beneficiaries: [],
+    installments: []
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockSetValue = vi.fn();
+    mockTrigger = vi.fn();
+    mockGetValues = ((name?: Path<Step3FormValues>): unknown => {
+      if (name === undefined) {
+        return baseFormValues as unknown;
+      }
+      if (name === 'installments') {
+        return baseFormValues.installments as unknown;
+      }
+      if (name === 'beneficiaries') {
+        return baseFormValues.beneficiaries as unknown;
+      }
+      return undefined as unknown;
+    }) as UseFormGetValues<Step3FormValues>;
+  });
+
+  it('should expose initial validation state and convenience getters', () => {
+    const { result } = renderHook(() =>
+      useStep3Validation({
+        setValue: mockSetValue,
+        trigger: mockTrigger,
+        getValues: mockGetValues
+      })
+    );
+
+    expect(result.current.validationState).toEqual({
+      hasClickedFinalCTA: false,
+      submissionCount: 0,
+      isSubmitting: false
+    });
+    expect(result.current.hasClickedFinalCTA).toBe(false);
+    expect(result.current.submissionCount).toBe(0);
+  });
+
+  it('markFinalCTAClicked should set hasClickedFinalCTA, increment submissionCount and set isSubmitting', () => {
+    const { result } = renderHook(() =>
+      useStep3Validation({
+        setValue: mockSetValue,
+        trigger: mockTrigger,
+        getValues: mockGetValues
+      })
+    );
+
+    act(() => {
+      result.current.markFinalCTAClicked();
+    });
+
+    expect(result.current.validationState.hasClickedFinalCTA).toBe(true);
+    expect(result.current.validationState.submissionCount).toBe(1);
+    expect(result.current.validationState.isSubmitting).toBe(true);
+  });
+
+  it('resetValidationState should reset state to defaults', () => {
+    const { result } = renderHook(() =>
+      useStep3Validation({
+        setValue: mockSetValue,
+        trigger: mockTrigger,
+        getValues: mockGetValues
+      })
+    );
+
+    act(() => {
+      result.current.markFinalCTAClicked();
+    });
+
+    act(() => {
+      result.current.resetValidationState();
+    });
+
+    expect(result.current.validationState).toEqual({
+      hasClickedFinalCTA: false,
+      submissionCount: 0,
+      isSubmitting: false
+    });
+  });
+
+  it('shouldShowErrors should respect submissionCount versus componentCreationCount', () => {
+    const { result } = renderHook(() =>
+      useStep3Validation({
+        setValue: mockSetValue,
+        trigger: mockTrigger,
+        getValues: mockGetValues
+      })
+    );
+
+    expect(result.current.shouldShowErrors()).toBe(false);
+
+    act(() => {
+      result.current.markFinalCTAClicked();
+    });
+
+    // After first submission, components created before (count 0) should show errors
+    expect(result.current.shouldShowErrors(0)).toBe(true);
+    // Components created in the same tick after submission (count 1) should not
+    expect(result.current.shouldShowErrors(1)).toBe(false);
+  });
+
+  describe('validateStep3Form', () => {
+    it('should short-circuit when form fields validation fails', async () => {
+      const utilsModule = await import('../utils/step3ValidationUtils');
+      vi.mocked(utilsModule.validateFormFields).mockResolvedValue(false);
+
+      const { result } = renderHook(() =>
+        useStep3Validation({
+          setValue: mockSetValue,
+          trigger: mockTrigger,
+          getValues: mockGetValues,
+          flagMandatoryDueDate: true
+        })
+      );
+
+      await act(async () =>
+        result.current.validateStep3Form({
+          isInstallment: false,
+          isMultibeneficiary: false,
+          totalAmount: '100.00'
+        })
+      );
+
+      expect(result.current.validationState.isSubmitting).toBe(false);
+      expect(utilsModule.validateFormFields).toHaveBeenCalled();
+      expect(utilsModule.validateBusinessLogic).not.toHaveBeenCalled();
+      vi.mocked(utilsModule.validateFormFields).mockResolvedValue(false);
+      const res = await result.current.validateStep3Form({
+        isInstallment: false,
+        isMultibeneficiary: false,
+        totalAmount: '100.00'
+      });
+      expect(res).toEqual({ isValid: false });
+    });
+
+    it('should orchestrate business validation and propagate synced installments', async () => {
+      const utilsModule = await import('../utils/step3ValidationUtils');
+
+      const mockedValidateInstallmentsData = vi.fn().mockResolvedValue({
+        isValid: true,
+        syncedInstallments: [{ id: '1' } as Installment]
+      });
+
+      vi.mocked(utilsModule.createValidateInstallmentsData).mockReturnValue(
+        mockedValidateInstallmentsData
+      );
+
+      vi.mocked(utilsModule.validateFormFields).mockResolvedValue(true);
+      vi.mocked(utilsModule.validateBusinessLogic).mockResolvedValue({
+        isValid: true,
+        syncedInstallments: [{ id: '1' } as Installment]
+      });
+
+      const { result } = renderHook(() =>
+        useStep3Validation({
+          setValue: mockSetValue,
+          trigger: mockTrigger,
+          getValues: mockGetValues,
+          flagMandatoryDueDate: true
+        })
+      );
+
+      const res = await result.current.validateStep3Form({
+        isInstallment: true,
+        isMultibeneficiary: false,
+        totalAmount: '100.00'
+      });
+
+      expect(utilsModule.createValidateInstallmentsData).toHaveBeenCalledWith({
+        getValues: mockGetValues,
+        setValue: mockSetValue,
+        trigger: mockTrigger
+      });
+      expect(utilsModule.validateBusinessLogic).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isInstallment: true,
+          isMultibeneficiary: false,
+          totalAmount: '100.00',
+          getValues: mockGetValues,
+          trigger: mockTrigger,
+          setValue: mockSetValue,
+          validateInstallmentsData: mockedValidateInstallmentsData
+        })
+      );
+      expect(res).toEqual({
+        isValid: true,
+        syncedInstallments: [{ id: '1' } as Installment]
+      });
+      expect(result.current.validationState.isSubmitting).toBe(false);
+    });
+
+    it('should pass flagMandatoryDueDate to form field validation', async () => {
+      const utilsModule = await import('../utils/step3ValidationUtils');
+      vi.mocked(utilsModule.validateFormFields).mockResolvedValue(true);
+      vi.mocked(utilsModule.validateBusinessLogic).mockResolvedValue({
+        isValid: true
+      });
+
+      const { result } = renderHook(() =>
+        useStep3Validation({
+          setValue: mockSetValue,
+          trigger: mockTrigger,
+          getValues: mockGetValues,
+          flagMandatoryDueDate: true
+        })
+      );
+
+      await result.current.validateStep3Form({
+        isInstallment: false,
+        isMultibeneficiary: false,
+        totalAmount: '100.00'
+      });
+
+      expect(utilsModule.validateFormFields).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isInstallment: false,
+          setValue: mockSetValue,
+          trigger: mockTrigger,
+          values: expect.objectContaining({ flagMandatoryDueDate: true })
+        })
+      );
+    });
+  });
+});

--- a/src/hooks/useStep3Validation.ts
+++ b/src/hooks/useStep3Validation.ts
@@ -1,0 +1,230 @@
+import { useCallback, useState } from 'react';
+import {
+  UseFormTrigger,
+  UseFormSetValue,
+  UseFormGetValues
+} from 'react-hook-form';
+import { Step3FormValues } from '../models/Step3Schema';
+import {
+  validateFormFields,
+  validateBusinessLogic,
+  createValidateInstallmentsData,
+  type ValidateFormFieldsParams,
+  type ValidateBusinessLogicParams
+} from '../utils/step3ValidationUtils';
+import type { Installment } from '../models/paymentTypes';
+
+/**
+ * Centralized state for validation management in Step3
+ * Unifies hasClickedFinalCTA and submissionCount logic
+ */
+export type ValidationState = {
+  /** Whether a final CTA (Create/Save) has been clicked */
+  hasClickedFinalCTA: boolean;
+  /** Counter to track submission attempts - used to determine when to show errors */
+  submissionCount: number;
+  /** Whether the form is currently in submission mode */
+  isSubmitting: boolean;
+};
+
+/**
+ * Parameters for the Step3 validation hook
+ */
+export type UseStep3ValidationParams = {
+  setValue: UseFormSetValue<Step3FormValues>;
+  trigger: UseFormTrigger<Step3FormValues>;
+  getValues: UseFormGetValues<Step3FormValues>;
+  flagMandatoryDueDate?: boolean;
+};
+
+/**
+ * Result of the Step3 validation hook
+ */
+export type UseStep3ValidationResult = {
+  /** Current validation state */
+  validationState: ValidationState;
+
+  /** Mark that a final CTA has been clicked and increment submission count */
+  markFinalCTAClicked: () => void;
+
+  /** Reset validation state (useful when changing payment options) */
+  resetValidationState: () => void;
+
+  /** Perform complete form validation including business logic */
+  validateStep3Form: (params: {
+    isInstallment: boolean;
+    isMultibeneficiary: boolean;
+    totalAmount: string;
+  }) => Promise<{
+    isValid: boolean;
+    syncedInstallments?: Array<Installment>;
+  }>;
+
+  /**
+   * Check if errors should be shown for a component based on current state
+   * This preserves the existing logic where components created after a submission
+   * should not show errors until the next submission.
+   */
+  shouldShowErrors: (componentCreationCount?: number) => boolean;
+
+  /** Convenience getters for backward compatibility */
+  hasClickedFinalCTA: boolean;
+  submissionCount: number;
+};
+
+/**
+ * Custom hook to centralize Step3 validation logic
+ *
+ * This hook manages:
+ * - hasClickedFinalCTA state
+ * - submissionCount tracking
+ * - Form validation orchestration
+ * - Error display logic based on component creation timing
+ *
+ * It maintains the existing behavior while centralizing the logic
+ * that was previously scattered across Step3, useStep3FormHandlers,
+ * BeneficiaryField, and InstallmentField components.
+ */
+export const useStep3Validation = (
+  params: UseStep3ValidationParams
+): UseStep3ValidationResult => {
+  const { setValue, trigger, getValues, flagMandatoryDueDate } = params;
+
+  // Centralized validation state
+  const [validationState, setValidationState] = useState<ValidationState>({
+    hasClickedFinalCTA: false,
+    submissionCount: 0,
+    isSubmitting: false
+  });
+
+  // Create the validateInstallmentsData function with form parameters
+  const validateInstallmentsDataFn = createValidateInstallmentsData({
+    getValues,
+    setValue,
+    trigger
+  });
+
+  /**
+   * Mark that a final CTA has been clicked and increment submission count
+   * This replaces the separate setHasClickedFinalCTA(true) and setSubmissionCount(prev => prev + 1) calls
+   */
+  const markFinalCTAClicked = useCallback(() => {
+    setValidationState((prev) => ({
+      ...prev,
+      hasClickedFinalCTA: true,
+      submissionCount: prev.submissionCount + 1,
+      isSubmitting: true
+    }));
+  }, []);
+
+  /**
+   * Reset validation state - useful when changing payment options
+   * This replaces the separate setHasClickedFinalCTA(false) and setSubmissionCount(0) calls
+   */
+  const resetValidationState = useCallback(() => {
+    setValidationState({
+      hasClickedFinalCTA: false,
+      submissionCount: 0,
+      isSubmitting: false
+    });
+  }, []);
+
+  /**
+   * Perform complete form validation including business logic
+   * This centralizes the validation logic that was in Step3's onSubmit method
+   */
+  const validateStep3Form = useCallback(
+    async (validationParams: {
+      isInstallment: boolean;
+      isMultibeneficiary: boolean;
+      totalAmount: string;
+    }) => {
+      const { isInstallment, isMultibeneficiary, totalAmount } =
+        validationParams;
+
+      // Set submitting state
+      setValidationState((prev) => ({
+        ...prev,
+        isSubmitting: true
+      }));
+
+      try {
+        const values = getValues();
+
+        // Validate form fields including mandatory due date
+        const formFieldsParams: ValidateFormFieldsParams = {
+          values: { ...values, flagMandatoryDueDate },
+          isInstallment,
+          setValue,
+          trigger
+        };
+
+        const isFormValid = await validateFormFields(formFieldsParams);
+        if (!isFormValid) {
+          return { isValid: false };
+        }
+
+        // Validate business logic (beneficiaries or installments)
+        const businessLogicParams: ValidateBusinessLogicParams = {
+          isInstallment,
+          isMultibeneficiary,
+          totalAmount,
+          getValues,
+          trigger,
+          setValue,
+          validateInstallmentsData: validateInstallmentsDataFn
+        };
+
+        const { isValid: isBusinessValid, syncedInstallments } =
+          await validateBusinessLogic(businessLogicParams);
+
+        return {
+          isValid: isBusinessValid,
+          syncedInstallments
+        };
+      } finally {
+        // Reset submitting state
+        setValidationState((prev) => ({
+          ...prev,
+          isSubmitting: false
+        }));
+      }
+    },
+    [
+      getValues,
+      setValue,
+      trigger,
+      validateInstallmentsDataFn,
+      flagMandatoryDueDate
+    ]
+  );
+
+  /**
+   * Check if errors should be shown for a component based on current state
+   *
+   * This preserves the existing logic:
+   * hasClickedFinalCTA && submissionCount > componentCreationCount
+   *
+   * Components created after a submission should not show errors until the next submission.
+   */
+  const shouldShowErrors = useCallback(
+    (componentCreationCount = 0) => {
+      return (
+        validationState.hasClickedFinalCTA &&
+        validationState.submissionCount > componentCreationCount
+      );
+    },
+    [validationState.hasClickedFinalCTA, validationState.submissionCount]
+  );
+
+  return {
+    validationState,
+    markFinalCTAClicked,
+    resetValidationState,
+    validateStep3Form,
+    shouldShowErrors,
+    // Convenience getters for backward compatibility
+    hasClickedFinalCTA: validationState.hasClickedFinalCTA,
+    submissionCount: validationState.submissionCount
+  };
+};

--- a/src/models/paymentTypes.ts
+++ b/src/models/paymentTypes.ts
@@ -168,6 +168,8 @@ export type BeneficiaryValidationContext<T extends FieldValues> = {
   fieldNamePrefix: string;
   getValues: UseFormGetValues<T>;
   t: (key: string) => string;
+  submissionCount: number;
+  creationSubmissionCount: number;
 };
 
 export type BaseHookProps<T extends FieldValues> = {
@@ -200,6 +202,7 @@ export type InstallmentManagementProps<T extends FieldValues> =
     readonly fieldNamePrefix: FieldArrayPath<T>;
     readonly setValue: UseFormSetValue<T>;
     readonly flagMandatoryDueDate?: boolean;
+    readonly submissionCount?: number;
     readonly onInstallmentsChange?: (
       installments: Array<Installment>,
       totalAmount: string

--- a/src/routes/DebtPositionCreateWizard/components/Beneficiary/BeneficiaryField.test.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Beneficiary/BeneficiaryField.test.tsx
@@ -513,7 +513,7 @@ describe('BeneficiaryField', () => {
         trigger={mockTrigger}
         onToggleMultibeneficiary={mockOnToggleMultibeneficiary}
         onBeneficiariesChange={mockOnBeneficiariesChange}
-        hasClickedFinalCTA={hasClickedFinalCTA}
+        shouldShowErrors={() => hasClickedFinalCTA}
       />
     );
 

--- a/src/routes/DebtPositionCreateWizard/components/Beneficiary/BeneficiaryField.test.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Beneficiary/BeneficiaryField.test.tsx
@@ -463,7 +463,7 @@ describe('BeneficiaryField', () => {
   it("passa correttamente i parametri all'hook useBeneficiaryManagement", () => {
     const totalAmount = '200.00';
     const fieldNamePrefix = 'beneficiaries';
-    const isSubmitted = true;
+    const hasClickedFinalCTA = true;
 
     const mockControl = {
       _formValues: {},
@@ -503,7 +503,7 @@ describe('BeneficiaryField', () => {
     render(
       <BeneficiaryField
         control={mockControl}
-        isSubmitted={isSubmitted}
+        isSubmitted={false}
         errors={mockErrors}
         totalAmount={totalAmount}
         fieldNamePrefix={fieldNamePrefix}
@@ -513,6 +513,7 @@ describe('BeneficiaryField', () => {
         trigger={mockTrigger}
         onToggleMultibeneficiary={mockOnToggleMultibeneficiary}
         onBeneficiariesChange={mockOnBeneficiariesChange}
+        hasClickedFinalCTA={hasClickedFinalCTA}
       />
     );
 
@@ -521,7 +522,7 @@ describe('BeneficiaryField', () => {
     ).toHaveBeenCalledWith(
       expect.objectContaining({
         control: mockControl,
-        isSubmitted,
+        isSubmitted: hasClickedFinalCTA,
         totalAmount,
         fieldNamePrefix,
         trigger: mockTrigger,

--- a/src/routes/DebtPositionCreateWizard/components/Beneficiary/BeneficiaryField.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Beneficiary/BeneficiaryField.tsx
@@ -54,9 +54,10 @@ type BeneficiaryFieldProps<T extends FieldValues = FieldValues> = {
   readonly installmentIndex?: number;
   readonly installmentsFieldNamePrefix?: string;
   readonly isEditing?: boolean;
-  readonly hasClickedFinalCTA?: boolean;
-  readonly submissionCount?: number;
-  readonly creationSubmissionCount?: number;
+  /** Function to determine when to show errors based on component creation timing */
+  readonly shouldShowErrors?: (componentCreationCount?: number) => boolean;
+  readonly submissionCount?: number; // Still needed for creation tracking
+  readonly creationSubmissionCount?: number; // Still needed for creation tracking
 };
 
 /**
@@ -92,7 +93,7 @@ const InternalBeneficiaryField = <T extends FieldValues>(
     installmentIndex,
     installmentsFieldNamePrefix,
     isEditing,
-    hasClickedFinalCTA = false,
+    shouldShowErrors,
     submissionCount = 0,
     creationSubmissionCount = 0
   } = props;
@@ -112,7 +113,9 @@ const InternalBeneficiaryField = <T extends FieldValues>(
           control,
           index: installmentIndex,
           installmentsFieldNamePrefix,
-          isSubmitted: hasClickedFinalCTA, // Use hasClickedFinalCTA to synchronize with validation
+          isSubmitted: shouldShowErrors
+            ? shouldShowErrors(creationSubmissionCountRef.current)
+            : false, // Use centralized shouldShowErrors logic
           getValues,
           setValue,
           trigger,
@@ -121,7 +124,9 @@ const InternalBeneficiaryField = <T extends FieldValues>(
       : useBeneficiaryManagement<T>({
           control,
           fieldNamePrefix: fieldNamePrefix as FieldArrayPath<T>,
-          isSubmitted: hasClickedFinalCTA, // Use hasClickedFinalCTA to synchronize with validation
+          isSubmitted: shouldShowErrors
+            ? shouldShowErrors(creationSubmissionCountRef.current)
+            : false, // Use centralized shouldShowErrors logic
           getValues,
           trigger,
           totalAmount,
@@ -189,9 +194,9 @@ const InternalBeneficiaryField = <T extends FieldValues>(
     const context = {
       id: field.id,
       index,
-      isSubmitted:
-        hasClickedFinalCTA &&
-        submissionCount > creationSubmissionCountRef.current, // Show errors only if created before current submission
+      isSubmitted: shouldShowErrors
+        ? shouldShowErrors(creationSubmissionCountRef.current)
+        : false, // Use centralized shouldShowErrors logic
       wasSubmittedRef,
       existingBeneficiaries,
       errors,

--- a/src/routes/DebtPositionCreateWizard/components/Beneficiary/BeneficiaryField.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Beneficiary/BeneficiaryField.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import React, { useImperativeHandle } from 'react';
+import React, { useImperativeHandle, useRef } from 'react';
 import {
   Control,
   UseFormGetValues,
@@ -54,6 +54,9 @@ type BeneficiaryFieldProps<T extends FieldValues = FieldValues> = {
   readonly installmentIndex?: number;
   readonly installmentsFieldNamePrefix?: string;
   readonly isEditing?: boolean;
+  readonly hasClickedFinalCTA?: boolean;
+  readonly submissionCount?: number;
+  readonly creationSubmissionCount?: number;
 };
 
 /**
@@ -76,7 +79,6 @@ const InternalBeneficiaryField = <T extends FieldValues>(
 ) => {
   const {
     control,
-    isSubmitted,
     errors,
     totalAmount,
     fieldNamePrefix,
@@ -89,10 +91,18 @@ const InternalBeneficiaryField = <T extends FieldValues>(
     isInsideInstallment = false,
     installmentIndex,
     installmentsFieldNamePrefix,
-    isEditing
+    isEditing,
+    hasClickedFinalCTA = false,
+    submissionCount = 0,
+    creationSubmissionCount = 0
   } = props;
 
   const { t } = useTranslation();
+
+  // Track the submissionCount at the moment the beneficiary is activated
+  // If the beneficiary is activated after a submit, it should not show errors
+  // until the next submit
+  const creationSubmissionCountRef = useRef(creationSubmissionCount);
 
   const beneficiaryManager =
     isInsideInstallment &&
@@ -102,7 +112,7 @@ const InternalBeneficiaryField = <T extends FieldValues>(
           control,
           index: installmentIndex,
           installmentsFieldNamePrefix,
-          isSubmitted,
+          isSubmitted: hasClickedFinalCTA, // Use hasClickedFinalCTA to synchronize with validation
           getValues,
           setValue,
           trigger,
@@ -111,7 +121,7 @@ const InternalBeneficiaryField = <T extends FieldValues>(
       : useBeneficiaryManagement<T>({
           control,
           fieldNamePrefix: fieldNamePrefix as FieldArrayPath<T>,
-          isSubmitted,
+          isSubmitted: hasClickedFinalCTA, // Use hasClickedFinalCTA to synchronize with validation
           getValues,
           trigger,
           totalAmount,
@@ -174,17 +184,25 @@ const InternalBeneficiaryField = <T extends FieldValues>(
     field: BeneficiaryField,
     index: number
   ): BeneficiaryValidationContext<T> => {
-    return {
+    // wasSubmittedRef is handled automatically by the hook through isSubmitted
+
+    const context = {
       id: field.id,
       index,
-      isSubmitted,
+      isSubmitted:
+        hasClickedFinalCTA &&
+        submissionCount > creationSubmissionCountRef.current, // Show errors only if created before current submission
       wasSubmittedRef,
       existingBeneficiaries,
       errors,
       fieldNamePrefix,
       getValues,
-      t
+      t,
+      submissionCount,
+      creationSubmissionCount: creationSubmissionCountRef.current
     };
+
+    return context;
   };
 
   /**

--- a/src/routes/DebtPositionCreateWizard/components/Beneficiary/BeneficiaryFieldComponents.test.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Beneficiary/BeneficiaryFieldComponents.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { UseFormTrigger } from 'react-hook-form';
-import { ValidationContext } from '../../../../utils/beneficiaryValidation';
+import type { BeneficiaryValidationContext } from '../../../../models/paymentTypes';
 import {
   handleAmountChange,
   handleIBANChange,
@@ -298,8 +298,10 @@ describe('Render Components', () => {
         errors: {},
         fieldNamePrefix: mockFieldNamePrefix,
         getValues: vi.fn(),
-        t: mockT
-      } as ValidationContext<Record<string, unknown>>;
+        t: mockT,
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as BeneficiaryValidationContext<Record<string, unknown>>;
 
       render(
         <EntityNameField field={mockField} t={mockT} context={mockContext} />
@@ -338,8 +340,10 @@ describe('Render Components', () => {
         errors: {},
         fieldNamePrefix: mockFieldNamePrefix,
         getValues: vi.fn(),
-        t: mockT
-      } as ValidationContext<Record<string, unknown>>;
+        t: mockT,
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as BeneficiaryValidationContext<Record<string, unknown>>;
 
       // Render the component
       const { container } = render(
@@ -373,8 +377,10 @@ describe('Validation Error Handling', () => {
         errors: {},
         fieldNamePrefix: mockFieldNamePrefix,
         getValues: vi.fn().mockImplementation(() => ''),
-        t: mockT
-      } as ValidationContext<Record<string, unknown>>;
+        t: mockT,
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as BeneficiaryValidationContext<Record<string, unknown>>;
 
       const result = hasIBANError(mockContext, {});
       expect(result).toBe(false);
@@ -394,8 +400,10 @@ describe('Validation Error Handling', () => {
           if (path.includes('iban')) return '';
           return '';
         }),
-        t: mockT
-      } as ValidationContext<Record<string, unknown>>;
+        t: mockT,
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as BeneficiaryValidationContext<Record<string, unknown>>;
 
       const result = hasIBANError(mockContext, {});
       expect(result).toBe(false);
@@ -425,8 +433,10 @@ describe('Validation Error Handling', () => {
           if (path.includes('iban')) return 'INVALID';
           return '';
         }),
-        t: mockT
-      } as unknown as ValidationContext<Record<string, unknown>>;
+        t: mockT,
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
       const result = hasIBANError(mockContext, mockErrors);
       expect(result).toBe(true);
@@ -444,8 +454,10 @@ describe('Validation Error Handling', () => {
         errors: {},
         fieldNamePrefix: mockFieldNamePrefix,
         getValues: vi.fn().mockImplementation(() => ''),
-        t: mockT
-      } as ValidationContext<Record<string, unknown>>;
+        t: mockT,
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as BeneficiaryValidationContext<Record<string, unknown>>;
 
       const result = getIBANErrorMessage(mockContext, {});
       expect(result).toBe('');
@@ -461,8 +473,10 @@ describe('Validation Error Handling', () => {
         errors: {},
         fieldNamePrefix: mockFieldNamePrefix,
         getValues: vi.fn().mockImplementation(() => ''),
-        t: mockT
-      } as ValidationContext<Record<string, unknown>>;
+        t: mockT,
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as BeneficiaryValidationContext<Record<string, unknown>>;
 
       const result = getIBANErrorMessage(mockContext, {});
       expect(result).toBe(
@@ -494,8 +508,10 @@ describe('Validation Error Handling', () => {
           if (path.includes('iban')) return 'INVALID';
           return '';
         }),
-        t: mockT
-      } as unknown as ValidationContext<Record<string, unknown>>;
+        t: mockT,
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
       const result = getIBANErrorMessage(mockContext, mockErrors);
       expect(result).toBe('Errore IBAN');
@@ -513,8 +529,10 @@ describe('Validation Error Handling', () => {
         errors: {},
         fieldNamePrefix: mockFieldNamePrefix,
         getValues: vi.fn().mockImplementation(() => ''),
-        t: mockT
-      } as ValidationContext<Record<string, unknown>>;
+        t: mockT,
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as BeneficiaryValidationContext<Record<string, unknown>>;
 
       const result = hasPostalAccountError(mockContext, {});
       expect(result).toBe(false);
@@ -534,8 +552,10 @@ describe('Validation Error Handling', () => {
           if (path.includes('postalAccount')) return '';
           return '';
         }),
-        t: mockT
-      } as ValidationContext<Record<string, unknown>>;
+        t: mockT,
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as BeneficiaryValidationContext<Record<string, unknown>>;
 
       const result = hasPostalAccountError(mockContext, {});
       expect(result).toBe(false);
@@ -565,8 +585,10 @@ describe('Validation Error Handling', () => {
           if (path.includes('postalAccount')) return 'INVALID';
           return '';
         }),
-        t: mockT
-      } as unknown as ValidationContext<Record<string, unknown>>;
+        t: mockT,
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
       const result = hasPostalAccountError(mockContext, mockErrors);
       expect(result).toBe(true);
@@ -584,8 +606,10 @@ describe('Validation Error Handling', () => {
         errors: {},
         fieldNamePrefix: mockFieldNamePrefix,
         getValues: vi.fn().mockImplementation(() => ''),
-        t: mockT
-      } as ValidationContext<Record<string, unknown>>;
+        t: mockT,
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as BeneficiaryValidationContext<Record<string, unknown>>;
 
       const result = getPostalAccountErrorMessage(mockContext, {});
       expect(result).toBe('');
@@ -601,8 +625,10 @@ describe('Validation Error Handling', () => {
         errors: {},
         fieldNamePrefix: mockFieldNamePrefix,
         getValues: vi.fn().mockImplementation(() => ''),
-        t: mockT
-      } as ValidationContext<Record<string, unknown>>;
+        t: mockT,
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as BeneficiaryValidationContext<Record<string, unknown>>;
 
       const result = getPostalAccountErrorMessage(mockContext, {});
       expect(result).toBe(
@@ -634,8 +660,10 @@ describe('Validation Error Handling', () => {
           if (path.includes('postalAccount')) return 'INVALID';
           return '';
         }),
-        t: mockT
-      } as unknown as ValidationContext<Record<string, unknown>>;
+        t: mockT,
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
       const result = getPostalAccountErrorMessage(mockContext, mockErrors);
       expect(result).toBe('Errore conto postale');
@@ -669,8 +697,10 @@ describe('AmountField', () => {
       errors: {},
       fieldNamePrefix: 'beneficiaries',
       getValues: vi.fn(),
-      t: mockT
-    } as ValidationContext<Record<string, unknown>>;
+      t: mockT,
+      submissionCount: 1,
+      creationSubmissionCount: 0
+    } as BeneficiaryValidationContext<Record<string, unknown>>;
 
     const mockFields: Array<Record<string, unknown>> = [{}];
 
@@ -732,8 +762,10 @@ describe('IBANField', () => {
       getValues: vi
         .fn()
         .mockImplementation(() => 'IT60X0542811101000000123456'),
-      t: mockT
-    } as ValidationContext<Record<string, unknown>>;
+      t: mockT,
+      submissionCount: 1,
+      creationSubmissionCount: 0
+    } as BeneficiaryValidationContext<Record<string, unknown>>;
 
     const { container } = render(
       <IBANField
@@ -797,8 +829,10 @@ describe('IBANField', () => {
         if (path.includes('iban')) return 'INVALID';
         return '';
       }),
-      t: mockT
-    } as unknown as ValidationContext<Record<string, unknown>>;
+      t: mockT,
+      submissionCount: 1,
+      creationSubmissionCount: 0
+    } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
     render(
       <IBANField
@@ -842,8 +876,10 @@ describe('PostalAccountField', () => {
       errors: {},
       fieldNamePrefix: 'beneficiaries',
       getValues: vi.fn().mockImplementation(() => '123456789012'),
-      t: mockT
-    } as ValidationContext<Record<string, unknown>>;
+      t: mockT,
+      submissionCount: 1,
+      creationSubmissionCount: 0
+    } as BeneficiaryValidationContext<Record<string, unknown>>;
 
     const { container } = render(
       <PostalAccountField
@@ -902,8 +938,10 @@ describe('PostalAccountField', () => {
         if (path.includes('postalAccount')) return 'INVALID';
         return '';
       }),
-      t: mockT
-    } as unknown as ValidationContext<Record<string, unknown>>;
+      t: mockT,
+      submissionCount: 1,
+      creationSubmissionCount: 0
+    } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
     render(
       <PostalAccountField
@@ -944,8 +982,10 @@ describe('TaxonomyCodeField', () => {
       errors: {},
       fieldNamePrefix: 'beneficiaries',
       getValues: vi.fn(),
-      t: mockT
-    } as ValidationContext<Record<string, unknown>>;
+      t: mockT,
+      submissionCount: 1,
+      creationSubmissionCount: 0
+    } as BeneficiaryValidationContext<Record<string, unknown>>;
 
     const { container } = render(
       <TaxonomyCodeField field={mockField} t={mockT} context={mockContext} />
@@ -996,8 +1036,10 @@ describe('TaxonomyCodeField', () => {
       errors: mockErrors,
       fieldNamePrefix: 'beneficiaries',
       getValues: vi.fn(),
-      t: mockT
-    } as unknown as ValidationContext<Record<string, unknown>>;
+      t: mockT,
+      submissionCount: 1,
+      creationSubmissionCount: 0
+    } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
     render(
       <TaxonomyCodeField field={mockField} t={mockT} context={mockContext} />
@@ -1030,8 +1072,10 @@ describe('RemittanceField', () => {
       errors: {},
       fieldNamePrefix: 'beneficiaries',
       getValues: vi.fn(),
-      t: mockT
-    } as ValidationContext<Record<string, unknown>>;
+      t: mockT,
+      submissionCount: 1,
+      creationSubmissionCount: 0
+    } as BeneficiaryValidationContext<Record<string, unknown>>;
 
     const { container } = render(
       <RemittanceField field={mockField} t={mockT} context={mockContext} />
@@ -1087,8 +1131,10 @@ describe('RemittanceField', () => {
       errors: mockErrors,
       fieldNamePrefix: 'beneficiaries',
       getValues: vi.fn().mockReturnValue(''),
-      t: mockT
-    } as unknown as ValidationContext<Record<string, unknown>>;
+      t: mockT,
+      submissionCount: 1,
+      creationSubmissionCount: 0
+    } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
     render(
       <RemittanceField field={mockField} t={mockT} context={mockContext} />
@@ -1161,8 +1207,10 @@ describe('PostalIban Components', () => {
         errors: {},
         fieldNamePrefix: mockFieldNamePrefix,
         getValues: vi.fn().mockImplementation(() => ''),
-        t: mockT
-      } as ValidationContext<Record<string, unknown>>;
+        t: mockT,
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as BeneficiaryValidationContext<Record<string, unknown>>;
 
       const result = hasPostalIbanError(mockContext, {});
       expect(result).toBe(false);
@@ -1181,8 +1229,10 @@ describe('PostalIban Components', () => {
           if (path.includes('postalIban')) return '';
           return undefined;
         }),
-        t: mockT
-      } as ValidationContext<Record<string, unknown>>;
+        t: mockT,
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as BeneficiaryValidationContext<Record<string, unknown>>;
 
       const result = hasPostalIbanError(mockContext, {});
       expect(result).toBe(false);
@@ -1211,8 +1261,10 @@ describe('PostalIban Components', () => {
           if (path.includes('postalIban')) return 'INVALID_IBAN';
           return undefined;
         }),
-        t: mockT
-      } as unknown as ValidationContext<Record<string, unknown>>;
+        t: mockT,
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
       const result = hasPostalIbanError(mockContext, mockErrors);
       expect(result).toBe(true);
@@ -1245,8 +1297,10 @@ describe('PostalIban Components', () => {
           if (path.includes('postalIban')) return 'INVALID_IBAN';
           return undefined;
         }),
-        t: mockT
-      } as unknown as ValidationContext<Record<string, unknown>>;
+        t: mockT,
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
       const result = hasPostalIbanError(mockContext, mockErrors);
       expect(result).toBe(true);
@@ -1264,8 +1318,10 @@ describe('PostalIban Components', () => {
         errors: {},
         fieldNamePrefix: mockFieldNamePrefix,
         getValues: vi.fn().mockImplementation(() => ''),
-        t: mockT
-      } as ValidationContext<Record<string, unknown>>;
+        t: mockT,
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as BeneficiaryValidationContext<Record<string, unknown>>;
 
       const result = getPostalIbanErrorMessage(mockContext, {});
       expect(result).toBe('');
@@ -1284,8 +1340,10 @@ describe('PostalIban Components', () => {
           if (path.includes('postalIban')) return '';
           return undefined;
         }),
-        t: mockT
-      } as ValidationContext<Record<string, unknown>>;
+        t: mockT,
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as BeneficiaryValidationContext<Record<string, unknown>>;
 
       const result = getPostalIbanErrorMessage(mockContext, {});
       expect(result).toBe('');
@@ -1314,8 +1372,10 @@ describe('PostalIban Components', () => {
           if (path.includes('postalIban')) return 'INVALID_IBAN';
           return undefined;
         }),
-        t: mockT
-      } as unknown as ValidationContext<Record<string, unknown>>;
+        t: mockT,
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
       const result = getPostalIbanErrorMessage(mockContext, mockErrors);
       expect(result).toBe('Invalid postalIban format');
@@ -1348,8 +1408,10 @@ describe('PostalIban Components', () => {
           if (path.includes('postalIban')) return 'INVALID_IBAN';
           return undefined;
         }),
-        t: mockT
-      } as unknown as ValidationContext<Record<string, unknown>>;
+        t: mockT,
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
       const result = getPostalIbanErrorMessage(mockContext, mockErrors);
       expect(result).toBe('Invalid postalIban in installment');
@@ -1382,8 +1444,10 @@ describe('PostalIban Components', () => {
         getValues: vi
           .fn()
           .mockImplementation(() => 'IT60X0542811101000000123456'),
-        t: mockT
-      } as ValidationContext<Record<string, unknown>>;
+        t: mockT,
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as BeneficiaryValidationContext<Record<string, unknown>>;
 
       const { container } = render(
         <PostalIbanField
@@ -1446,8 +1510,10 @@ describe('PostalIban Components', () => {
           if (path.includes('postalIban')) return 'INVALID';
           return '';
         }),
-        t: mockT
-      } as unknown as ValidationContext<Record<string, unknown>>;
+        t: mockT,
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
       render(
         <PostalIbanField
@@ -1487,8 +1553,10 @@ describe('PostalIban Components', () => {
         errors: {},
         fieldNamePrefix: 'beneficiaries',
         getValues: vi.fn().mockImplementation(() => ''),
-        t: mockT
-      } as ValidationContext<Record<string, unknown>>;
+        t: mockT,
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as BeneficiaryValidationContext<Record<string, unknown>>;
 
       const { container } = render(
         <PostalIbanField

--- a/src/routes/DebtPositionCreateWizard/components/Beneficiary/BeneficiaryFieldComponents.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Beneficiary/BeneficiaryFieldComponents.tsx
@@ -14,12 +14,12 @@ import {
   UseFormTrigger
 } from 'react-hook-form';
 import {
-  ValidationContext,
   hasFieldError,
   getFieldErrorMessage,
   shouldSkipValidation,
   buildFieldPath
 } from '../../../../utils/beneficiaryValidation';
+import type { BeneficiaryValidationContext } from '../../../../models/paymentTypes';
 import {
   handleAmountInputBlur,
   handleAmountInputChange,
@@ -175,7 +175,7 @@ export function EntityNameField<T extends FieldValues>(
     };
     t: (key: string) => string;
     disabled?: boolean;
-    context: ValidationContext<T>;
+    context: BeneficiaryValidationContext<T>;
   }>
 ) {
   const { field, t, disabled = false, context } = props;
@@ -212,7 +212,7 @@ export function AmountField<T extends FieldValues>(
     };
     t: (key: string) => string;
     disabled?: boolean;
-    context: ValidationContext<T>;
+    context: BeneficiaryValidationContext<T>;
     index: number;
     fields: Array<Record<string, unknown>>;
     trigger: UseFormTrigger<T>;
@@ -280,7 +280,7 @@ export function TaxCodeField<T extends FieldValues>(
     };
     t: (key: string) => string;
     disabled?: boolean;
-    context: ValidationContext<T>;
+    context: BeneficiaryValidationContext<T>;
   }>
 ) {
   const { field, t, disabled = false, context } = props;
@@ -317,7 +317,7 @@ export function RemittanceField<T extends FieldValues>(
     };
     t: (key: string) => string;
     disabled?: boolean;
-    context: ValidationContext<T>;
+    context: BeneficiaryValidationContext<T>;
   }>
 ) {
   const { field, t, disabled = false, context } = props;
@@ -344,7 +344,7 @@ export function RemittanceField<T extends FieldValues>(
 }
 
 export function hasIBANError<T extends FieldValues>(
-  context: ValidationContext<T>,
+  context: BeneficiaryValidationContext<T>,
   errors: FieldErrors<T>
 ): boolean {
   if (shouldSkipValidation(context)) {
@@ -405,7 +405,7 @@ export function hasIBANError<T extends FieldValues>(
 }
 
 export function hasPostalIbanError<T extends FieldValues>(
-  context: ValidationContext<T>,
+  context: BeneficiaryValidationContext<T>,
   errors: FieldErrors<T>
 ): boolean {
   if (shouldSkipValidation(context)) {
@@ -460,7 +460,7 @@ export function hasPostalIbanError<T extends FieldValues>(
 }
 
 export function getIBANErrorMessage<T extends FieldValues>(
-  context: ValidationContext<T>,
+  context: BeneficiaryValidationContext<T>,
   errors: FieldErrors<T>
 ): string {
   if (shouldSkipValidation(context)) {
@@ -534,7 +534,7 @@ export function getIBANErrorMessage<T extends FieldValues>(
 }
 
 export function getPostalIbanErrorMessage<T extends FieldValues>(
-  context: ValidationContext<T>,
+  context: BeneficiaryValidationContext<T>,
   errors: FieldErrors<T>
 ): string {
   if (shouldSkipValidation(context)) {
@@ -602,7 +602,7 @@ export function IBANField<T extends FieldValues>(
     };
     t: (key: string) => string;
     disabled?: boolean;
-    context: ValidationContext<T>;
+    context: BeneficiaryValidationContext<T>;
     index: number;
     trigger: UseFormTrigger<T>;
     fieldNamePrefix: string;
@@ -656,7 +656,7 @@ export function PostalIbanField<T extends FieldValues>(
     };
     t: (key: string) => string;
     disabled?: boolean;
-    context: ValidationContext<T>;
+    context: BeneficiaryValidationContext<T>;
     index: number;
     trigger: UseFormTrigger<T>;
     fieldNamePrefix: string;
@@ -705,7 +705,7 @@ export function PostalIbanField<T extends FieldValues>(
 }
 
 export function hasPostalAccountError<T extends FieldValues>(
-  context: ValidationContext<T>,
+  context: BeneficiaryValidationContext<T>,
   errors: FieldErrors<T>
 ): boolean {
   if (shouldSkipValidation(context)) {
@@ -770,7 +770,7 @@ export function hasPostalAccountError<T extends FieldValues>(
 }
 
 export function getPostalAccountErrorMessage<T extends FieldValues>(
-  context: ValidationContext<T>,
+  context: BeneficiaryValidationContext<T>,
   errors: FieldErrors<T>
 ): string {
   if (shouldSkipValidation(context)) {
@@ -854,7 +854,7 @@ export function PostalAccountField<T extends FieldValues>(
     };
     t: (key: string) => string;
     disabled?: boolean;
-    context: ValidationContext<T>;
+    context: BeneficiaryValidationContext<T>;
     index: number;
     trigger: UseFormTrigger<T>;
     fieldNamePrefix: string;
@@ -901,7 +901,7 @@ export function TaxonomyCodeField<T extends FieldValues>(
     };
     t: (key: string) => string;
     disabled?: boolean;
-    context: ValidationContext<T>;
+    context: BeneficiaryValidationContext<T>;
   }>
 ) {
   const { field, t, disabled = false, context } = props;

--- a/src/routes/DebtPositionCreateWizard/components/Beneficiary/BeneficiaryFieldControls/BeneficiaryAmountFields.test.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Beneficiary/BeneficiaryFieldControls/BeneficiaryAmountFields.test.tsx
@@ -89,7 +89,9 @@ describe('BeneficiaryAmountFields', () => {
       errors: {},
       fieldNamePrefix: fieldNamePrefix,
       getValues: vi.fn(),
-      t: t
+      t: t,
+      submissionCount: 0,
+      creationSubmissionCount: 0
     };
 
     render(
@@ -129,7 +131,9 @@ describe('BeneficiaryAmountFields', () => {
       errors: {},
       fieldNamePrefix: fieldNamePrefix,
       getValues: vi.fn(),
-      t: t
+      t: t,
+      submissionCount: 1,
+      creationSubmissionCount: 0
     };
 
     render(
@@ -164,7 +168,9 @@ describe('BeneficiaryAmountFields', () => {
       errors: {},
       fieldNamePrefix: fieldNamePrefix,
       getValues: vi.fn(),
-      t: t
+      t: t,
+      submissionCount: 0,
+      creationSubmissionCount: 0
     };
 
     render(

--- a/src/routes/DebtPositionCreateWizard/components/Beneficiary/BeneficiaryFieldControls/BeneficiaryClassificationFields.test.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Beneficiary/BeneficiaryFieldControls/BeneficiaryClassificationFields.test.tsx
@@ -70,7 +70,9 @@ describe('BeneficiaryClassificationFields', () => {
     errors: {},
     fieldNamePrefix: 'beneficiaries',
     getValues: vi.fn(),
-    t: mockT
+    t: mockT,
+    submissionCount: 0,
+    creationSubmissionCount: 0
   };
 
   const defaultProps = {

--- a/src/routes/DebtPositionCreateWizard/components/Installment/AmountField.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Installment/AmountField.tsx
@@ -28,6 +28,7 @@ type AmountFieldProps<T extends FieldValues> = {
   ) => void;
   trigger: UseFormTrigger<T>;
   onAmountChange: (value: string) => void;
+  showErrors?: boolean;
 };
 
 const AmountField = <T extends FieldValues>({
@@ -38,7 +39,8 @@ const AmountField = <T extends FieldValues>({
   error,
   validateInstallmentAmount,
   trigger,
-  onAmountChange
+  onAmountChange,
+  showErrors = true
 }: AmountFieldProps<T>) => {
   const { t } = useTranslation();
 
@@ -64,8 +66,8 @@ const AmountField = <T extends FieldValues>({
               style: { textAlign: 'left' }
             }
           }}
-          error={!!error}
-          helperText={error?.message || ''}
+          error={showErrors && !!error}
+          helperText={showErrors && error?.message ? error.message : ''}
           onChange={(e) => {
             const normalizedValue = handleAmountInputChange(e.target.value);
             onAmountChange(normalizedValue);

--- a/src/routes/DebtPositionCreateWizard/components/Installment/BeneficiaryControl.test.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Installment/BeneficiaryControl.test.tsx
@@ -1062,6 +1062,205 @@ describe('BeneficiaryControl', () => {
       expect(mockSetValueCopy).toHaveBeenCalled();
     });
   });
+
+  test('should pass submissionCount prop to BeneficiaryField', () => {
+    const testSubmissionCount = 5;
+
+    render(
+      <BeneficiaryControl<TestFormData>
+        index={0}
+        control={mockControl}
+        errors={mockErrors}
+        isSubmitted={true}
+        fieldNamePrefix="installments"
+        getValues={mockGetValues}
+        setValue={mockSetValue}
+        trigger={mockTrigger}
+        isMultibeneficiary={true}
+        toggleMultibeneficiary={mockToggleMultibeneficiary}
+        submissionCount={testSubmissionCount}
+      />
+    );
+
+    // Verify BeneficiaryField component exists
+    expect(screen.getByTestId('beneficiary-field')).toBeInTheDocument();
+  });
+
+  test('should pass hasClickedFinalCTA (isSubmitted) to BeneficiaryField correctly', () => {
+    render(
+      <BeneficiaryControl<TestFormData>
+        index={0}
+        control={mockControl}
+        errors={mockErrors}
+        isSubmitted={true}
+        fieldNamePrefix="installments"
+        getValues={mockGetValues}
+        setValue={mockSetValue}
+        trigger={mockTrigger}
+        isMultibeneficiary={true}
+        toggleMultibeneficiary={mockToggleMultibeneficiary}
+      />
+    );
+
+    // Verify that the component renders with isSubmitted=true passed as hasClickedFinalCTA
+    expect(screen.getByTestId('beneficiary-field')).toBeInTheDocument();
+  });
+
+  test('should handle empty beneficiaries array when copying', async () => {
+    const mockGetValuesEmpty = createMockGetValuesWithConsistentReturn({
+      installment0: {
+        isMultibeneficiary: true,
+        beneficiaries: []
+      },
+      installment1Amount: '100,00',
+      sameBeneficiariesAsBefore: false
+    });
+
+    const mockSetValueEmpty = vi.fn();
+
+    render(
+      <BeneficiaryControl<TestFormData>
+        index={1}
+        control={mockControl}
+        errors={mockErrors}
+        isSubmitted={false}
+        fieldNamePrefix="installments"
+        getValues={
+          mockGetValuesEmpty as unknown as UseFormGetValues<TestFormData>
+        }
+        setValue={mockSetValueEmpty}
+        trigger={mockTrigger}
+        isMultibeneficiary={true}
+        toggleMultibeneficiary={mockToggleMultibeneficiary}
+      />
+    );
+
+    // When previous beneficiaries are empty, radio buttons should not be shown
+    expect(
+      screen.queryByText(
+        'Are the beneficiaries the same as the previous installment?'
+      )
+    ).not.toBeInTheDocument();
+
+    expect(screen.queryByText('Yes')).not.toBeInTheDocument();
+    expect(screen.queryByText('No')).not.toBeInTheDocument();
+
+    // But BeneficiaryField should still be shown for creating new beneficiaries
+    expect(screen.getByTestId('beneficiary-field')).toBeInTheDocument();
+  });
+
+  test('should handle malformed beneficiary data gracefully', async () => {
+    const mockGetValuesMalformed = vi
+      .fn()
+      .mockImplementation((path: string): unknown => {
+        if (path === 'installments.0') {
+          return { isMultibeneficiary: true, beneficiaries: null } as unknown; // malformed data
+        }
+        if (path === 'installments.1.amount') {
+          return '100,00' as unknown;
+        }
+        return undefined as unknown;
+      });
+
+    render(
+      <BeneficiaryControl<TestFormData>
+        index={1}
+        control={mockControl}
+        errors={mockErrors}
+        isSubmitted={false}
+        fieldNamePrefix="installments"
+        getValues={
+          mockGetValuesMalformed as unknown as UseFormGetValues<TestFormData>
+        }
+        setValue={mockSetValue}
+        trigger={mockTrigger}
+        isMultibeneficiary={true}
+        toggleMultibeneficiary={mockToggleMultibeneficiary}
+      />
+    );
+
+    // Should not show radio buttons when beneficiaries data is malformed
+    expect(
+      screen.queryByText(
+        'Are the beneficiaries the same as the previous installment?'
+      )
+    ).not.toBeInTheDocument();
+  });
+
+  test('should handle default submissionCount when prop is not provided', () => {
+    render(
+      <BeneficiaryControl<TestFormData>
+        index={0}
+        control={mockControl}
+        errors={mockErrors}
+        isSubmitted={false}
+        fieldNamePrefix="installments"
+        getValues={mockGetValues}
+        setValue={mockSetValue}
+        trigger={mockTrigger}
+        isMultibeneficiary={true}
+        toggleMultibeneficiary={mockToggleMultibeneficiary}
+        // submissionCount not provided - should default to 0
+      />
+    );
+
+    expect(screen.getByTestId('beneficiary-field')).toBeInTheDocument();
+  });
+
+  test('should handle radio button interaction without errors', () => {
+    const mockGetValuesForRadio = createMockGetValuesWithConsistentReturn({
+      installment0: {
+        isMultibeneficiary: true,
+        beneficiaries: [
+          { amount: '50,00', denomination: 'Previous beneficiary' }
+        ]
+      },
+      installment1Amount: '100,00',
+      sameBeneficiariesAsBefore: false
+    });
+
+    render(
+      <BeneficiaryControl<TestFormData>
+        index={1}
+        control={mockControl}
+        errors={mockErrors}
+        isSubmitted={false}
+        fieldNamePrefix="installments"
+        getValues={
+          mockGetValuesForRadio as unknown as UseFormGetValues<TestFormData>
+        }
+        setValue={mockSetValue}
+        trigger={mockTrigger}
+        isMultibeneficiary={true}
+        toggleMultibeneficiary={mockToggleMultibeneficiary}
+        isEditing={false}
+      />
+    );
+
+    // Should show radio buttons
+    expect(
+      screen.getByText(
+        'Are the beneficiaries the same as the previous installment?'
+      )
+    ).toBeInTheDocument();
+
+    const yesRadio = screen.getByText('Yes');
+    const noRadio = screen.getByText('No');
+
+    expect(yesRadio).toBeInTheDocument();
+    expect(noRadio).toBeInTheDocument();
+
+    // Should be able to click radio buttons without errors
+    fireEvent.click(yesRadio);
+    fireEvent.click(noRadio);
+
+    // Component should still be in the document after interactions
+    expect(
+      screen.getByText(
+        'Are the beneficiaries the same as the previous installment?'
+      )
+    ).toBeInTheDocument();
+  });
 });
 
 type BeneficiaryType = {

--- a/src/routes/DebtPositionCreateWizard/components/Installment/BeneficiaryControl.test.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Installment/BeneficiaryControl.test.tsx
@@ -227,7 +227,7 @@ describe('BeneficiaryControl', () => {
         index={0}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={mockGetValues}
         setValue={mockSetValue}
@@ -247,7 +247,7 @@ describe('BeneficiaryControl', () => {
         index={0}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={mockGetValues}
         setValue={mockSetValue}
@@ -278,7 +278,7 @@ describe('BeneficiaryControl', () => {
         index={1}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={
           mockGetValuesForTest as unknown as UseFormGetValues<TestFormData>
@@ -305,7 +305,7 @@ describe('BeneficiaryControl', () => {
         index={0}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={mockGetValues}
         setValue={mockSetValue}
@@ -353,7 +353,7 @@ describe('BeneficiaryControl', () => {
         index={1}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={getValuesMock as unknown as UseFormGetValues<TestFormData>}
         setValue={mockSetValue}
@@ -419,7 +419,7 @@ describe('BeneficiaryControl', () => {
         index={1}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={getValuesMock as unknown as UseFormGetValues<TestFormData>}
         setValue={mockSetValue}
@@ -454,7 +454,7 @@ describe('BeneficiaryControl', () => {
         index={0}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={mockGetValues}
         setValue={mockSetValue}
@@ -474,7 +474,7 @@ describe('BeneficiaryControl', () => {
         index={0}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={mockGetValues}
         setValue={mockSetValue}
@@ -506,7 +506,7 @@ describe('BeneficiaryControl', () => {
         index={1}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={
           getValuesNoPrevBeneficiaries as unknown as UseFormGetValues<TestFormData>
@@ -545,7 +545,7 @@ describe('BeneficiaryControl', () => {
         index={1}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={
           getValuesWithExistingBeneficiaries as unknown as UseFormGetValues<TestFormData>
@@ -599,7 +599,7 @@ describe('BeneficiaryControl', () => {
         index={1}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={
           getValuesWithShowForm as unknown as UseFormGetValues<TestFormData>
@@ -652,7 +652,7 @@ describe('BeneficiaryControl', () => {
         index={1}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={
           getValuesWithAmountsAndBeneficiaries as unknown as UseFormGetValues<TestFormData>
@@ -703,7 +703,7 @@ describe('BeneficiaryControl', () => {
         index={1}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={
           mockGetValuesAutoDefault as unknown as UseFormGetValues<TestFormData>
@@ -750,7 +750,7 @@ describe('BeneficiaryControl', () => {
         index={1}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={
           mockGetValuesEditing as unknown as UseFormGetValues<TestFormData>
@@ -789,7 +789,7 @@ describe('BeneficiaryControl', () => {
         index={1}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={
           mockGetValuesNoPrev as unknown as UseFormGetValues<TestFormData>
@@ -828,7 +828,7 @@ describe('BeneficiaryControl', () => {
         index={1}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={
           mockGetValuesEditingForm as unknown as UseFormGetValues<TestFormData>
@@ -868,7 +868,7 @@ describe('BeneficiaryControl', () => {
         index={0}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={mockGetValues}
         setValue={mockSetValue}
@@ -894,7 +894,7 @@ describe('BeneficiaryControl', () => {
         index={1}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={mockGetValues}
         setValue={mockSetValue}
@@ -924,7 +924,7 @@ describe('BeneficiaryControl', () => {
         index={1}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={
           mockGetValuesNoValidBeneficiaries as unknown as UseFormGetValues<TestFormData>
@@ -960,7 +960,7 @@ describe('BeneficiaryControl', () => {
         index={1}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={
           mockGetValuesNull as unknown as UseFormGetValues<TestFormData>
@@ -997,7 +997,7 @@ describe('BeneficiaryControl', () => {
         index={1}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={
           mockGetValuesForDefault as unknown as UseFormGetValues<TestFormData>
@@ -1042,7 +1042,7 @@ describe('BeneficiaryControl', () => {
         index={1}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={
           mockGetValuesCopyTest as unknown as UseFormGetValues<TestFormData>
@@ -1071,7 +1071,7 @@ describe('BeneficiaryControl', () => {
         index={0}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={true}
+        shouldShowErrors={() => true}
         fieldNamePrefix="installments"
         getValues={mockGetValues}
         setValue={mockSetValue}
@@ -1086,13 +1086,13 @@ describe('BeneficiaryControl', () => {
     expect(screen.getByTestId('beneficiary-field')).toBeInTheDocument();
   });
 
-  test('should pass hasClickedFinalCTA (isSubmitted) to BeneficiaryField correctly', () => {
+  test('should pass shouldShowErrors to BeneficiaryField correctly', () => {
     render(
       <BeneficiaryControl<TestFormData>
         index={0}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={true}
+        shouldShowErrors={() => true}
         fieldNamePrefix="installments"
         getValues={mockGetValues}
         setValue={mockSetValue}
@@ -1123,7 +1123,7 @@ describe('BeneficiaryControl', () => {
         index={1}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={
           mockGetValuesEmpty as unknown as UseFormGetValues<TestFormData>
@@ -1167,7 +1167,7 @@ describe('BeneficiaryControl', () => {
         index={1}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={
           mockGetValuesMalformed as unknown as UseFormGetValues<TestFormData>
@@ -1193,7 +1193,7 @@ describe('BeneficiaryControl', () => {
         index={0}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={mockGetValues}
         setValue={mockSetValue}
@@ -1224,7 +1224,7 @@ describe('BeneficiaryControl', () => {
         index={1}
         control={mockControl}
         errors={mockErrors}
-        isSubmitted={false}
+        shouldShowErrors={() => false}
         fieldNamePrefix="installments"
         getValues={
           mockGetValuesForRadio as unknown as UseFormGetValues<TestFormData>

--- a/src/routes/DebtPositionCreateWizard/components/Installment/BeneficiaryControl.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Installment/BeneficiaryControl.tsx
@@ -48,7 +48,8 @@ const BeneficiaryControl = <T extends FieldValues>({
   toggleMultibeneficiary,
   isEditing = false,
   submissionCount = 0,
-  shouldShowErrors
+  shouldShowErrors,
+  installmentFieldId
 }: {
   index: number;
   control: Control<T>;
@@ -379,7 +380,8 @@ const BeneficiaryControl = <T extends FieldValues>({
     setValue,
     sameBeneficiariesAsBeforePath,
     copyBeneficiariesFromPreviousInstallment,
-    isEditing
+    isEditing,
+    installmentFieldId
   ]);
 
   /**
@@ -410,7 +412,8 @@ const BeneficiaryControl = <T extends FieldValues>({
     hasPreviousBeneficiaries,
     sameBeneficiariesAsBeforePath,
     copyBeneficiariesFromPreviousInstallment,
-    isEditing
+    isEditing,
+    installmentFieldId
   ]);
 
   /**

--- a/src/routes/DebtPositionCreateWizard/components/Installment/BeneficiaryControl.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Installment/BeneficiaryControl.tsx
@@ -47,7 +47,10 @@ const BeneficiaryControl = <T extends FieldValues>({
   trigger,
   isMultibeneficiary,
   toggleMultibeneficiary,
-  isEditing = false
+  isEditing = false,
+  submissionCount = 0,
+  existingInstallments = {},
+  installmentFieldId
 }: {
   index: number;
   control: Control<T>;
@@ -61,6 +64,9 @@ const BeneficiaryControl = <T extends FieldValues>({
   isMultibeneficiary: boolean;
   toggleMultibeneficiary: (value: boolean) => void;
   isEditing?: boolean;
+  submissionCount?: number;
+  existingInstallments?: Record<string, boolean>;
+  installmentFieldId?: string;
 }) => {
   const { t } = useTranslation();
 
@@ -579,24 +585,40 @@ const BeneficiaryControl = <T extends FieldValues>({
 
       {isMultibeneficiary && showBeneficiaryForm && (
         <Grid item xs={12} mt={1}>
-          <BeneficiaryField
-            control={control}
-            errors={errors}
-            isSubmitted={isSubmitted}
-            totalAmount={getValues(amountPath) || ''}
-            fieldNamePrefix={
-              `${fieldNamePrefix}.${index}.beneficiaries` as FieldArrayPath<T>
-            }
-            disabled={false}
-            setValue={setValue}
-            getValues={getValues}
-            trigger={trigger}
-            onToggleMultibeneficiary={toggleMultibeneficiary}
-            isInsideInstallment={true}
-            installmentIndex={index}
-            installmentsFieldNamePrefix={fieldNamePrefix}
-            isEditing={isEditing}
-          />
+          {(() => {
+            // Check if this installment was created after submit using the real field ID
+            const installmentWasCreatedAfterSubmit =
+              submissionCount > 0 &&
+              installmentFieldId &&
+              !existingInstallments[installmentFieldId];
+            const shouldShowBeneficiaryErrors =
+              isSubmitted && !installmentWasCreatedAfterSubmit;
+
+            // Store the shouldShowBeneficiaryErrors in a way we can access it below
+            return (
+              <BeneficiaryField
+                control={control}
+                errors={errors}
+                isSubmitted={shouldShowBeneficiaryErrors}
+                totalAmount={getValues(amountPath) || ''}
+                fieldNamePrefix={
+                  `${fieldNamePrefix}.${index}.beneficiaries` as FieldArrayPath<T>
+                }
+                disabled={false}
+                setValue={setValue}
+                getValues={getValues}
+                trigger={trigger}
+                onToggleMultibeneficiary={toggleMultibeneficiary}
+                isInsideInstallment={true}
+                installmentIndex={index}
+                installmentsFieldNamePrefix={fieldNamePrefix}
+                isEditing={isEditing}
+                hasClickedFinalCTA={shouldShowBeneficiaryErrors}
+                submissionCount={submissionCount}
+                creationSubmissionCount={submissionCount}
+              />
+            );
+          })()}
         </Grid>
       )}
     </>

--- a/src/routes/DebtPositionCreateWizard/components/Installment/BeneficiaryControl.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Installment/BeneficiaryControl.tsx
@@ -39,7 +39,6 @@ const BeneficiaryControl = <T extends FieldValues>({
   index,
   control,
   errors,
-  isSubmitted,
   fieldNamePrefix,
   disabled = false,
   getValues,
@@ -49,13 +48,11 @@ const BeneficiaryControl = <T extends FieldValues>({
   toggleMultibeneficiary,
   isEditing = false,
   submissionCount = 0,
-  existingInstallments = {},
-  installmentFieldId
+  shouldShowErrors
 }: {
   index: number;
   control: Control<T>;
   errors: FieldErrors<T>;
-  isSubmitted: boolean;
   fieldNamePrefix: string;
   disabled?: boolean;
   getValues: UseFormGetValues<T>;
@@ -67,6 +64,7 @@ const BeneficiaryControl = <T extends FieldValues>({
   submissionCount?: number;
   existingInstallments?: Record<string, boolean>;
   installmentFieldId?: string;
+  shouldShowErrors?: (componentCreationCount?: number) => boolean;
 }) => {
   const { t } = useTranslation();
 
@@ -587,19 +585,12 @@ const BeneficiaryControl = <T extends FieldValues>({
         <Grid item xs={12} mt={1}>
           {(() => {
             // Check if this installment was created after submit using the real field ID
-            const installmentWasCreatedAfterSubmit =
-              submissionCount > 0 &&
-              installmentFieldId &&
-              !existingInstallments[installmentFieldId];
-            const shouldShowBeneficiaryErrors =
-              isSubmitted && !installmentWasCreatedAfterSubmit;
-
-            // Store the shouldShowBeneficiaryErrors in a way we can access it below
+            // Pass the centralized shouldShowErrors to BeneficiaryField
             return (
               <BeneficiaryField
                 control={control}
                 errors={errors}
-                isSubmitted={shouldShowBeneficiaryErrors}
+                isSubmitted={false}
                 totalAmount={getValues(amountPath) || ''}
                 fieldNamePrefix={
                   `${fieldNamePrefix}.${index}.beneficiaries` as FieldArrayPath<T>
@@ -613,7 +604,7 @@ const BeneficiaryControl = <T extends FieldValues>({
                 installmentIndex={index}
                 installmentsFieldNamePrefix={fieldNamePrefix}
                 isEditing={isEditing}
-                hasClickedFinalCTA={shouldShowBeneficiaryErrors}
+                shouldShowErrors={shouldShowErrors}
                 submissionCount={submissionCount}
                 creationSubmissionCount={submissionCount}
               />

--- a/src/routes/DebtPositionCreateWizard/components/Installment/DateField.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Installment/DateField.tsx
@@ -20,6 +20,7 @@ type DateFieldProps<T extends FieldValues> = {
   validateDueDate: (index: number, trigger: UseFormTrigger<T>) => void;
   trigger: UseFormTrigger<T>;
   flagMandatoryDueDate?: boolean;
+  showErrors?: boolean;
 };
 
 const DateField = <T extends FieldValues>({
@@ -29,7 +30,8 @@ const DateField = <T extends FieldValues>({
   disabled = false,
   validateDueDate,
   trigger,
-  flagMandatoryDueDate = true
+  flagMandatoryDueDate = true,
+  showErrors = true
 }: DateFieldProps<T>) => {
   const { t } = useTranslation();
 
@@ -74,8 +76,8 @@ const DateField = <T extends FieldValues>({
                 id: `installment-due-date-${index}`,
                 fullWidth: true,
                 required: flagMandatoryDueDate,
-                error: !!error,
-                helperText: error?.message || '',
+                error: showErrors && !!error,
+                helperText: showErrors && error?.message ? error.message : '',
                 size: 'small'
               },
               actionBar: {

--- a/src/routes/DebtPositionCreateWizard/components/Installment/InstallmentField.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Installment/InstallmentField.tsx
@@ -44,6 +44,8 @@ type InstallmentFieldProps<T extends FieldValues> = {
   readonly flagMandatoryDueDate?: boolean;
   readonly onInstallmentsChange?: (totalAmount: string) => void;
   readonly isEditing?: boolean;
+  readonly hasClickedFinalCTA?: boolean;
+  readonly submissionCount?: number;
 };
 
 /**
@@ -61,7 +63,9 @@ function InstallmentField<T extends FieldValues>({
   disabled = false,
   flagMandatoryDueDate = true,
   onInstallmentsChange,
-  isEditing = false
+  isEditing = false,
+  hasClickedFinalCTA = false,
+  submissionCount = 0
 }: InstallmentFieldProps<T>) {
   const { t } = useTranslation();
 
@@ -70,7 +74,8 @@ function InstallmentField<T extends FieldValues>({
     MIN_INSTALLMENTS,
     MAX_INSTALLMENTS,
     addInstallment,
-    removeInstallment
+    removeInstallment,
+    existingInstallments
   } = useInstallmentManagement<T>({
     control,
     fieldNamePrefix: fieldNamePrefix as FieldArrayPath<T>,
@@ -79,6 +84,7 @@ function InstallmentField<T extends FieldValues>({
     setValue,
     trigger,
     flagMandatoryDueDate,
+    submissionCount,
     onInstallmentsChange: (_installments, totalAmount) => {
       if (onInstallmentsChange) {
         onInstallmentsChange(totalAmount);
@@ -163,6 +169,9 @@ function InstallmentField<T extends FieldValues>({
                 flagMandatoryDueDate={flagMandatoryDueDate}
                 isEditing={isEditing}
                 readonlyProps={readonlyProps}
+                hasClickedFinalCTA={hasClickedFinalCTA}
+                submissionCount={submissionCount}
+                existingInstallments={existingInstallments}
               />
             </Grid>
           );

--- a/src/routes/DebtPositionCreateWizard/components/Installment/InstallmentField.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Installment/InstallmentField.tsx
@@ -44,8 +44,8 @@ type InstallmentFieldProps<T extends FieldValues> = {
   readonly flagMandatoryDueDate?: boolean;
   readonly onInstallmentsChange?: (totalAmount: string) => void;
   readonly isEditing?: boolean;
-  readonly hasClickedFinalCTA?: boolean;
-  readonly submissionCount?: number;
+  readonly shouldShowErrors?: (componentCreationCount?: number) => boolean;
+  readonly submissionCount?: number; // Still needed for creation tracking
 };
 
 /**
@@ -64,7 +64,7 @@ function InstallmentField<T extends FieldValues>({
   flagMandatoryDueDate = true,
   onInstallmentsChange,
   isEditing = false,
-  hasClickedFinalCTA = false,
+  shouldShowErrors,
   submissionCount = 0
 }: InstallmentFieldProps<T>) {
   const { t } = useTranslation();
@@ -169,7 +169,7 @@ function InstallmentField<T extends FieldValues>({
                 flagMandatoryDueDate={flagMandatoryDueDate}
                 isEditing={isEditing}
                 readonlyProps={readonlyProps}
-                hasClickedFinalCTA={hasClickedFinalCTA}
+                shouldShowErrors={shouldShowErrors}
                 submissionCount={submissionCount}
                 existingInstallments={existingInstallments}
               />

--- a/src/routes/DebtPositionCreateWizard/components/Installment/InstallmentItem.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Installment/InstallmentItem.tsx
@@ -66,8 +66,8 @@ type InstallmentItemProps<T extends FieldValues> = {
     remittance?: boolean;
     isMultibeneficiary?: boolean;
   };
-  readonly hasClickedFinalCTA?: boolean;
-  readonly submissionCount?: number;
+  readonly shouldShowErrors?: (componentCreationCount?: number) => boolean;
+  readonly submissionCount?: number; // Still needed for creation tracking
   readonly existingInstallments?: Record<string, boolean>;
 };
 
@@ -92,7 +92,7 @@ const InstallmentItem = <T extends FieldValues>({
   flagMandatoryDueDate = true,
   isEditing,
   readonlyProps,
-  hasClickedFinalCTA = false,
+  shouldShowErrors,
   submissionCount = 0,
   existingInstallments = {}
 }: InstallmentItemProps<T>) => {
@@ -126,10 +126,14 @@ const InstallmentItem = <T extends FieldValues>({
     submissionCount > 0 && !existingInstallments[field.id];
 
   // Show errors only if installment existed at submit time
-  const shouldShowErrors = hasClickedFinalCTA && !wasCreatedAfterSubmit;
+  // Pass 0 for existing installments, current submissionCount for new ones
+  const componentCreationCount = wasCreatedAfterSubmit ? submissionCount : 0;
+  const shouldShowFieldErrors = shouldShowErrors
+    ? shouldShowErrors(componentCreationCount)
+    : false;
   const fieldErrors = errors[fieldNamePrefix as keyof typeof errors];
   const amountErrors =
-    shouldShowErrors && fieldErrors && index in fieldErrors
+    shouldShowFieldErrors && fieldErrors && index in fieldErrors
       ? (
           fieldErrors as Record<
             number,
@@ -144,7 +148,7 @@ const InstallmentItem = <T extends FieldValues>({
         )[index]?.amount
       : undefined;
   const dueDateErrors =
-    shouldShowErrors && fieldErrors && index in fieldErrors
+    shouldShowFieldErrors && fieldErrors && index in fieldErrors
       ? (
           fieldErrors as Record<
             number,
@@ -159,7 +163,7 @@ const InstallmentItem = <T extends FieldValues>({
         )[index]?.dueDate
       : undefined;
   const remittanceErrors =
-    shouldShowErrors && fieldErrors && index in fieldErrors
+    shouldShowFieldErrors && fieldErrors && index in fieldErrors
       ? (
           fieldErrors as Record<
             number,
@@ -229,7 +233,7 @@ const InstallmentItem = <T extends FieldValues>({
               validateInstallmentAmount={validators.validateInstallmentAmount}
               trigger={trigger}
               onAmountChange={handleInstallmentAmountChange}
-              showErrors={shouldShowErrors}
+              showErrors={shouldShowFieldErrors}
             />
           </Grid>
 
@@ -244,7 +248,7 @@ const InstallmentItem = <T extends FieldValues>({
               validateDueDate={validators.validateDueDate}
               trigger={trigger}
               flagMandatoryDueDate={flagMandatoryDueDate}
-              showErrors={shouldShowErrors}
+              showErrors={shouldShowFieldErrors}
             />
           </Grid>
 
@@ -258,7 +262,7 @@ const InstallmentItem = <T extends FieldValues>({
               error={remittanceErrors}
               validateRemittance={validators.validateRemittance}
               trigger={trigger}
-              showErrors={shouldShowErrors}
+              showErrors={shouldShowFieldErrors}
             />
           </Grid>
 
@@ -267,7 +271,6 @@ const InstallmentItem = <T extends FieldValues>({
             index={index}
             control={control}
             errors={errors}
-            isSubmitted={hasClickedFinalCTA}
             fieldNamePrefix={fieldNamePrefix}
             disabled={disabled || readonlyProps?.isMultibeneficiary}
             getValues={getValues}
@@ -279,6 +282,7 @@ const InstallmentItem = <T extends FieldValues>({
             submissionCount={submissionCount}
             existingInstallments={existingInstallments}
             installmentFieldId={field.id}
+            shouldShowErrors={shouldShowErrors}
           />
         </Grid>
       </Box>

--- a/src/routes/DebtPositionCreateWizard/components/Installment/InstallmentItem.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Installment/InstallmentItem.tsx
@@ -66,6 +66,9 @@ type InstallmentItemProps<T extends FieldValues> = {
     remittance?: boolean;
     isMultibeneficiary?: boolean;
   };
+  readonly hasClickedFinalCTA?: boolean;
+  readonly submissionCount?: number;
+  readonly existingInstallments?: Record<string, boolean>;
 };
 
 /**
@@ -75,6 +78,7 @@ type InstallmentItemProps<T extends FieldValues> = {
  */
 const InstallmentItem = <T extends FieldValues>({
   index,
+  field,
   control,
   errors,
   isSubmitted,
@@ -87,7 +91,10 @@ const InstallmentItem = <T extends FieldValues>({
   onRemove,
   flagMandatoryDueDate = true,
   isEditing,
-  readonlyProps
+  readonlyProps,
+  hasClickedFinalCTA = false,
+  submissionCount = 0,
+  existingInstallments = {}
 }: InstallmentItemProps<T>) => {
   const { t } = useTranslation();
 
@@ -111,10 +118,18 @@ const InstallmentItem = <T extends FieldValues>({
   const dueDatePath = `${fieldNamePrefix}.${index}.dueDate` as Path<T>;
   const remittancePath = `${fieldNamePrefix}.${index}.remittance` as Path<T>;
 
-  // Typed access to errors
+  // Track if this installment was created after the final CTA was clicked
+  // An installment is considered "created after submit" if:
+  // 1. A submit has already happened (submissionCount > 0)
+  // 2. This installment was NOT in the existingInstallments registry (wasn't present at submit time)
+  const wasCreatedAfterSubmit =
+    submissionCount > 0 && !existingInstallments[field.id];
+
+  // Show errors only if installment existed at submit time
+  const shouldShowErrors = hasClickedFinalCTA && !wasCreatedAfterSubmit;
   const fieldErrors = errors[fieldNamePrefix as keyof typeof errors];
   const amountErrors =
-    fieldErrors && index in fieldErrors
+    shouldShowErrors && fieldErrors && index in fieldErrors
       ? (
           fieldErrors as Record<
             number,
@@ -129,7 +144,7 @@ const InstallmentItem = <T extends FieldValues>({
         )[index]?.amount
       : undefined;
   const dueDateErrors =
-    fieldErrors && index in fieldErrors
+    shouldShowErrors && fieldErrors && index in fieldErrors
       ? (
           fieldErrors as Record<
             number,
@@ -144,7 +159,7 @@ const InstallmentItem = <T extends FieldValues>({
         )[index]?.dueDate
       : undefined;
   const remittanceErrors =
-    fieldErrors && index in fieldErrors
+    shouldShowErrors && fieldErrors && index in fieldErrors
       ? (
           fieldErrors as Record<
             number,
@@ -214,6 +229,7 @@ const InstallmentItem = <T extends FieldValues>({
               validateInstallmentAmount={validators.validateInstallmentAmount}
               trigger={trigger}
               onAmountChange={handleInstallmentAmountChange}
+              showErrors={shouldShowErrors}
             />
           </Grid>
 
@@ -228,10 +244,11 @@ const InstallmentItem = <T extends FieldValues>({
               validateDueDate={validators.validateDueDate}
               trigger={trigger}
               flagMandatoryDueDate={flagMandatoryDueDate}
+              showErrors={shouldShowErrors}
             />
           </Grid>
 
-          {/* Remittance Field - Campo causale */}
+          {/* Remittance Field - Remittance field */}
           <Grid item xs={12}>
             <RemittanceField<T>
               control={control}
@@ -241,6 +258,7 @@ const InstallmentItem = <T extends FieldValues>({
               error={remittanceErrors}
               validateRemittance={validators.validateRemittance}
               trigger={trigger}
+              showErrors={shouldShowErrors}
             />
           </Grid>
 
@@ -249,7 +267,7 @@ const InstallmentItem = <T extends FieldValues>({
             index={index}
             control={control}
             errors={errors}
-            isSubmitted={isSubmitted}
+            isSubmitted={hasClickedFinalCTA}
             fieldNamePrefix={fieldNamePrefix}
             disabled={disabled || readonlyProps?.isMultibeneficiary}
             getValues={getValues}
@@ -258,6 +276,9 @@ const InstallmentItem = <T extends FieldValues>({
             isMultibeneficiary={isMultibeneficiary}
             toggleMultibeneficiary={toggleMultibeneficiary}
             isEditing={isEditing}
+            submissionCount={submissionCount}
+            existingInstallments={existingInstallments}
+            installmentFieldId={field.id}
           />
         </Grid>
       </Box>

--- a/src/routes/DebtPositionCreateWizard/components/Installment/InstallmentItem.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Installment/InstallmentItem.tsx
@@ -268,6 +268,7 @@ const InstallmentItem = <T extends FieldValues>({
 
           {/* Beneficiary Controls - Using extracted component */}
           <BeneficiaryControl<T>
+            key={`beneficiary-control-${field.id}-${index}`}
             index={index}
             control={control}
             errors={errors}

--- a/src/routes/DebtPositionCreateWizard/components/Installment/RemittanceField.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Installment/RemittanceField.tsx
@@ -18,6 +18,7 @@ type RemittanceFieldProps<T extends FieldValues> = {
   };
   validateRemittance?: (index: number, trigger: UseFormTrigger<T>) => void;
   trigger: UseFormTrigger<T>;
+  showErrors?: boolean;
 };
 
 /**
@@ -30,7 +31,8 @@ const RemittanceField = <T extends FieldValues>({
   disabled = false,
   error,
   validateRemittance,
-  trigger
+  trigger,
+  showErrors = true
 }: RemittanceFieldProps<T>) => {
   const { t } = useTranslation();
 
@@ -56,8 +58,8 @@ const RemittanceField = <T extends FieldValues>({
           required
           disabled={disabled}
           value={field.value || ''}
-          error={!!error}
-          helperText={error?.message || ''}
+          error={showErrors && !!error}
+          helperText={showErrors && error?.message ? error.message : ''}
           onChange={(e) => {
             field.onChange(e.target.value);
           }}

--- a/src/routes/DebtPositionCreateWizard/components/Step/Step3.test.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step/Step3.test.tsx
@@ -1,2092 +1,655 @@
-import React from 'react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '../../../../__tests__/renderers';
+import userEvent from '@testing-library/user-event';
 import Step3 from './Step3';
 import {
+  Step3Data,
   Step1Data,
   Step2Data,
-  Step3Data,
   DebtPositionTypeEnum
 } from '../../../../models/DebtPositionType';
-import {
-  PaymentOptionTypeEnum,
-  DebtPositionStatus
-} from '../../../../../generated/data-contracts';
-import { MemoryRouter } from 'react-router';
-import { useStore } from '../../../../store/GlobalStore';
-import debtPositionsApi from '../../../../api/debtPositions';
+import type { Beneficiary, Installment } from '../../../../models/paymentTypes';
 
-// Import the mocked utility to access directly in tests
-import * as paymentUtility from '../../../../utils/paymentUtility';
-import * as installmentValidation from '../../../../utils/paymentUtility';
-
-vi.mock('react-i18next', () => ({
-  useTranslation: () => ({
-    t: (key: string) => {
-      const translations: Record<string, string> = {
-        'debtPositionCreateWizard.configurationAlert.title': 'Configuration',
-        'debtPositionCreateWizard.configurationAlert.subtitle':
-          'Configure debt position',
-        'debtPositionCreateWizard.step3.title': 'Payment Options',
-        'debtPositionCreateWizard.step3.paymentObject.label': 'Payment Object',
-        'debtPositionCreateWizard.step3.paymentOption.label': 'Payment Option',
-        'debtPositionCreateWizard.step3.paymentOption.single': 'Single Payment',
-        'debtPositionCreateWizard.step3.paymentOption.installments':
-          'Installments',
-        'debtPositionCreateWizard.step3.amount.label': 'Amount',
-        'debtPositionCreateWizard.step3.amount.installmentHelperText':
-          'The amount will be calculated from installments',
-        'debtPositionCreateWizard.step3.dueDate.label': 'Due Date',
-        'debtPositionCreateWizard.step3.dueDate.required':
-          'Due date is required',
-        'debtPositionCreateWizard.step3.isMultibeneficiary.label':
-          'Multiple Beneficiaries',
-        'debtPositionCreateWizard.step3.error.subtitle':
-          'Error creating debt position',
-        'commons.create': 'Create',
-        'commons.save': 'Save',
-        'commons.saveDraft': 'Save Draft'
-      };
-      return translations[key] || key;
-    }
-  })
+vi.mock('../../../../hooks/useStep3ApiOperations', () => ({
+  useStep3ApiOperations: vi.fn(() => ({
+    handleEditModeFlow: vi.fn(),
+    handleCreateModeFlow: vi.fn(),
+    lastActionWasPublish: { current: false }
+  }))
 }));
 
-vi.mock('react-router', async (importOriginal) => {
-  const actual = (await importOriginal()) as object;
-  return {
-    ...actual,
-    useNavigate: () => vi.fn(),
-    Navigate: ({ to }: { to: string }) => (
-      <div data-testid="navigate" data-to={to}>
-        Navigate
-      </div>
-    )
-  };
-});
+vi.mock('../../../../hooks/useStep3FormHandlers', () => ({
+  useStep3FormHandlers: vi.fn(() => ({
+    handleAmountChange: vi.fn(),
+    handleAmountBlur: vi.fn(),
+    handlePaymentOptionChange: vi.fn(),
+    handleMultibeneficiaryToggle: vi.fn()
+  }))
+}));
 
-vi.mock('../../../../store/GlobalStore', () => ({
-  useStore: vi.fn()
+vi.mock('../../../../utils/step3ValidationUtils', () => ({
+  validateFormFields: vi.fn(() => Promise.resolve(true)),
+  validateBusinessLogic: vi.fn(() =>
+    Promise.resolve({
+      isValid: true,
+      syncedInstallments: []
+    })
+  ),
+  createValidateInstallmentsData: vi.fn(() =>
+    vi.fn(() =>
+      Promise.resolve({
+        isValid: true,
+        syncedInstallments: []
+      })
+    )
+  )
+}));
+
+vi.mock('../../../../utils/step3FormDataUtils', () => ({
+  hasActualDataToPopulate: vi.fn(() => false),
+  populateAllFormFields: vi.fn(() => ({ hasPopulatedSomething: false })),
+  prepareFormData: vi.fn((params) => params.values)
 }));
 
 vi.mock('../../../../api/debtPositions', () => ({
   default: {
-    createDebtPosition: vi.fn(),
-    manageDebtPositionInstallments: vi.fn(),
-    getDebtPositionDetail: vi.fn()
+    createDebtPosition: vi.fn(() => ({
+      mutateAsync: vi.fn()
+    })),
+    manageDebtPositionInstallments: vi.fn(() => ({
+      mutateAsync: vi.fn()
+    })),
+    getDebtPositionDetail: vi.fn(() => ({
+      data: null
+    }))
   }
 }));
 
-vi.mock('../../../../utils', () => ({
-  default: {
-    notify: {
-      emit: vi.fn()
-    },
-    config: {
-      deployPath: '/piattaformaunitaria'
-    }
-  }
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return {
+    ...actual,
+    useLocation: vi.fn(() => ({
+      state: { debtPositionId: '123' }
+    }))
+  };
+});
+
+vi.mock('../../../../store/GlobalStore', () => ({
+  StoreProvider: ({ children }: { children: React.ReactNode }) => children,
+  useStore: vi.fn(() => ({
+    state: { organizationId: 1 }
+  }))
 }));
 
-vi.mock('../../../../utils/paymentUtility', () => ({
-  DEFAULT_VALUES: {
-    FLAG_IUV_VOLATILE: false,
-    MULTI_DEBTOR: false,
-    FLAG_PAGO_PA_PAYMENT: true,
-    PAYMENT_OPTION_INDEX: 1
-  },
-  createInstallmentObject: vi.fn((installment) => ({
-    installmentNumber: 1,
-    amount: installment.amount || '100',
-    dueDate: installment.dueDate?.value || new Date(),
-    beneficiaries: []
-  })),
-  createSingleInstallmentObject: vi.fn(() => ({
-    installmentNumber: 1,
-    amount: '100',
-    dueDate: new Date(),
-    beneficiaries: []
-  })),
-  triggerValidationForAllBeneficiaries: vi.fn(),
-  syncInstallmentBeneficiaries: vi.fn(() => ({
-    installments: [],
-    modified: false
-  })),
-  validateInstallments: vi.fn(() => ({})),
-  validateMultiBeneficiary: vi.fn(() => true),
-  handleInstallmentValidationFailure: vi.fn()
+vi.mock('../Beneficiary/BeneficiaryField', () => ({
+  default: vi.fn(({ children }) => (
+    <div data-testid="beneficiary-field">{children}</div>
+  )),
+  BeneficiaryFieldRef: {}
 }));
 
-vi.mock('../../../../components/Wizard/SectionBox', () => ({
-  default: ({
-    children,
-    title
-  }: {
-    children: React.ReactNode;
-    title: string;
-  }) => (
-    <div data-testid="section-box">
-      <h3>{title}</h3>
-      {children}
-    </div>
-  )
-}));
-
-vi.mock('../../../../components/Wizard/WizardStepWrapper', () => ({
-  default: ({
-    children,
-    title
-  }: {
-    children: React.ReactNode;
-    title: string;
-  }) => (
-    <div data-testid="wizard-step-wrapper">
-      <h2>{title}</h2>
-      {children}
-    </div>
-  )
+vi.mock('../Installment/InstallmentField', () => ({
+  default: vi.fn(({ children }) => (
+    <div data-testid="installment-field">{children}</div>
+  ))
 }));
 
 vi.mock('../../../../components/Wizard/WizardStepButtons', () => ({
-  default: ({
-    onBack,
-    onNext,
-    onSaveDraft,
-    nextLabel,
-    showSaveDraft
-  }: {
-    onBack: () => void;
-    onNext: () => void;
-    onSaveDraft: () => void;
-    nextLabel: string;
-    showSaveDraft: boolean;
-  }) => (
+  default: vi.fn(({ onNext, onBack, onSaveDraft }) => (
     <div data-testid="wizard-step-buttons">
       <button onClick={onBack} data-testid="back-button">
         Back
       </button>
       <button onClick={onNext} data-testid="next-button">
-        {nextLabel}
+        Next
       </button>
-      {showSaveDraft && (
+      {onSaveDraft && (
         <button onClick={onSaveDraft} data-testid="save-draft-button">
           Save Draft
         </button>
       )}
     </div>
-  )
-}));
-
-vi.mock('../Beneficiary/BeneficiaryField', () => ({
-  default: vi.fn(() => (
-    <div data-testid="beneficiary-field">Beneficiary Field</div>
   ))
 }));
 
-vi.mock('../Installment/InstallmentField', () => ({
-  default: vi.fn(() => (
-    <div data-testid="installment-field">Installment Field</div>
-  ))
-}));
-
-vi.mock('@mui/x-date-pickers/DatePicker', () => ({
-  DatePicker: ({
-    label,
-    value,
-    onChange,
-    disabled
-  }: {
-    label: string;
-    value: Date | null;
-    onChange: (date: Date | null) => void;
-    disabled: boolean;
-    slotProps: Record<string, unknown>;
-  }) => (
-    <div data-testid="date-picker">
-      <label>{label}</label>
-      <input
-        type="text"
-        value={value ? value.toISOString().split('T')[0] : ''}
-        onChange={(e) => {
-          onChange(e.target.value ? new Date(e.target.value) : null);
-        }}
-        disabled={disabled}
-        data-testid="date-picker-input"
-      />
+vi.mock('../../../../components/Wizard/WizardStepWrapper', () => ({
+  default: vi.fn(({ children, ...props }) => (
+    <div data-testid="wizard-step-wrapper" {...props}>
+      {children}
     </div>
-  )
+  ))
 }));
+
+vi.mock('../../../../components/Wizard/SectionBox', () => ({
+  default: vi.fn(({ children, title, ...props }) => (
+    <div data-testid="section-box" {...props}>
+      <h2>{title}</h2>
+      {children}
+    </div>
+  ))
+}));
+
+const createDefaultStep1Data = (): Step1Data => ({
+  description: { value: 'Test Description', readonly: false },
+  debtPositionType: { value: '1', flagMandatoryDueDate: false, readonly: false }
+});
+
+const createDefaultStep2Data = (): Step2Data => ({
+  subjectType: { value: 'individual', readonly: false },
+  taxCode: { value: 'RSSMRA80A01H501U', readonly: false },
+  fullName: { value: 'Mario Rossi', readonly: false },
+  address: { value: 'Via Roma', readonly: false },
+  civicNumber: { value: '1', readonly: false },
+  zipCode: { value: '00100', readonly: false },
+  country: { value: 'IT', readonly: false },
+  province: { value: 'RM', readonly: false },
+  city: { value: 'Roma', readonly: false }
+});
+
+const createDefaultStep3Data = (): Step3Data => ({
+  paymentObject: { value: '', readonly: false },
+  paymentOption: { value: DebtPositionTypeEnum.SINGLE, readonly: false },
+  amount: { value: '', readonly: false },
+  dueDate: { value: '', readonly: false },
+  isMultibeneficiary: { value: false, readonly: false },
+  beneficiaries: [],
+  installments: [],
+  flagMandatoryDueDate: false
+});
+
+const createTestBeneficiary = (): Beneficiary => ({
+  entityName: 'Test Entity',
+  amount: '100.00',
+  taxCode: 'RSSMRA80A01H501U',
+  remittance: 'Test remittance',
+  iban: 'IT60X0542811101000000123456',
+  postalIban: '',
+  taxonomyCode: 'TAX001'
+});
+
+const createTestInstallment = (): Installment => ({
+  amount: '100.00',
+  dueDate: '2024-12-31',
+  remittance: 'Test installment',
+  isMultibeneficiary: false,
+  beneficiaries: []
+});
 
 describe('Step3 Component', () => {
-  const mockSetData = vi.fn();
-  const mockOnNext = vi.fn();
-  const mockOnBack = vi.fn();
-  const mockCreateDebtPosition = vi.fn();
-  const mockManageDebtPositionInstallments = vi.fn();
-  const mockGetDebtPositionDetail = vi.fn();
-  const mockCreateDebtPositionAsync = vi.fn();
-  const mockManageDebtPositionInstallmentsAsync = vi.fn();
-
-  const initialData: Step3Data = {
-    paymentObject: { value: 'Test Payment', readonly: false },
-    paymentOption: { value: DebtPositionTypeEnum.SINGLE, readonly: false },
-    amount: { value: '100.00', readonly: false },
-    dueDate: { value: '2025-06-01', readonly: false },
-    isMultibeneficiary: { value: false, readonly: false },
-    flagMandatoryDueDate: false
-  };
-
-  const mockStep1Data: Step1Data = {
-    description: { value: 'Test Description', readonly: false },
-    debtPositionType: {
-      value: '1',
-      readonly: false,
-      flagMandatoryDueDate: false
-    }
-  };
-
-  const mockStep2Data: Step2Data = {
-    taxCode: { value: 'ABCDEF12G34H567I', readonly: false },
-    fullName: { value: 'John Doe', readonly: false },
-    subjectType: { value: 'PF', readonly: false },
-    address: { value: '', readonly: false },
-    civicNumber: { value: '', readonly: false },
-    zipCode: { value: '', readonly: false },
-    country: { value: '', readonly: false },
-    province: { value: '', readonly: false },
-    city: { value: '', readonly: false }
+  const defaultProps = {
+    data: createDefaultStep3Data(),
+    setData: vi.fn(),
+    onNext: vi.fn(),
+    onBack: vi.fn(),
+    step1Data: createDefaultStep1Data(),
+    step2Data: createDefaultStep2Data(),
+    isEditing: false
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
-
-    (useStore as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      state: { organizationId: '123' }
-    });
-
-    mockCreateDebtPositionAsync.mockResolvedValue({
-      paymentObject: 'Test Payment Object',
-      response: {
-        status: DebtPositionStatus.UNPAID,
-        debtPositionId: 123
-      }
-    });
-
-    mockManageDebtPositionInstallmentsAsync.mockResolvedValue({
-      description: 'Test Description',
-      status: DebtPositionStatus.UNPAID,
-      debtPositionId: 123
-    });
-
-    (
-      debtPositionsApi.createDebtPosition as unknown as ReturnType<typeof vi.fn>
-    ).mockReturnValue({
-      mutate: mockCreateDebtPosition,
-      mutateAsync: mockCreateDebtPositionAsync
-    });
-
-    (
-      debtPositionsApi.manageDebtPositionInstallments as unknown as ReturnType<
-        typeof vi.fn
-      >
-    ).mockReturnValue({
-      mutate: mockManageDebtPositionInstallments,
-      mutateAsync: mockManageDebtPositionInstallmentsAsync
-    });
-
-    (
-      debtPositionsApi.getDebtPositionDetail as unknown as ReturnType<
-        typeof vi.fn
-      >
-    ).mockReturnValue({
-      data: null
-    });
-
-    mockGetDebtPositionDetail.mockReturnValue({
-      data: null
-    });
   });
 
-  const renderComponent = () => {
-    return render(
-      <MemoryRouter>
-        <Step3
-          data={initialData}
-          setData={mockSetData}
-          onNext={mockOnNext}
-          onBack={mockOnBack}
-          step1Data={mockStep1Data}
-          step2Data={mockStep2Data}
-        />
-      </MemoryRouter>
-    );
-  };
-
-  it('should render the component correctly', () => {
-    renderComponent();
-
-    expect(screen.getByTestId('wizard-step-wrapper')).toBeInTheDocument();
-    expect(screen.getByTestId('section-box')).toBeInTheDocument();
-    expect(screen.getByText('Payment Options')).toBeInTheDocument();
-    expect(screen.getByText('Payment Object')).toBeInTheDocument();
-    expect(screen.getByText('Payment Option')).toBeInTheDocument();
-    expect(screen.getByText('Amount')).toBeInTheDocument();
-    expect(screen.getByTestId('date-picker')).toBeInTheDocument();
+  afterEach(() => {
+    vi.clearAllTimers();
   });
 
-  it('should handle payment option change from single to installments', async () => {
-    renderComponent();
+  describe('Component Rendering', () => {
+    it('should render the component with basic elements', () => {
+      render(<Step3 {...defaultProps} />);
 
-    const selectNativeInput = screen.getByDisplayValue('SINGLE');
-    fireEvent.change(selectNativeInput, {
-      target: { value: PaymentOptionTypeEnum.INSTALLMENTS }
+      expect(screen.getByTestId('wizard-step-wrapper')).toBeInTheDocument();
+      expect(screen.getByTestId('section-box')).toBeInTheDocument();
+      expect(screen.getByTestId('wizard-step-buttons')).toBeInTheDocument();
+      expect(screen.getByTestId('payment-object-field')).toBeInTheDocument();
+      expect(screen.getByTestId('payment-option-field')).toBeInTheDocument();
+      expect(screen.getByTestId('amount-field')).toBeInTheDocument();
     });
 
-    await waitFor(() => {
-      expect(screen.getByTestId('installment-field')).toBeInTheDocument();
+    it('should render payment option dropdown', () => {
+      render(<Step3 {...defaultProps} />);
+
+      const paymentOptionSelect = screen.getByTestId('payment-option-field');
+      expect(paymentOptionSelect).toBeInTheDocument();
+
+      const selectElement =
+        paymentOptionSelect.querySelector('[role="combobox"]');
+      expect(selectElement).toBeInTheDocument();
     });
 
-    expect(screen.queryByTestId('date-picker')).not.toBeInTheDocument();
-  });
+    it('should show multi-beneficiary switch when not in installment mode', () => {
+      render(<Step3 {...defaultProps} />);
 
-  it('should handle multi-beneficiary toggle and amount change', async () => {
-    const triggerSpy = vi.fn();
-    vi.spyOn(
-      paymentUtility,
-      'triggerValidationForAllBeneficiaries'
-    ).mockImplementation(triggerSpy);
-
-    renderComponent();
-
-    const multiBeneficiarySwitch = screen.getByRole('checkbox', {
-      name: /Multiple Beneficiaries/i
-    });
-    fireEvent.click(multiBeneficiarySwitch);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('beneficiary-field')).toBeInTheDocument();
-    });
-
-    const amountInput = screen.getByRole('textbox', { name: /Amount/i });
-    fireEvent.change(amountInput, { target: { value: '200,00' } });
-    fireEvent.blur(amountInput);
-
-    expect(screen.getByTestId('beneficiary-field')).toBeInTheDocument();
-    expect(amountInput).toHaveValue('200,00');
-  });
-
-  it('should handle form submission for single payment', async () => {
-    renderComponent();
-    const paymentObjectInput = screen.getByRole('textbox', {
-      name: /Payment Object/i
-    });
-    const amountInput = screen.getByRole('textbox', { name: /Amount/i });
-    const datePicker = screen.getByTestId('date-picker-input');
-    const submitButton = screen.getByTestId('next-button');
-
-    fireEvent.change(paymentObjectInput, {
-      target: { value: 'Updated Payment Object' }
-    });
-
-    fireEvent.change(amountInput, { target: { value: '200,50' } });
-    fireEvent.blur(amountInput);
-
-    fireEvent.change(datePicker, { target: { value: '2025-07-15' } });
-
-    expect(paymentObjectInput).toHaveValue('Updated Payment Object');
-    expect(amountInput).toHaveValue('200,50');
-    expect(datePicker).toHaveValue('2025-07-15');
-
-    fireEvent.click(submitButton);
-
-    expect(paymentObjectInput).toHaveValue('Updated Payment Object');
-    expect(amountInput).toHaveValue('200,50');
-    expect(datePicker).toHaveValue('2025-07-15');
-    expect(submitButton).toBeInTheDocument();
-
-    expect(submitButton.closest('form')).toHaveAttribute(
-      'id',
-      'step3-configuration-form'
-    );
-  });
-
-  it('should handle amount input correctly', async () => {
-    renderComponent();
-
-    const amountInput = screen.getByRole('textbox', { name: /Amount/i });
-
-    fireEvent.change(amountInput, { target: { value: '123,45' } });
-    fireEvent.blur(amountInput);
-
-    expect(amountInput).toHaveValue('123,45');
-
-    fireEvent.change(amountInput, { target: { value: 'abc123' } });
-
-    expect(amountInput).toHaveValue('123');
-  });
-
-  it('should handle mandatory due date validation', async () => {
-    render(
-      <MemoryRouter>
-        <Step3
-          data={{ ...initialData, flagMandatoryDueDate: true }}
-          setData={mockSetData}
-          onNext={mockOnNext}
-          onBack={mockOnBack}
-          step1Data={mockStep1Data}
-          step2Data={mockStep2Data}
-        />
-      </MemoryRouter>
-    );
-
-    const datePicker = screen.getByTestId('date-picker-input');
-    fireEvent.change(datePicker, { target: { value: '' } });
-
-    const submitButton = screen.getByTestId('next-button');
-    fireEvent.click(submitButton);
-
-    await waitFor(() => {
-      expect(mockCreateDebtPositionAsync).not.toHaveBeenCalled();
-    });
-  });
-
-  it('should handle back button click', () => {
-    renderComponent();
-
-    const backButton = screen.getByTestId('back-button');
-    fireEvent.click(backButton);
-
-    expect(mockOnBack).toHaveBeenCalled();
-  });
-
-  it('should trigger validation when changing amount with multi-beneficiary', async () => {
-    vi.clearAllMocks();
-
-    renderComponent();
-
-    const multiBeneficiarySwitch = screen.getByRole('checkbox', {
-      name: /Multiple Beneficiaries/i
-    });
-    fireEvent.click(multiBeneficiarySwitch);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('beneficiary-field')).toBeInTheDocument();
-    });
-
-    const amountInput = screen.getByRole('textbox', { name: /Amount/i });
-    fireEvent.change(amountInput, { target: { value: '500,00' } });
-
-    await waitFor(() => {
       expect(
-        paymentUtility.triggerValidationForAllBeneficiaries
-      ).toHaveBeenCalled();
+        screen.getByTestId('multi-beneficiary-switch')
+      ).toBeInTheDocument();
+    });
+
+    it('should not show beneficiary section initially', () => {
+      render(<Step3 {...defaultProps} />);
+
+      expect(screen.queryByTestId('beneficiary-field')).not.toBeInTheDocument();
+    });
+
+    it('should not show installments section initially', () => {
+      render(<Step3 {...defaultProps} />);
+
+      expect(screen.queryByTestId('installment-field')).not.toBeInTheDocument();
     });
   });
 
-  // Fix failing test
-  it('should handle save as draft functionality', async () => {
-    renderComponent();
+  describe('Form Interactions', () => {
+    it('should handle payment object input change', async () => {
+      render(<Step3 {...defaultProps} />);
 
-    // Fill the form with valid data (same as working test)
-    const paymentObjectInput = screen.getByRole('textbox', {
-      name: /Payment Object/i
-    });
-    const amountInput = screen.getByRole('textbox', { name: /Amount/i });
-    const datePicker = screen.getByTestId('date-picker-input');
+      const paymentObjectField = screen.getByTestId('payment-object-field');
+      const paymentObjectInput = paymentObjectField.querySelector('input');
 
-    fireEvent.change(paymentObjectInput, {
-      target: { value: 'Updated Payment Object' }
-    });
+      expect(paymentObjectInput).toBeInTheDocument();
 
-    fireEvent.change(amountInput, { target: { value: '200,50' } });
-    fireEvent.blur(amountInput);
+      if (paymentObjectInput) {
+        await userEvent.clear(paymentObjectInput);
+        await userEvent.type(paymentObjectInput, 'Test Payment Object');
 
-    fireEvent.change(datePicker, { target: { value: '2025-07-15' } });
-
-    // Verify form is filled
-    expect(paymentObjectInput).toHaveValue('Updated Payment Object');
-    expect(amountInput).toHaveValue('200,50');
-    expect(datePicker).toHaveValue('2025-07-15');
-
-    // Get the save draft button and verify it exists
-    const saveDraftButton = screen.getByTestId('save-draft-button');
-    expect(saveDraftButton).toBeInTheDocument();
-    expect(saveDraftButton).toHaveTextContent('Save Draft');
-
-    // Clear mocks
-    mockSetData.mockClear();
-    mockCreateDebtPositionAsync.mockClear();
-
-    // test that the button click triggers the expected behavior by mocking the onSubmit directly
-    const originalSubmit = HTMLFormElement.prototype.submit;
-    const mockSubmit = vi.fn();
-    HTMLFormElement.prototype.submit = mockSubmit;
-
-    // Click the save draft button
-    fireEvent.click(saveDraftButton);
-
-    // Verify the button was clicked
-    expect(saveDraftButton).toBeInTheDocument();
-
-    // Test the save draft flow by manually calling the expected functions
-    // This simulates what should happen when save draft succeeds
-    mockSetData({
-      paymentObject: { value: 'Updated Payment Object', readonly: false },
-      paymentOption: { value: 'SINGLE', readonly: false },
-      amount: { value: '200.50', readonly: false },
-      dueDate: { value: '2025-07-15', readonly: false },
-      isMultibeneficiary: { value: false, readonly: false },
-      beneficiaries: [],
-      installments: [],
-      flagMandatoryDueDate: false
-    });
-
-    mockCreateDebtPositionAsync({
-      body: {
-        status: DebtPositionStatus.DRAFT,
-        description: 'Updated Payment Object'
-      },
-      paymentObject: 'Updated Payment Object'
-    });
-
-    // Verify the expected functions were called with correct data
-    expect(mockSetData).toHaveBeenCalledWith(
-      expect.objectContaining({
-        paymentObject: { value: 'Updated Payment Object', readonly: false }
-      })
-    );
-
-    expect(mockCreateDebtPositionAsync).toHaveBeenCalledWith(
-      expect.objectContaining({
-        body: expect.objectContaining({
-          status: DebtPositionStatus.DRAFT
-        })
-      })
-    );
-
-    // Restore original submit
-    HTMLFormElement.prototype.submit = originalSubmit;
-  });
-
-  it('should validate installments when submitting with installment payment option', async () => {
-    renderComponent();
-
-    const selectNativeInput = screen.getByDisplayValue('SINGLE');
-    fireEvent.change(selectNativeInput, {
-      target: { value: PaymentOptionTypeEnum.INSTALLMENTS }
-    });
-
-    await waitFor(() => {
-      expect(screen.getByTestId('installment-field')).toBeInTheDocument();
-    });
-
-    vi.spyOn(installmentValidation, 'validateInstallments').mockReturnValueOnce(
-      {
-        hasInvalidBeneficiaries: false,
-        hasInvalidPaymentFields: false,
-        hasInvalidAmounts: false,
-        hasEmptyRemittance: false
-      }
-    );
-
-    vi.spyOn(
-      installmentValidation,
-      'syncInstallmentBeneficiaries'
-    ).mockReturnValueOnce({
-      installments: [
-        {
-          amount: '100',
-          dueDate: '2025-07-15',
-          remittance: 'Test payment',
-          isMultibeneficiary: false,
-          beneficiaries: []
-        }
-      ],
-      modified: true
-    });
-
-    const submitButton = screen.getByTestId('next-button');
-    fireEvent.click(submitButton);
-    await waitFor(() => {
-      expect(mockCreateDebtPositionAsync).toHaveBeenCalled();
-    });
-  });
-
-  it('should handle mandatory due date validation failure', async () => {
-    render(
-      <MemoryRouter>
-        <Step3
-          data={{ ...initialData, flagMandatoryDueDate: true }}
-          setData={mockSetData}
-          onNext={mockOnNext}
-          onBack={mockOnBack}
-          step1Data={mockStep1Data}
-          step2Data={mockStep2Data}
-        />
-      </MemoryRouter>
-    );
-
-    const datePicker = screen.getByTestId('date-picker-input');
-    fireEvent.change(datePicker, { target: { value: '' } });
-    fireEvent.blur(datePicker);
-
-    const submitButton = screen.getByTestId('next-button');
-    fireEvent.click(submitButton);
-    await waitFor(() => {
-      expect(mockCreateDebtPositionAsync).not.toHaveBeenCalled();
-    });
-  });
-
-  it('should validate due date when date changes and it is mandatory', async () => {
-    render(
-      <MemoryRouter>
-        <Step3
-          data={{ ...initialData, flagMandatoryDueDate: true }}
-          setData={mockSetData}
-          onNext={mockOnNext}
-          onBack={mockOnBack}
-          step1Data={mockStep1Data}
-          step2Data={mockStep2Data}
-        />
-      </MemoryRouter>
-    );
-
-    const datePicker = screen.getByTestId('date-picker-input');
-
-    fireEvent.change(datePicker, { target: { value: '2025-07-15' } });
-
-    fireEvent.change(datePicker, { target: { value: '' } });
-
-    fireEvent.blur(datePicker);
-
-    expect(datePicker).toHaveValue('');
-  });
-
-  it('should handle wheel event properly when target is HTMLElement', async () => {
-    renderComponent();
-
-    const amountInput = screen.getByRole('textbox', { name: /Amount/i });
-
-    expect(amountInput).toBeInTheDocument();
-    expect(amountInput).toHaveValue('100,00');
-
-    fireEvent.change(amountInput, { target: { value: '200,50' } });
-    expect(amountInput).toHaveValue('200,50');
-  });
-
-  it('should handle DatePicker onClose callback when due date is mandatory', async () => {
-    render(
-      <MemoryRouter>
-        <Step3
-          data={{ ...initialData, flagMandatoryDueDate: true }}
-          setData={mockSetData}
-          onNext={mockOnNext}
-          onBack={mockOnBack}
-          step1Data={mockStep1Data}
-          step2Data={mockStep2Data}
-        />
-      </MemoryRouter>
-    );
-
-    const datePicker = screen.getByTestId('date-picker-input');
-
-    fireEvent.change(datePicker, { target: { value: '2025-07-15' } });
-
-    fireEvent.blur(datePicker);
-
-    expect(datePicker).toHaveValue('2025-07-15');
-  });
-
-  it('should handle payment option readonly state', () => {
-    render(
-      <MemoryRouter>
-        <Step3
-          data={{
-            ...initialData,
-            paymentOption: {
-              value: DebtPositionTypeEnum.SINGLE,
-              readonly: true
-            }
-          }}
-          setData={mockSetData}
-          onNext={mockOnNext}
-          onBack={mockOnBack}
-          step1Data={mockStep1Data}
-          step2Data={mockStep2Data}
-        />
-      </MemoryRouter>
-    );
-
-    const paymentOptionSelect = screen.getByDisplayValue('SINGLE');
-    expect(paymentOptionSelect).toBeDisabled();
-  });
-
-  it('should handle amount readonly state in installment mode', async () => {
-    render(
-      <MemoryRouter>
-        <Step3
-          data={{
-            ...initialData,
-            paymentOption: {
-              value: DebtPositionTypeEnum.INSTALLMENTS,
-              readonly: false
-            },
-            amount: { value: '100.00', readonly: true }
-          }}
-          setData={mockSetData}
-          onNext={mockOnNext}
-          onBack={mockOnBack}
-          step1Data={mockStep1Data}
-          step2Data={mockStep2Data}
-        />
-      </MemoryRouter>
-    );
-
-    await waitFor(() => {
-      const amountInput = screen.getByRole('textbox', { name: /Amount/i });
-      expect(amountInput).toBeDisabled();
-    });
-  });
-
-  it('should handle due date readonly state', () => {
-    render(
-      <MemoryRouter>
-        <Step3
-          data={{
-            ...initialData,
-            dueDate: { value: '2025-06-01', readonly: true }
-          }}
-          setData={mockSetData}
-          onNext={mockOnNext}
-          onBack={mockOnBack}
-          step1Data={mockStep1Data}
-          step2Data={mockStep2Data}
-        />
-      </MemoryRouter>
-    );
-
-    const datePicker = screen.getByTestId('date-picker-input');
-    expect(datePicker).toBeDisabled();
-  });
-
-  it('should handle multi-beneficiary readonly state', () => {
-    render(
-      <MemoryRouter>
-        <Step3
-          data={{
-            ...initialData,
-            isMultibeneficiary: { value: false, readonly: true }
-          }}
-          setData={mockSetData}
-          onNext={mockOnNext}
-          onBack={mockOnBack}
-          step1Data={mockStep1Data}
-          step2Data={mockStep2Data}
-        />
-      </MemoryRouter>
-    );
-
-    const multiBeneficiarySwitch = screen.getByRole('checkbox', {
-      name: /Multiple Beneficiaries/i
-    });
-    expect(multiBeneficiarySwitch).toBeDisabled();
-  });
-
-  it('should handle payment object disabled state in installments mode', async () => {
-    render(
-      <MemoryRouter>
-        <Step3
-          data={{
-            ...initialData,
-            paymentOption: {
-              value: DebtPositionTypeEnum.INSTALLMENTS,
-              readonly: false
-            }
-          }}
-          setData={mockSetData}
-          onNext={mockOnNext}
-          onBack={mockOnBack}
-          step1Data={mockStep1Data}
-          step2Data={mockStep2Data}
-        />
-      </MemoryRouter>
-    );
-
-    await waitFor(() => {
-      const paymentObjectInput = screen.getByRole('textbox', {
-        name: /Payment Object/i
-      });
-      expect(paymentObjectInput).toBeDisabled();
-    });
-  });
-
-  it('should handle validation failures for installments', async () => {
-    renderComponent();
-
-    const selectNativeInput = screen.getByDisplayValue('SINGLE');
-    fireEvent.change(selectNativeInput, {
-      target: { value: DebtPositionTypeEnum.INSTALLMENTS }
-    });
-
-    await waitFor(() => {
-      expect(screen.getByTestId('installment-field')).toBeInTheDocument();
-    });
-
-    vi.spyOn(installmentValidation, 'validateInstallments').mockReturnValueOnce(
-      {
-        hasInvalidBeneficiaries: true,
-        hasInvalidPaymentFields: false,
-        hasInvalidAmounts: false,
-        hasEmptyRemittance: false
-      }
-    );
-
-    const submitButton = screen.getByTestId('next-button');
-    fireEvent.click(submitButton);
-
-    await waitFor(() => {
-      expect(mockCreateDebtPositionAsync).not.toHaveBeenCalled();
-    });
-  });
-
-  it('should set showSaveDraft to false when isEditing is true', () => {
-    render(
-      <MemoryRouter>
-        <Step3
-          data={initialData}
-          setData={mockSetData}
-          onNext={mockOnNext}
-          onBack={mockOnBack}
-          step1Data={mockStep1Data}
-          step2Data={mockStep2Data}
-          isEditing={true}
-        />
-      </MemoryRouter>
-    );
-
-    expect(screen.queryByTestId('save-draft-button')).not.toBeInTheDocument();
-  });
-
-  it('should handle installments array fallback when formattedValues.installments is undefined', async () => {
-    render(
-      <MemoryRouter>
-        <Step3
-          data={{
-            ...initialData,
-            paymentOption: {
-              value: DebtPositionTypeEnum.INSTALLMENTS,
-              readonly: false
-            },
-            installments: undefined
-          }}
-          setData={mockSetData}
-          onNext={mockOnNext}
-          onBack={mockOnBack}
-          step1Data={mockStep1Data}
-          step2Data={mockStep2Data}
-        />
-      </MemoryRouter>
-    );
-
-    const submitButton = screen.getByTestId('next-button');
-    fireEvent.click(submitButton);
-
-    await waitFor(() => {
-      expect(mockSetData).toHaveBeenCalled();
-    });
-  });
-
-  it('should trigger paymentObject field onChange directly', async () => {
-    renderComponent();
-
-    const paymentObjectInput = screen.getByRole('textbox', {
-      name: /Payment Object/i
-    });
-
-    fireEvent.change(paymentObjectInput, {
-      target: { value: 'Test onChange' }
-    });
-
-    expect(paymentObjectInput).toHaveValue('Test onChange');
-  });
-
-  it('should show error helper text for paymentObject when submitted with error', async () => {
-    render(
-      <MemoryRouter>
-        <Step3
-          data={initialData}
-          setData={mockSetData}
-          onNext={mockOnNext}
-          onBack={mockOnBack}
-          step1Data={mockStep1Data}
-          step2Data={mockStep2Data}
-        />
-      </MemoryRouter>
-    );
-
-    const paymentObjectInput = screen.getByRole('textbox', {
-      name: /Payment Object/i
-    });
-
-    fireEvent.change(paymentObjectInput, { target: { value: '' } });
-    fireEvent.blur(paymentObjectInput);
-
-    const submitButton = screen.getByTestId('next-button');
-    fireEvent.click(submitButton);
-
-    await waitFor(() => {
-      const errorText = screen.queryByText(/required/i);
-      if (errorText) {
-        expect(errorText).toBeInTheDocument();
+        expect(paymentObjectInput.value).toBe('Test Payment Object');
       }
     });
-  });
 
-  it('should trigger validation timeout when date changes with mandatory flag', async () => {
-    vi.useFakeTimers();
+    it('should handle amount input change', async () => {
+      render(<Step3 {...defaultProps} />);
 
-    render(
-      <MemoryRouter>
-        <Step3
-          data={{ ...initialData, flagMandatoryDueDate: true }}
-          setData={mockSetData}
-          onNext={mockOnNext}
-          onBack={mockOnBack}
-          step1Data={mockStep1Data}
-          step2Data={mockStep2Data}
-        />
-      </MemoryRouter>
-    );
+      const amountField = screen.getByTestId('amount-field');
+      const amountInput = amountField.querySelector('input');
 
-    const datePicker = screen.getByTestId('date-picker-input');
+      expect(amountInput).toBeInTheDocument();
 
-    fireEvent.change(datePicker, { target: { value: '2025-07-15' } });
-
-    vi.runAllTimers();
-
-    expect(datePicker).toHaveValue('2025-07-15');
-
-    vi.useRealTimers();
-  });
-
-  it('should handle trigger validation timeout execution', async () => {
-    vi.useFakeTimers();
-
-    render(
-      <MemoryRouter>
-        <Step3
-          data={{ ...initialData, flagMandatoryDueDate: true }}
-          setData={mockSetData}
-          onNext={mockOnNext}
-          onBack={mockOnBack}
-          step1Data={mockStep1Data}
-          step2Data={mockStep2Data}
-        />
-      </MemoryRouter>
-    );
-
-    const datePicker = screen.getByTestId('date-picker-input');
-
-    fireEvent.change(datePicker, { target: { value: '2025-07-15' } });
-    fireEvent.change(datePicker, { target: { value: '2025-08-15' } });
-
-    vi.runAllTimers();
-
-    expect(datePicker).toHaveValue('2025-08-15');
-
-    vi.useRealTimers();
-  });
-
-  it('should cover formattedValues.installments fallback to empty array', async () => {
-    vi.spyOn(installmentValidation, 'validateInstallments').mockReturnValueOnce(
-      {
-        hasInvalidBeneficiaries: false,
-        hasInvalidPaymentFields: false,
-        hasInvalidAmounts: false,
-        hasEmptyRemittance: false
+      if (amountInput) {
+        expect(amountInput).not.toBeDisabled();
+        await userEvent.click(amountInput);
+        expect(amountInput).toHaveFocus();
       }
-    );
-
-    vi.spyOn(
-      installmentValidation,
-      'syncInstallmentBeneficiaries'
-    ).mockReturnValueOnce({
-      installments: [],
-      modified: false
     });
 
-    render(
-      <MemoryRouter>
-        <Step3
-          data={{
-            ...initialData,
-            paymentOption: {
-              value: DebtPositionTypeEnum.INSTALLMENTS,
-              readonly: false
-            },
-            installments: undefined
-          }}
-          setData={mockSetData}
-          onNext={mockOnNext}
-          onBack={mockOnBack}
-          step1Data={mockStep1Data}
-          step2Data={mockStep2Data}
-        />
-      </MemoryRouter>
-    );
-
-    const submitButton = screen.getByTestId('next-button');
-    fireEvent.click(submitButton);
-
-    await waitFor(() => {
-      expect(mockCreateDebtPositionAsync).toHaveBeenCalledWith(
-        expect.objectContaining({
-          body: expect.objectContaining({
-            paymentOptions: expect.arrayContaining([
-              expect.objectContaining({
-                installments: []
-              })
-            ])
-          })
-        })
-      );
-    });
-  });
-
-  it('should trigger validation on DatePicker onClose when flagMandatoryDueDate is false', async () => {
-    render(
-      <MemoryRouter>
-        <Step3
-          data={{ ...initialData, flagMandatoryDueDate: false }}
-          setData={mockSetData}
-          onNext={mockOnNext}
-          onBack={mockOnBack}
-          step1Data={mockStep1Data}
-          step2Data={mockStep2Data}
-        />
-      </MemoryRouter>
-    );
-
-    const datePicker = screen.getByTestId('date-picker-input');
-
-    fireEvent.change(datePicker, { target: { value: '2025-07-15' } });
-
-    fireEvent.blur(datePicker);
-
-    expect(datePicker).toHaveValue('2025-07-15');
-  });
-
-  it('should handle edge case in onSubmit when isInstallment is true but validateInstallmentsData returns invalid', async () => {
-    render(
-      <MemoryRouter>
-        <Step3
-          data={{
-            ...initialData,
-            paymentOption: {
-              value: DebtPositionTypeEnum.INSTALLMENTS,
-              readonly: false
-            }
-          }}
-          setData={mockSetData}
-          onNext={mockOnNext}
-          onBack={mockOnBack}
-          step1Data={mockStep1Data}
-          step2Data={mockStep2Data}
-        />
-      </MemoryRouter>
-    );
-
-    vi.spyOn(installmentValidation, 'validateInstallments').mockReturnValueOnce(
-      {
-        hasInvalidBeneficiaries: true,
-        hasInvalidPaymentFields: true,
-        hasInvalidAmounts: true,
-        hasEmptyRemittance: true
-      }
-    );
-
-    const submitButton = screen.getByTestId('next-button');
-    fireEvent.click(submitButton);
-
-    await waitFor(() => {
-      expect(mockCreateDebtPositionAsync).not.toHaveBeenCalled();
-    });
-  });
-
-  it('should test wheel event handler edge case', async () => {
-    renderComponent();
-
-    const amountInput = screen.getByRole('textbox', { name: /Amount/i });
-
-    const inputProps = amountInput.getAttribute('style');
-    expect(inputProps).toContain('text-align: left');
-
-    expect(amountInput).toBeInTheDocument();
-  });
-
-  it('should test amount field onChange handler callback', async () => {
-    renderComponent();
-
-    const amountInput = screen.getByRole('textbox', { name: /Amount/i });
-
-    fireEvent.change(amountInput, { target: { value: '300,75' } });
-
-    expect(amountInput).toHaveValue('300,75');
-  });
-
-  it('should trigger DatePicker onClose logic without mandatory flag', async () => {
-    render(
-      <MemoryRouter>
-        <Step3
-          data={{ ...initialData, flagMandatoryDueDate: false }}
-          setData={mockSetData}
-          onNext={mockOnNext}
-          onBack={mockOnBack}
-          step1Data={mockStep1Data}
-          step2Data={mockStep2Data}
-        />
-      </MemoryRouter>
-    );
-
-    const datePicker = screen.getByTestId('date-picker-input');
-
-    fireEvent.change(datePicker, { target: { value: '2025-07-15' } });
-    fireEvent.blur(datePicker);
-
-    expect(datePicker).toHaveValue('2025-07-15');
-  });
-
-  it('should test complex scenario with installments and editing mode', async () => {
-    render(
-      <MemoryRouter>
-        <Step3
-          data={{
-            ...initialData,
-            paymentOption: {
-              value: DebtPositionTypeEnum.INSTALLMENTS,
-              readonly: false
-            },
-            installments: []
-          }}
-          setData={mockSetData}
-          onNext={mockOnNext}
-          onBack={mockOnBack}
-          step1Data={mockStep1Data}
-          step2Data={mockStep2Data}
-          isEditing={true}
-        />
-      </MemoryRouter>
-    );
-
-    expect(screen.getByTestId('installment-field')).toBeInTheDocument();
-
-    expect(screen.queryByTestId('save-draft-button')).not.toBeInTheDocument();
-  });
-
-  it('should cover onWheel event preventDefault case when target is not HTMLElement', async () => {
-    renderComponent();
-
-    const amountInput = screen.getByRole('textbox', { name: /Amount/i });
-
-    fireEvent.wheel(amountInput);
-
-    expect(amountInput).toBeInTheDocument();
-    expect(amountInput).toHaveValue('100,00');
-  });
-
-  it('should cover paymentObject field onChange direct execution', async () => {
-    renderComponent();
-
-    const paymentObjectInput = screen.getByRole('textbox', {
-      name: /Payment Object/i
-    });
-
-    const testValue = 'Test Payment Object Direct';
-
-    fireEvent.change(paymentObjectInput, {
-      target: { value: testValue }
-    });
-
-    expect(paymentObjectInput).toHaveValue(testValue);
-  });
-
-  it('should execute DatePicker onClose callback when mandatory flag is active', async () => {
-    vi.useFakeTimers();
-
-    render(
-      <MemoryRouter>
-        <Step3
-          data={{ ...initialData, flagMandatoryDueDate: true }}
-          setData={mockSetData}
-          onNext={mockOnNext}
-          onBack={mockOnBack}
-          step1Data={mockStep1Data}
-          step2Data={mockStep2Data}
-        />
-      </MemoryRouter>
-    );
-
-    const datePicker = screen.getByTestId('date-picker-input');
-
-    fireEvent.change(datePicker, { target: { value: '2025-07-15' } });
-
-    fireEvent.blur(datePicker);
-
-    vi.runAllTimers();
-
-    expect(datePicker).toHaveValue('2025-07-15');
-
-    vi.useRealTimers();
-  });
-
-  it('should handle real wheel event simulation with HTMLElement target', async () => {
-    renderComponent();
-
-    const amountInput = screen.getByRole('textbox', { name: /Amount/i });
-
-    amountInput.focus();
-
-    const wheelEvent = new WheelEvent('wheel', {
-      bubbles: true,
-      cancelable: true,
-      deltaY: 100
-    });
-
-    amountInput.dispatchEvent(wheelEvent);
-
-    expect(amountInput).toBeInTheDocument();
-  });
-
-  it('should cover edge case: formattedValues.installments undefined in API call', async () => {
-    vi.spyOn(installmentValidation, 'validateInstallments').mockReturnValueOnce(
-      {
-        hasInvalidBeneficiaries: false,
-        hasInvalidPaymentFields: false,
-        hasInvalidAmounts: false,
-        hasEmptyRemittance: false
-      }
-    );
-
-    vi.spyOn(
-      installmentValidation,
-      'syncInstallmentBeneficiaries'
-    ).mockReturnValueOnce({
-      installments: [],
-      modified: false
-    });
-
-    render(
-      <MemoryRouter>
-        <Step3
-          data={{
-            ...initialData,
-            paymentOption: {
-              value: DebtPositionTypeEnum.INSTALLMENTS,
-              readonly: false
-            },
-            installments: undefined
-          }}
-          setData={mockSetData}
-          onNext={mockOnNext}
-          onBack={mockOnBack}
-          step1Data={mockStep1Data}
-          step2Data={mockStep2Data}
-        />
-      </MemoryRouter>
-    );
-
-    const submitButton = screen.getByTestId('next-button');
-    fireEvent.click(submitButton);
-
-    await waitFor(() => {
-      expect(mockCreateDebtPositionAsync).toHaveBeenCalledWith(
-        expect.objectContaining({
-          body: expect.objectContaining({
-            paymentOptions: expect.arrayContaining([
-              expect.objectContaining({
-                installments: []
-              })
-            ])
-          })
-        })
-      );
-    });
-  });
-
-  it('should test multiple setTimeout executions in DatePicker', async () => {
-    vi.useFakeTimers();
-
-    render(
-      <MemoryRouter>
-        <Step3
-          data={{ ...initialData, flagMandatoryDueDate: true }}
-          setData={mockSetData}
-          onNext={mockOnNext}
-          onBack={mockOnBack}
-          step1Data={mockStep1Data}
-          step2Data={mockStep2Data}
-        />
-      </MemoryRouter>
-    );
-
-    const datePicker = screen.getByTestId('date-picker-input');
-
-    fireEvent.change(datePicker, { target: { value: '2025-01-15' } });
-    fireEvent.change(datePicker, { target: { value: '2025-02-15' } });
-    fireEvent.change(datePicker, { target: { value: '2025-03-15' } });
-
-    vi.runAllTimers();
-
-    expect(datePicker).toHaveValue('2025-03-15');
-
-    vi.useRealTimers();
-  });
-
-  it('should test onWheel with different event target scenarios', async () => {
-    renderComponent();
-
-    const amountInput = screen.getByRole('textbox', { name: /Amount/i });
-
-    fireEvent.wheel(amountInput, { deltaY: 100 });
-
-    expect(amountInput).toBeInTheDocument();
-    expect(amountInput).toHaveValue('100,00');
-  });
-
-  describe('getSaveDraftHandler function', () => {
-    it('should return undefined for UNPAID/EXPIRED in edit mode (no save draft option)', () => {
-      render(
-        <MemoryRouter
-          initialEntries={[
-            {
-              pathname: '/debt-position-edit',
-              state: { debtPositionId: 123 }
-            }
-          ]}
-        >
-          <Step3
-            data={initialData}
-            setData={mockSetData}
-            onNext={mockOnNext}
-            onBack={mockOnBack}
-            step1Data={mockStep1Data}
-            step2Data={mockStep2Data}
-            isEditing={true}
-          />
-        </MemoryRouter>
-      );
-
-      // In edit mode per UNPAID/EXPIRED, il save draft button non dovrebbe essere visibile
-      expect(screen.queryByTestId('save-draft-button')).not.toBeInTheDocument();
-    });
-
-    it('should show save draft button for DRAFT in edit mode', async () => {
-      // Mock per DRAFT debt position
-      (
-        debtPositionsApi.getDebtPositionDetail as unknown as ReturnType<
-          typeof vi.fn
-        >
-      ).mockReturnValue({
-        data: {
-          status: DebtPositionStatus.DRAFT,
-          paymentOptions: [{ paymentOptionId: 'payment-123' }]
-        }
-      });
-
-      render(
-        <MemoryRouter
-          initialEntries={[
-            {
-              pathname: '/debt-position-edit',
-              state: { debtPositionId: 123 }
-            }
-          ]}
-        >
-          <Step3
-            data={initialData}
-            setData={mockSetData}
-            onNext={mockOnNext}
-            onBack={mockOnBack}
-            step1Data={mockStep1Data}
-            step2Data={mockStep2Data}
-            isEditing={true}
-          />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByTestId('save-draft-button')).toBeInTheDocument();
-      });
-    });
-
-    it('should show correct buttons for DRAFT in edit mode', async () => {
-      (
-        debtPositionsApi.getDebtPositionDetail as unknown as ReturnType<
-          typeof vi.fn
-        >
-      ).mockReturnValue({
-        data: {
-          status: DebtPositionStatus.DRAFT,
-          paymentOptions: [{ paymentOptionId: 'payment-123' }]
-        }
-      });
-
-      render(
-        <MemoryRouter
-          initialEntries={[
-            {
-              pathname: '/debt-position-edit',
-              state: { debtPositionId: 123 }
-            }
-          ]}
-        >
-          <Step3
-            data={initialData}
-            setData={mockSetData}
-            onNext={mockOnNext}
-            onBack={mockOnBack}
-            step1Data={mockStep1Data}
-            step2Data={mockStep2Data}
-            isEditing={true}
-          />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByTestId('next-button')).toBeInTheDocument();
-        expect(screen.getByTestId('save-draft-button')).toBeInTheDocument();
-      });
-    });
-
-    it('should show save draft button in creation mode', async () => {
-      render(
-        <MemoryRouter>
-          <Step3
-            data={initialData}
-            setData={mockSetData}
-            onNext={mockOnNext}
-            onBack={mockOnBack}
-            step1Data={mockStep1Data}
-            step2Data={mockStep2Data}
-            isEditing={false}
-          />
-        </MemoryRouter>
-      );
-
-      expect(screen.getByTestId('save-draft-button')).toBeInTheDocument();
-      expect(screen.getByTestId('next-button')).toBeInTheDocument();
-    });
-  });
-
-  describe('Edit mode error handling', () => {
-    it('should handle missing paymentOptionId in edit mode', async () => {
-      (
-        debtPositionsApi.getDebtPositionDetail as unknown as ReturnType<
-          typeof vi.fn
-        >
-      ).mockReturnValue({
-        data: {
-          status: DebtPositionStatus.DRAFT,
-          paymentOptions: [{ paymentOptionId: null }]
-        }
-      });
-
-      render(
-        <MemoryRouter
-          initialEntries={[
-            {
-              pathname: '/debt-position-edit',
-              state: { debtPositionId: 123 }
-            }
-          ]}
-        >
-          <Step3
-            data={initialData}
-            setData={mockSetData}
-            onNext={mockOnNext}
-            onBack={mockOnBack}
-            step1Data={mockStep1Data}
-            step2Data={mockStep2Data}
-            isEditing={true}
-          />
-        </MemoryRouter>
-      );
-
-      const nextButton = screen.getByTestId('next-button');
-      fireEvent.click(nextButton);
-
-      await waitFor(() => {
-        expect(mockManageDebtPositionInstallmentsAsync).not.toHaveBeenCalled();
-      });
-    });
-
-    it('should handle invalid debtPositionId in edit mode', async () => {
-      (
-        debtPositionsApi.getDebtPositionDetail as unknown as ReturnType<
-          typeof vi.fn
-        >
-      ).mockReturnValue({
-        data: {
-          status: DebtPositionStatus.DRAFT,
-          paymentOptions: [{ paymentOptionId: 'payment-123' }]
-        }
-      });
-
-      render(
-        <MemoryRouter
-          initialEntries={[
-            {
-              pathname: '/debt-position-edit',
-              state: { debtPositionId: 'invalid-id' }
-            }
-          ]}
-        >
-          <Step3
-            data={initialData}
-            setData={mockSetData}
-            onNext={mockOnNext}
-            onBack={mockOnBack}
-            step1Data={mockStep1Data}
-            step2Data={mockStep2Data}
-            isEditing={true}
-          />
-        </MemoryRouter>
-      );
-
-      const nextButton = screen.getByTestId('next-button');
-      fireEvent.click(nextButton);
-
-      await waitFor(() => {
-        expect(mockManageDebtPositionInstallmentsAsync).not.toHaveBeenCalled();
-      });
-    });
-  });
-
-  describe('Button labels and visibility', () => {
-    it('should show correct button labels for DRAFT in edit mode', async () => {
-      (
-        debtPositionsApi.getDebtPositionDetail as unknown as ReturnType<
-          typeof vi.fn
-        >
-      ).mockReturnValue({
-        data: {
-          status: DebtPositionStatus.DRAFT,
-          paymentOptions: [{ paymentOptionId: 'payment-123' }]
-        }
-      });
-
-      render(
-        <MemoryRouter
-          initialEntries={[
-            {
-              pathname: '/debt-position-edit',
-              state: { debtPositionId: 123 }
-            }
-          ]}
-        >
-          <Step3
-            data={initialData}
-            setData={mockSetData}
-            onNext={mockOnNext}
-            onBack={mockOnBack}
-            step1Data={mockStep1Data}
-            step2Data={mockStep2Data}
-            isEditing={true}
-          />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => {
-        const nextButton = screen.getByTestId('next-button');
-        expect(nextButton).toHaveTextContent('commons.create');
-
-        const saveDraftButton = screen.getByTestId('save-draft-button');
-        expect(saveDraftButton).toHaveTextContent('Save Draft');
-      });
-    });
-
-    it('should show correct button labels for UNPAID in edit mode', async () => {
-      (
-        debtPositionsApi.getDebtPositionDetail as unknown as ReturnType<
-          typeof vi.fn
-        >
-      ).mockReturnValue({
-        data: {
-          status: DebtPositionStatus.UNPAID,
-          paymentOptions: [{ paymentOptionId: 'payment-123' }]
-        }
-      });
-
-      render(
-        <MemoryRouter
-          initialEntries={[
-            {
-              pathname: '/debt-position-edit',
-              state: { debtPositionId: 123 }
-            }
-          ]}
-        >
-          <Step3
-            data={initialData}
-            setData={mockSetData}
-            onNext={mockOnNext}
-            onBack={mockOnBack}
-            step1Data={mockStep1Data}
-            step2Data={mockStep2Data}
-            isEditing={true}
-          />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => {
-        const nextButton = screen.getByTestId('next-button');
-        expect(nextButton).toHaveTextContent('commons.save');
-
-        expect(
-          screen.queryByTestId('save-draft-button')
-        ).not.toBeInTheDocument();
-      });
-    });
-  });
-
-  describe('Form data population in edit mode', () => {
-    it('should populate form fields when editing with actual data', async () => {
-      const dataWithActualValues: Step3Data = {
-        paymentObject: { value: 'Existing Payment Object', readonly: false },
-        paymentOption: { value: DebtPositionTypeEnum.SINGLE, readonly: false },
-        amount: { value: '150.50', readonly: false },
-        dueDate: { value: '2025-12-01', readonly: false },
-        isMultibeneficiary: { value: true, readonly: false },
-        beneficiaries: [
-          {
-            entityName: 'Test Entity',
-            amount: '150.50',
-            taxCode: 'TEST123',
-            remittance: 'Test remittance',
-            iban: 'IT60X0542811101000000123456',
-            taxonomyCode: 'TEST'
-          }
-        ],
-        installments: [],
-        flagMandatoryDueDate: false
-      };
-
-      render(
-        <MemoryRouter
-          initialEntries={[
-            {
-              pathname: '/debt-position-edit',
-              state: { debtPositionId: 123 }
-            }
-          ]}
-        >
-          <Step3
-            data={dataWithActualValues}
-            setData={mockSetData}
-            onNext={mockOnNext}
-            onBack={mockOnBack}
-            step1Data={mockStep1Data}
-            step2Data={mockStep2Data}
-            isEditing={true}
-          />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => {
-        expect(
-          screen.getByDisplayValue('Existing Payment Object')
-        ).toBeInTheDocument();
-        expect(screen.getByDisplayValue('150,50')).toBeInTheDocument();
-      });
-    });
-
-    it('should not populate form fields when editing without actual data', async () => {
-      const dataWithEmptyValues: Step3Data = {
-        paymentObject: { value: '', readonly: false },
-        paymentOption: { value: DebtPositionTypeEnum.SINGLE, readonly: false },
-        amount: { value: '', readonly: false },
-        dueDate: { value: '', readonly: false },
-        isMultibeneficiary: { value: false, readonly: false },
-        beneficiaries: [],
-        installments: [],
-        flagMandatoryDueDate: false
-      };
-
-      render(
-        <MemoryRouter
-          initialEntries={[
-            {
-              pathname: '/debt-position-edit',
-              state: { debtPositionId: 123 }
-            }
-          ]}
-        >
-          <Step3
-            data={dataWithEmptyValues}
-            setData={mockSetData}
-            onNext={mockOnNext}
-            onBack={mockOnBack}
-            step1Data={mockStep1Data}
-            step2Data={mockStep2Data}
-            isEditing={true}
-          />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => {
-        const paymentObjectInput = screen.getByRole('textbox', {
-          name: /Payment Object/i
-        });
-        expect(paymentObjectInput).toHaveValue('');
-      });
-    });
-
-    it('should populate form fields with installments data', async () => {
-      const dataWithInstallments: Step3Data = {
-        paymentObject: { value: 'Installment Payment', readonly: false },
+    it('should handle payment option change to installments', async () => {
+      const installmentsData = {
+        ...createDefaultStep3Data(),
         paymentOption: {
           value: DebtPositionTypeEnum.INSTALLMENTS,
           readonly: false
-        },
-        amount: { value: '300.00', readonly: false },
-        dueDate: { value: '', readonly: false },
-        isMultibeneficiary: { value: false, readonly: false },
-        beneficiaries: [],
-        installments: [
-          {
-            amount: '100.00',
-            dueDate: '2025-06-01',
-            remittance: 'First installment',
-            isMultibeneficiary: false,
-            beneficiaries: []
-          },
-          {
-            amount: '200.00',
-            dueDate: '2025-07-01',
-            remittance: 'Second installment',
-            isMultibeneficiary: false,
-            beneficiaries: []
-          }
-        ],
-        flagMandatoryDueDate: false
+        }
       };
-
-      render(
-        <MemoryRouter
-          initialEntries={[
-            {
-              pathname: '/debt-position-edit',
-              state: { debtPositionId: 123 }
-            }
-          ]}
-        >
-          <Step3
-            data={dataWithInstallments}
-            setData={mockSetData}
-            onNext={mockOnNext}
-            onBack={mockOnBack}
-            step1Data={mockStep1Data}
-            step2Data={mockStep2Data}
-            isEditing={true}
-          />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByTestId('installment-field')).toBeInTheDocument();
-      });
+      render(<Step3 {...defaultProps} data={installmentsData} />);
+      expect(screen.getByTestId('installment-field')).toBeInTheDocument();
     });
 
-    it('should handle date value as string in dueDate field', async () => {
-      const dataWithStringDate: Step3Data = {
-        paymentObject: { value: 'Payment with string date', readonly: false },
-        paymentOption: { value: DebtPositionTypeEnum.SINGLE, readonly: false },
-        amount: { value: '100.00', readonly: false },
-        dueDate: { value: '2025-06-15', readonly: false },
-        isMultibeneficiary: { value: false, readonly: false },
-        beneficiaries: [],
-        installments: [],
-        flagMandatoryDueDate: false
+    it('should handle multi-beneficiary toggle', () => {
+      const multiBeneficiaryData = {
+        ...createDefaultStep3Data(),
+        isMultibeneficiary: { value: true, readonly: false }
       };
 
-      render(
-        <MemoryRouter
-          initialEntries={[
-            {
-              pathname: '/debt-position-edit',
-              state: { debtPositionId: 123 }
-            }
-          ]}
-        >
-          <Step3
-            data={dataWithStringDate}
-            setData={mockSetData}
-            onNext={mockOnNext}
-            onBack={mockOnBack}
-            step1Data={mockStep1Data}
-            step2Data={mockStep2Data}
-            isEditing={true}
-          />
-        </MemoryRouter>
-      );
+      render(<Step3 {...defaultProps} data={multiBeneficiaryData} />);
 
-      await waitFor(() => {
-        const datePicker = screen.getByTestId('date-picker-input');
-        expect(datePicker).toHaveValue('2025-06-15');
-      });
+      expect(screen.getByTestId('beneficiary-field')).toBeInTheDocument();
     });
   });
 
-  describe('Multi-beneficiary initialization logic', () => {
-    it('should initialize beneficiaries when multi-beneficiary is enabled and no beneficiaries exist', async () => {
-      render(
-        <MemoryRouter>
-          <Step3
-            data={{
-              ...initialData,
-              isMultibeneficiary: { value: false, readonly: false }
-            }}
-            setData={mockSetData}
-            onNext={mockOnNext}
-            onBack={mockOnBack}
-            step1Data={mockStep1Data}
-            step2Data={mockStep2Data}
-            isEditing={false}
-          />
-        </MemoryRouter>
+  describe('Form Validation', () => {
+    it('should show validation errors when form is invalid', async () => {
+      const { validateFormFields } = await import(
+        '../../../../utils/step3ValidationUtils'
       );
+      vi.mocked(validateFormFields).mockResolvedValueOnce(false);
 
-      const multiBeneficiarySwitch = screen.getByRole('checkbox', {
-        name: /Multiple Beneficiaries/i
-      });
+      render(<Step3 {...defaultProps} />);
 
-      fireEvent.click(multiBeneficiarySwitch);
+      const nextButton = screen.getByTestId('next-button');
+      await userEvent.click(nextButton);
 
-      await waitFor(() => {
-        expect(screen.getByTestId('beneficiary-field')).toBeInTheDocument();
-      });
+      expect(defaultProps.onNext).not.toHaveBeenCalled();
     });
 
-    it('should not initialize beneficiaries when in editing mode with already set up data', async () => {
-      const dataWithExistingBeneficiaries: Step3Data = {
-        ...initialData,
-        isMultibeneficiary: { value: true, readonly: false },
-        beneficiaries: [
-          {
-            entityName: 'Existing Entity',
-            amount: '100.00',
-            taxCode: 'EXISTING123',
-            remittance: 'Existing remittance',
-            iban: 'IT60X0542811101000000123456',
-            taxonomyCode: 'EXISTING'
-          }
-        ]
-      };
-
-      render(
-        <MemoryRouter
-          initialEntries={[
-            {
-              pathname: '/debt-position-edit',
-              state: { debtPositionId: 123 }
-            }
-          ]}
-        >
-          <Step3
-            data={dataWithExistingBeneficiaries}
-            setData={mockSetData}
-            onNext={mockOnNext}
-            onBack={mockOnBack}
-            step1Data={mockStep1Data}
-            step2Data={mockStep2Data}
-            isEditing={true}
-          />
-        </MemoryRouter>
+    it('should proceed when form is valid', async () => {
+      const { validateFormFields, validateBusinessLogic } = await import(
+        '../../../../utils/step3ValidationUtils'
+      );
+      const { prepareFormData } = await import(
+        '../../../../utils/step3FormDataUtils'
       );
 
-      await waitFor(() => {
-        expect(screen.getByTestId('beneficiary-field')).toBeInTheDocument();
-      });
+      vi.mocked(validateFormFields).mockResolvedValueOnce(true);
+      vi.mocked(validateBusinessLogic).mockResolvedValueOnce({ isValid: true });
+      vi.mocked(prepareFormData).mockReturnValueOnce(createDefaultStep3Data());
+
+      render(<Step3 {...defaultProps} />);
+
+      const nextButton = screen.getByTestId('next-button');
+      await userEvent.click(nextButton);
+
+      expect(nextButton).toBeInTheDocument();
     });
 
-    it('should clear beneficiaries when multi-beneficiary is disabled', async () => {
-      render(
-        <MemoryRouter>
-          <Step3
-            data={{
-              ...initialData,
-              isMultibeneficiary: { value: true, readonly: false }
-            }}
-            setData={mockSetData}
-            onNext={mockOnNext}
-            onBack={mockOnBack}
-            step1Data={mockStep1Data}
-            step2Data={mockStep2Data}
-            isEditing={false}
-          />
-        </MemoryRouter>
+    it('should handle business logic validation failure', async () => {
+      const { validateFormFields, validateBusinessLogic } = await import(
+        '../../../../utils/step3ValidationUtils'
       );
 
-      await waitFor(() => {
-        expect(screen.getByTestId('beneficiary-field')).toBeInTheDocument();
+      vi.mocked(validateFormFields).mockResolvedValueOnce(true);
+      vi.mocked(validateBusinessLogic).mockResolvedValueOnce({
+        isValid: false
       });
 
-      const multiBeneficiarySwitch = screen.getByRole('checkbox', {
-        name: /Multiple Beneficiaries/i
-      });
+      render(<Step3 {...defaultProps} />);
 
-      fireEvent.click(multiBeneficiarySwitch);
+      const nextButton = screen.getByTestId('next-button');
+      await userEvent.click(nextButton);
 
-      await waitFor(() => {
-        expect(
-          screen.queryByTestId('beneficiary-field')
-        ).not.toBeInTheDocument();
-      });
+      expect(nextButton).toBeInTheDocument();
     });
   });
 
-  describe('Additional edge cases', () => {
-    it('should handle beneficiary validation failure correctly', async () => {
-      vi.spyOn(paymentUtility, 'validateMultiBeneficiary').mockReturnValue(
-        false
-      );
+  describe('Edit Mode', () => {
+    const editModeProps = {
+      ...defaultProps,
+      isEditing: true,
+      data: {
+        ...createDefaultStep3Data(),
+        paymentObject: { value: 'Existing Payment Object', readonly: false },
+        amount: { value: '150.00', readonly: false }
+      }
+    };
 
-      render(
-        <MemoryRouter>
-          <Step3
-            data={{
-              ...initialData,
-              isMultibeneficiary: { value: true, readonly: false }
-            }}
-            setData={mockSetData}
-            onNext={mockOnNext}
-            onBack={mockOnBack}
-            step1Data={mockStep1Data}
-            step2Data={mockStep2Data}
-            isEditing={false}
-          />
-        </MemoryRouter>
-      );
+    it('should render in edit mode', () => {
+      render(<Step3 {...editModeProps} />);
 
-      await waitFor(() => {
-        expect(screen.getByTestId('beneficiary-field')).toBeInTheDocument();
-      });
-
-      const nextButton = screen.getByTestId('next-button');
-      fireEvent.click(nextButton);
-
-      await waitFor(() => {
-        expect(mockCreateDebtPositionAsync).not.toHaveBeenCalled();
-      });
+      expect(screen.getByTestId('wizard-step-wrapper')).toBeInTheDocument();
+      expect(
+        screen.getByDisplayValue('Existing Payment Object')
+      ).toBeInTheDocument();
+      expect(screen.getByDisplayValue('150,00')).toBeInTheDocument();
     });
 
-    it('should handle form validation failure correctly', async () => {
-      render(
-        <MemoryRouter>
-          <Step3
-            data={{
-              ...initialData,
-              paymentObject: { value: '', readonly: false }
-            }}
-            setData={mockSetData}
-            onNext={mockOnNext}
-            onBack={mockOnBack}
-            step1Data={mockStep1Data}
-            step2Data={mockStep2Data}
-            isEditing={false}
-          />
-        </MemoryRouter>
+    it('should populate form fields in edit mode', async () => {
+      const { hasActualDataToPopulate, populateAllFormFields } = await import(
+        '../../../../utils/step3FormDataUtils'
       );
 
-      const nextButton = screen.getByTestId('next-button');
-      fireEvent.click(nextButton);
-
-      await waitFor(() => {
-        expect(mockCreateDebtPositionAsync).not.toHaveBeenCalled();
+      vi.mocked(hasActualDataToPopulate).mockReturnValueOnce(true);
+      vi.mocked(populateAllFormFields).mockReturnValueOnce({
+        hasPopulatedSomething: true
       });
+
+      render(<Step3 {...editModeProps} />);
+
+      expect(hasActualDataToPopulate).toHaveBeenCalledWith(editModeProps.data);
     });
 
-    it('should handle installments modification correctly', async () => {
-      vi.spyOn(
-        installmentValidation,
-        'syncInstallmentBeneficiaries'
-      ).mockReturnValueOnce({
-        installments: [
-          {
-            amount: '100',
-            dueDate: '2025-07-15',
-            remittance: 'Modified payment',
-            isMultibeneficiary: false,
-            beneficiaries: []
-          }
-        ],
-        modified: true
-      });
-
-      vi.spyOn(
-        installmentValidation,
-        'validateInstallments'
-      ).mockReturnValueOnce({
-        hasInvalidBeneficiaries: false,
-        hasInvalidPaymentFields: false,
-        hasInvalidAmounts: false,
-        hasEmptyRemittance: false
-      });
-
-      render(
-        <MemoryRouter>
-          <Step3
-            data={{
-              ...initialData,
-              paymentOption: {
-                value: DebtPositionTypeEnum.INSTALLMENTS,
-                readonly: false
-              }
-            }}
-            setData={mockSetData}
-            onNext={mockOnNext}
-            onBack={mockOnBack}
-            step1Data={mockStep1Data}
-            step2Data={mockStep2Data}
-            isEditing={false}
-          />
-        </MemoryRouter>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByTestId('installment-field')).toBeInTheDocument();
-      });
+    it('should show correct button labels in edit mode', () => {
+      render(<Step3 {...editModeProps} />);
 
       const nextButton = screen.getByTestId('next-button');
-      fireEvent.click(nextButton);
+      expect(nextButton).toBeInTheDocument();
+    });
+  });
 
-      await waitFor(() => {
-        expect(mockCreateDebtPositionAsync).toHaveBeenCalled();
-      });
+  describe('Draft Mode', () => {
+    it('should show save draft button in creation mode', () => {
+      render(<Step3 {...defaultProps} />);
+
+      expect(screen.getByTestId('save-draft-button')).toBeInTheDocument();
     });
 
-    it('should handle amount formatting on blur with invalid number', async () => {
-      render(
-        <MemoryRouter>
-          <Step3
-            data={initialData}
-            setData={mockSetData}
-            onNext={mockOnNext}
-            onBack={mockOnBack}
-            step1Data={mockStep1Data}
-            step2Data={mockStep2Data}
-            isEditing={false}
-          />
-        </MemoryRouter>
+    it('should handle save draft click', async () => {
+      const { validateFormFields, validateBusinessLogic } = await import(
+        '../../../../utils/step3ValidationUtils'
       );
 
-      const amountInput = screen.getByRole('textbox', { name: /Amount/i });
+      vi.mocked(validateFormFields).mockResolvedValueOnce(true);
+      vi.mocked(validateBusinessLogic).mockResolvedValueOnce({ isValid: true });
 
-      fireEvent.change(amountInput, { target: { value: 'invalid-number' } });
-      fireEvent.blur(amountInput);
+      render(<Step3 {...defaultProps} />);
 
-      // Should not throw error and maintain the invalid value
-      expect(amountInput).toHaveValue('');
+      const saveDraftButton = screen.getByTestId('save-draft-button');
+      await userEvent.click(saveDraftButton);
+
+      expect(saveDraftButton).toBeInTheDocument();
+    });
+  });
+
+  describe('Installments Mode', () => {
+    const installmentsData = {
+      ...createDefaultStep3Data(),
+      paymentOption: {
+        value: DebtPositionTypeEnum.INSTALLMENTS,
+        readonly: false
+      },
+      installments: [createTestInstallment()]
+    };
+
+    it('should render installments field when payment option is installments', () => {
+      render(<Step3 {...defaultProps} data={installmentsData} />);
+
+      expect(screen.getByTestId('installment-field')).toBeInTheDocument();
+    });
+
+    it('should not show due date field in installments mode', () => {
+      render(<Step3 {...defaultProps} data={installmentsData} />);
+
+      expect(screen.queryByTestId('due-date-picker')).not.toBeInTheDocument();
+    });
+
+    it('should not show multi-beneficiary switch in installments mode', () => {
+      render(<Step3 {...defaultProps} data={installmentsData} />);
+
+      expect(
+        screen.queryByTestId('multi-beneficiary-switch')
+      ).not.toBeInTheDocument();
+    });
+
+    it('should disable amount field in installments mode', () => {
+      render(<Step3 {...defaultProps} data={installmentsData} />);
+
+      const amountField = screen.getByTestId('amount-field');
+      const amountInput = amountField.querySelector('input');
+      if (amountInput) {
+        expect(amountInput).toBeDisabled();
+      }
+    });
+
+    it('should disable payment object field in installments mode', () => {
+      render(<Step3 {...defaultProps} data={installmentsData} />);
+
+      const paymentObjectField = screen.getByTestId('payment-object-field');
+      const paymentObjectInput = paymentObjectField.querySelector('input');
+      if (paymentObjectInput) {
+        expect(paymentObjectInput).toBeDisabled();
+      }
+    });
+  });
+
+  describe('Multi-beneficiary Mode', () => {
+    const multiBeneficiaryData = {
+      ...createDefaultStep3Data(),
+      isMultibeneficiary: { value: true, readonly: false },
+      beneficiaries: [createTestBeneficiary()]
+    };
+
+    it('should render beneficiary field when multi-beneficiary is enabled', () => {
+      render(<Step3 {...defaultProps} data={multiBeneficiaryData} />);
+
+      expect(screen.getByTestId('beneficiary-field')).toBeInTheDocument();
+    });
+
+    it('should pass correct props to beneficiary field', async () => {
+      const { default: BeneficiaryField } = await import(
+        '../Beneficiary/BeneficiaryField'
+      );
+
+      render(<Step3 {...defaultProps} data={multiBeneficiaryData} />);
+
+      expect(BeneficiaryField).toHaveBeenCalledWith(
+        expect.objectContaining({
+          totalAmount: '',
+          fieldNamePrefix: 'beneficiaries',
+          disabled: false,
+          isEditing: false
+        }),
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('Button Interactions', () => {
+    it('should call onBack when back button is clicked', async () => {
+      render(<Step3 {...defaultProps} />);
+
+      const backButton = screen.getByTestId('back-button');
+      await userEvent.click(backButton);
+
+      expect(defaultProps.onBack).toHaveBeenCalled();
+    });
+
+    it('should handle create button click', async () => {
+      render(<Step3 {...defaultProps} />);
+
+      const nextButton = screen.getByTestId('next-button');
+      await userEvent.click(nextButton);
+
+      expect(screen.getByTestId('wizard-step-wrapper')).toBeInTheDocument();
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should handle API errors gracefully', async () => {
+      const { validateFormFields } = await import(
+        '../../../../utils/step3ValidationUtils'
+      );
+
+      vi.mocked(validateFormFields).mockRejectedValueOnce(
+        new Error('Validation error')
+      );
+
+      render(<Step3 {...defaultProps} />);
+
+      const nextButton = screen.getByTestId('next-button');
+      await userEvent.click(nextButton);
+
+      expect(screen.getByTestId('wizard-step-wrapper')).toBeInTheDocument();
+    });
+  });
+
+  describe('Form State Management', () => {
+    it('should update form state when data changes', () => {
+      const initialData = {
+        ...createDefaultStep3Data(),
+        paymentObject: { value: 'Initial Payment Object', readonly: false }
+      };
+
+      const { rerender } = render(
+        <Step3 {...defaultProps} data={initialData} />
+      );
+
+      const paymentObjectField = screen.getByTestId('payment-object-field');
+      const paymentObjectInput = paymentObjectField.querySelector('input');
+      if (paymentObjectInput) {
+        expect(paymentObjectInput).toHaveValue('Initial Payment Object');
+      }
+
+      const updatedData = {
+        ...createDefaultStep3Data(),
+        paymentObject: { value: 'Updated Payment Object', readonly: false }
+      };
+
+      rerender(<Step3 {...defaultProps} data={updatedData} />);
+
+      const updatedPaymentObjectField = screen.getByTestId(
+        'payment-object-field'
+      );
+      const updatedPaymentObjectInput =
+        updatedPaymentObjectField.querySelector('input');
+
+      expect(updatedPaymentObjectField).toBeInTheDocument();
+      if (updatedPaymentObjectInput) {
+        expect(updatedPaymentObjectInput).toBeInTheDocument();
+      }
+    });
+
+    it('should handle installments change', async () => {
+      render(<Step3 {...defaultProps} />);
+
+      expect(screen.getByTestId('wizard-step-wrapper')).toBeInTheDocument();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('should have proper form labels', () => {
+      render(<Step3 {...defaultProps} />);
+
+      expect(screen.getByTestId('payment-object-field')).toBeInTheDocument();
+      expect(screen.getByTestId('payment-option-field')).toBeInTheDocument();
+      expect(screen.getByTestId('amount-field')).toBeInTheDocument();
+    });
+
+    it('should have proper button roles', () => {
+      render(<Step3 {...defaultProps} />);
+
+      expect(screen.getByTestId('back-button')).toBeInTheDocument();
+      expect(screen.getByTestId('next-button')).toBeInTheDocument();
+      expect(screen.getByTestId('save-draft-button')).toBeInTheDocument();
+    });
+
+    it('should have proper form structure', () => {
+      render(<Step3 {...defaultProps} />);
+
+      const form = screen.getByTestId('step3-form');
+      expect(form).toBeInTheDocument();
+      expect(form).toHaveAttribute('id', 'step3-configuration-form');
+    });
+  });
+
+  describe('Performance', () => {
+    it('should not cause unnecessary re-renders', () => {
+      const { rerender } = render(<Step3 {...defaultProps} />);
+
+      rerender(<Step3 {...defaultProps} />);
+
+      expect(screen.getByTestId('wizard-step-wrapper')).toBeInTheDocument();
+    });
+  });
+
+  describe('Integration', () => {
+    it('should integrate properly with custom hooks', async () => {
+      const { useStep3ApiOperations } = await import(
+        '../../../../hooks/useStep3ApiOperations'
+      );
+      const { useStep3FormHandlers } = await import(
+        '../../../../hooks/useStep3FormHandlers'
+      );
+
+      render(<Step3 {...defaultProps} />);
+
+      expect(useStep3ApiOperations).toHaveBeenCalled();
+      expect(useStep3FormHandlers).toHaveBeenCalled();
+    });
+
+    it('should integrate properly with validation utilities', async () => {
+      render(<Step3 {...defaultProps} />);
+
+      const nextButton = screen.getByTestId('next-button');
+      await userEvent.click(nextButton);
+
+      expect(nextButton).toBeInTheDocument();
+    });
+
+    it('should integrate properly with form data utilities', async () => {
+      const { hasActualDataToPopulate } = await import(
+        '../../../../utils/step3FormDataUtils'
+      );
+
+      render(<Step3 {...defaultProps} isEditing={true} />);
+
+      expect(hasActualDataToPopulate).toHaveBeenCalled();
     });
   });
 });

--- a/src/routes/DebtPositionCreateWizard/components/Step/Step3.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step/Step3.tsx
@@ -13,7 +13,7 @@ import SectionBox from '../../../../components/Wizard/SectionBox';
 import ArticleIcon from '@mui/icons-material/Article';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useLocation } from 'react-router';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import BeneficiaryField from '../Beneficiary/BeneficiaryField';
 import InstallmentField from '../Installment/InstallmentField';
 import utils from '../../../../utils';
@@ -190,6 +190,13 @@ const Step3 = ({
   // Ref to track if the last action was publish (for correct title in completed page)
   const lastActionWasPublish = useRef(false);
 
+  // State to track if a final CTA (Create or Save draft) has been clicked
+  const [hasClickedFinalCTA, setHasClickedFinalCTA] = useState(false);
+
+  // Counter to track the number of submissions
+  // It is incremented on each final CTA click to distinguish between subsequent submissions
+  const [submissionCount, setSubmissionCount] = useState(0);
+
   const isDraftInEdit =
     isEditing && debtPositionDetail?.status === DebtPositionStatus.DRAFT;
 
@@ -225,7 +232,7 @@ const Step3 = ({
   const {
     handleSubmit,
     control,
-    formState: { errors, isSubmitted },
+    formState: { errors },
     watch,
     setValue,
     trigger,
@@ -396,6 +403,11 @@ const Step3 = ({
     const value = e.target.value;
     field.onChange(value);
 
+    // Reset hasClickedFinalCTA and submissionCount when payment mode changes
+    // Each mode should start "clean" without premature errors
+    setHasClickedFinalCTA(false);
+    setSubmissionCount(0);
+
     switch (value) {
       case DebtPositionTypeEnum.INSTALLMENTS:
         reset({
@@ -486,14 +498,38 @@ const Step3 = ({
     return { isValid: true, syncedInstallments };
   };
 
+  const handleCreateClick = () => {
+    setHasClickedFinalCTA(true);
+    setSubmissionCount((prev) => prev + 1);
+
+    // Force a re-render and then submit
+    setTimeout(() => {
+      handleSubmit((values) => onSubmit(values, false, isDraftInEdit))();
+    }, 0);
+  };
+
+  const handleSaveDraftClick = () => {
+    setHasClickedFinalCTA(true);
+    setSubmissionCount((prev) => prev + 1);
+
+    // Force a re-render and then submit
+    setTimeout(() => {
+      if (isDraftInEdit) {
+        handleSubmit((values) => onSubmit(values, false, false))();
+      } else {
+        handleSubmit((values) => onSubmit(values, true))();
+      }
+    }, 0);
+  };
+
   const getSaveDraftHandler = (): (() => void) | undefined => {
     if (isDraftInEdit) {
       // DRAFT in edit: save without publishing
-      return handleSubmit((values) => onSubmit(values, false, false));
+      return handleSaveDraftClick;
     }
     if (!isEditing) {
       // Creation mode: save as draft
-      return handleSubmit((values) => onSubmit(values, true));
+      return handleSaveDraftClick;
     }
     // UNPAID/EXPIRED in edit: no save draft option
     return undefined;
@@ -707,12 +743,12 @@ const Step3 = ({
                     required={!isInstallment}
                     disabled={data.paymentObject?.readonly || isInstallment}
                     error={
-                      isSubmitted &&
+                      hasClickedFinalCTA &&
                       !!errors.paymentObject?.value &&
                       !isInstallment
                     }
                     helperText={
-                      isSubmitted &&
+                      hasClickedFinalCTA &&
                       errors.paymentObject?.value?.message &&
                       !isInstallment
                         ? errors.paymentObject?.value?.message
@@ -743,8 +779,12 @@ const Step3 = ({
                     )}
                     required
                     disabled={data.paymentOption?.readonly}
-                    error={!!errors.paymentOption?.value}
-                    helperText={errors.paymentOption?.value?.message || ''}
+                    error={hasClickedFinalCTA && !!errors.paymentOption?.value}
+                    helperText={
+                      hasClickedFinalCTA && errors.paymentOption?.value?.message
+                        ? errors.paymentOption?.value?.message
+                        : ''
+                    }
                     onChange={(e) => handlePaymentOptionChange(e, field)}
                   >
                     <MenuItem
@@ -795,14 +835,16 @@ const Step3 = ({
                       }
                     }}
                     error={
-                      isSubmitted && !!errors.amount?.value && !isInstallment
+                      hasClickedFinalCTA &&
+                      !!errors.amount?.value &&
+                      !isInstallment
                     }
                     helperText={
                       isInstallment
                         ? t(
                             'debtPositionCreateWizard.step3.amount.installmentHelperText'
                           )
-                        : isSubmitted && errors.amount?.value?.message
+                        : hasClickedFinalCTA && errors.amount?.value?.message
                     }
                     onChange={(e) => handleAmountChange(e, field.onChange)}
                     onBlur={(e) => handleAmountBlur(e, field)}
@@ -831,14 +873,17 @@ const Step3 = ({
                           fullWidth: true,
                           required: data.flagMandatoryDueDate,
                           error: data.flagMandatoryDueDate
-                            ? isSubmitted && (!value || !!errors.dueDate?.value)
-                            : isSubmitted && !!errors.dueDate?.value,
+                            ? hasClickedFinalCTA &&
+                              (!value || !!errors.dueDate?.value)
+                            : hasClickedFinalCTA && !!errors.dueDate?.value,
                           helperText:
-                            isSubmitted && data.flagMandatoryDueDate && !value
+                            hasClickedFinalCTA &&
+                            data.flagMandatoryDueDate &&
+                            !value
                               ? t(
                                   'debtPositionCreateWizard.step3.dueDate.required'
                                 )
-                              : (isSubmitted &&
+                              : (hasClickedFinalCTA &&
                                   errors.dueDate?.value?.message) ||
                                 ''
                         },
@@ -903,7 +948,7 @@ const Step3 = ({
                   ref={beneficiaryFieldRef}
                   control={control}
                   errors={errors}
-                  isSubmitted={isSubmitted}
+                  isSubmitted={false}
                   totalAmount={totalAmount}
                   fieldNamePrefix="beneficiaries"
                   disabled={false}
@@ -912,6 +957,8 @@ const Step3 = ({
                   trigger={trigger}
                   onToggleMultibeneficiary={handleMultibeneficiaryToggle}
                   isEditing={isEditing}
+                  hasClickedFinalCTA={hasClickedFinalCTA}
+                  submissionCount={submissionCount}
                 />
               </Grid>
             )}
@@ -924,7 +971,7 @@ const Step3 = ({
           <InstallmentField<Step3FormValues>
             control={control}
             errors={errors}
-            isSubmitted={isSubmitted}
+            isSubmitted={hasClickedFinalCTA}
             fieldNamePrefix="installments"
             disabled={false}
             flagMandatoryDueDate={data.flagMandatoryDueDate}
@@ -933,14 +980,14 @@ const Step3 = ({
             trigger={trigger}
             onInstallmentsChange={handleInstallmentsChange}
             isEditing={isEditing}
+            hasClickedFinalCTA={hasClickedFinalCTA}
+            submissionCount={submissionCount}
           />
         </div>
       )}
       <WizardStepButtons
         onBack={onBack}
-        onNext={handleSubmit((values) =>
-          onSubmit(values, false, isDraftInEdit)
-        )}
+        onNext={handleCreateClick}
         onSaveDraft={getSaveDraftHandler()}
         disableNext={false}
         nextLabel={getNextButtonLabel()}

--- a/src/routes/DebtPositionCreateWizard/components/Step/Step3.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step/Step3.tsx
@@ -6,21 +6,17 @@ import {
   Switch,
   FormControlLabel
 } from '@mui/material';
-import { Controller, useForm, Path, UseFormSetValue } from 'react-hook-form';
+import { Controller, useForm } from 'react-hook-form';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import WizardStepButtons from '../../../../components/Wizard/WizardStepButtons';
 import SectionBox from '../../../../components/Wizard/SectionBox';
 import ArticleIcon from '@mui/icons-material/Article';
 import { useTranslation } from 'react-i18next';
-import { useNavigate, useLocation } from 'react-router';
+import { useLocation } from 'react-router';
 import { useEffect, useRef, useState } from 'react';
 import BeneficiaryField from '../Beneficiary/BeneficiaryField';
 import InstallmentField from '../Installment/InstallmentField';
-import utils from '../../../../utils';
-import type {
-  Installment,
-  PaymentOption
-} from '../../../../models/paymentTypes';
+import type { PaymentOption } from '../../../../models/paymentTypes';
 import WizardStepWrapper from '../../../../components/Wizard/WizardStepWrapper';
 import { BeneficiaryFieldRef } from '../Beneficiary/BeneficiaryField';
 import { useStore } from '../../../../store/GlobalStore';
@@ -30,30 +26,24 @@ import {
   Step1Data,
   DebtPositionTypeEnum
 } from '../../../../models/DebtPositionType';
-import {
-  DEFAULT_VALUES,
-  createInstallmentObject,
-  createSingleInstallmentObject,
-  triggerValidationForAllBeneficiaries,
-  syncInstallmentBeneficiaries,
-  validateInstallments,
-  validateMultiBeneficiary,
-  handleInstallmentValidationFailure
-} from '../../../../utils/paymentUtility';
 import debtPositionsApi from '../../../../api/debtPositions';
-import {
-  DebtPositionDTO,
-  DebtPositionStatus,
-  DebtPositionOrigin,
-  PaymentOptionTypeEnum
-} from '../../../../../generated/data-contracts';
-import { PageRoutes } from '../../../../routes';
+import { DebtPositionStatus } from '../../../../../generated/data-contracts';
 import {
   createStep3Resolver,
-  convertFormValuesToStep3Data,
-  Step3FormValues,
-  convertFormDataToManageDebtPositionDTO
+  Step3FormValues
 } from '../../../../models/Step3Schema';
+import { useStep3ApiOperations } from '../../../../hooks/useStep3ApiOperations';
+import { useStep3FormHandlers } from '../../../../hooks/useStep3FormHandlers';
+import {
+  validateFormFields,
+  validateBusinessLogic,
+  createValidateInstallmentsData
+} from '../../../../utils/step3ValidationUtils';
+import {
+  hasActualDataToPopulate,
+  populateAllFormFields,
+  prepareFormData
+} from '../../../../utils/step3FormDataUtils';
 
 type Props = {
   data: Step3Data;
@@ -65,101 +55,6 @@ type Props = {
   isEditing?: boolean;
 };
 
-/**
- * Checks if there's actual data to populate in the form (not just empty strings)
- */
-const hasActualDataToPopulate = (data: Step3Data): boolean => {
-  return Boolean(
-    (data.paymentObject?.value && data.paymentObject.value.trim() !== '') ||
-      (data.paymentOption?.value && data.paymentOption.value.trim() !== '') ||
-      (data.amount?.value && data.amount.value.trim() !== '') ||
-      (data.dueDate?.value && data.dueDate.value.trim() !== '') ||
-      (data.beneficiaries && data.beneficiaries.length > 0) ||
-      (data.installments && data.installments.length > 0)
-  );
-};
-
-/**
- * Populates the basic form fields with available data
- */
-const populateBasicFields = (
-  data: Step3Data,
-  setValue: UseFormSetValue<Step3FormValues>
-): boolean => {
-  let hasPopulatedSomething = false;
-
-  if (data.paymentObject?.value && data.paymentObject.value.trim() !== '') {
-    setValue('paymentObject.value', data.paymentObject.value);
-    hasPopulatedSomething = true;
-  }
-
-  if (data.paymentOption?.value && data.paymentOption.value.trim() !== '') {
-    setValue('paymentOption.value', data.paymentOption.value);
-    hasPopulatedSomething = true;
-  }
-
-  if (data.amount?.value && data.amount.value.trim() !== '') {
-    setValue('amount.value', data.amount.value);
-    hasPopulatedSomething = true;
-  }
-
-  return hasPopulatedSomething;
-};
-
-/**
- * Populates the due date field converting from string to Date if necessary
- */
-const populateDueDateField = (
-  data: Step3Data,
-  setValue: UseFormSetValue<Step3FormValues>
-): boolean => {
-  if (data.dueDate?.value && data.dueDate.value.trim() !== '') {
-    const dateValue =
-      typeof data.dueDate.value === 'string'
-        ? new Date(data.dueDate.value)
-        : data.dueDate.value;
-    setValue('dueDate.value', dateValue);
-    return true;
-  }
-  return false;
-};
-
-/**
- * Populates the multi-beneficiary field
- */
-const populateMultiBeneficiaryField = (
-  data: Step3Data,
-  setValue: UseFormSetValue<Step3FormValues>
-): boolean => {
-  if (data.isMultibeneficiary?.value != null) {
-    setValue('isMultibeneficiary.value', data.isMultibeneficiary.value);
-    return true;
-  }
-  return false;
-};
-
-/**
- * Populates the beneficiaries and installments fields
- */
-const populateComplexFields = (
-  data: Step3Data,
-  setValue: UseFormSetValue<Step3FormValues>
-): boolean => {
-  let hasPopulatedSomething = false;
-
-  if (data.beneficiaries && data.beneficiaries.length > 0) {
-    setValue('beneficiaries', data.beneficiaries);
-    hasPopulatedSomething = true;
-  }
-
-  if (data.installments && data.installments.length > 0) {
-    setValue('installments', data.installments);
-    hasPopulatedSomething = true;
-  }
-
-  return hasPopulatedSomething;
-};
-
 const Step3 = ({
   data,
   setData,
@@ -169,11 +64,13 @@ const Step3 = ({
   isEditing = false
 }: Props) => {
   const { t } = useTranslation();
-  const navigate = useNavigate();
   const location = useLocation();
   const {
     state: { organizationId }
   } = useStore();
+
+  // Custom hook for managing API operations
+  const { handleEditModeFlow, handleCreateModeFlow } = useStep3ApiOperations();
 
   // Extract debtPositionId for edit mode
   const debtPositionId = location.state?.debtPositionId;
@@ -186,9 +83,6 @@ const Step3 = ({
 
   // Ref to avoid executing the setup logic more than once
   const hasSetupStep3Data = useRef(false);
-
-  // Ref to track if the last action was publish (for correct title in completed page)
-  const lastActionWasPublish = useRef(false);
 
   // State to track if a final CTA (Create or Save draft) has been clicked
   const [hasClickedFinalCTA, setHasClickedFinalCTA] = useState(false);
@@ -256,19 +150,10 @@ const Step3 = ({
     const hasActualData = hasActualDataToPopulate(data);
 
     if (hasActualData && !hasSetupStep3Data.current) {
-      const basicFieldsPopulated = populateBasicFields(data, setValue);
-      const dueDatePopulated = populateDueDateField(data, setValue);
-      const multiBeneficiaryPopulated = populateMultiBeneficiaryField(
+      const { hasPopulatedSomething } = populateAllFormFields({
         data,
         setValue
-      );
-      const complexFieldsPopulated = populateComplexFields(data, setValue);
-
-      const hasPopulatedSomething =
-        basicFieldsPopulated ||
-        dueDatePopulated ||
-        multiBeneficiaryPopulated ||
-        complexFieldsPopulated;
+      });
 
       if (hasPopulatedSomething) {
         hasSetupStep3Data.current = true;
@@ -291,6 +176,29 @@ const Step3 = ({
   const beneficiaries = watch('beneficiaries') || [];
   const paymentOption = watch('paymentOption.value');
   const isInstallment = paymentOption === DebtPositionTypeEnum.INSTALLMENTS;
+
+  // Reference to BeneficiaryField component to access its methods
+  const beneficiaryFieldRef = useRef<BeneficiaryFieldRef>({});
+
+  // Custom hook per gestire gli event handlers del form
+  const {
+    handleAmountChange,
+    handleAmountBlur,
+    handlePaymentOptionChange,
+    handleMultibeneficiaryToggle
+  } = useStep3FormHandlers({
+    setValue,
+    trigger,
+    reset,
+    getValues,
+    initialData,
+    isMultibeneficiary,
+    beneficiaries,
+    paymentOption,
+    beneficiaryFieldRef,
+    setHasClickedFinalCTA,
+    setSubmissionCount
+  });
 
   // Effect to handle beneficiaries initialization
   useEffect(() => {
@@ -330,173 +238,12 @@ const Step3 = ({
     setValue('amount.value', totalAmount);
   };
 
-  // Reference to BeneficiaryField component to access its methods
-  const beneficiaryFieldRef = useRef<BeneficiaryFieldRef>({});
-
-  // Handle multi-beneficiary toggle switch
-  const handleMultibeneficiaryToggle = (value: boolean) => {
-    // First reset the previous validation state
-    if (
-      value &&
-      beneficiaryFieldRef.current &&
-      beneficiaryFieldRef.current.resetAllBeneficiaries
-    ) {
-      beneficiaryFieldRef.current.resetAllBeneficiaries();
-    }
-
-    // Then set the new value
-    setValue('isMultibeneficiary.value', value, { shouldValidate: false });
-
-    // If disabling multi-beneficiary, reset beneficiaries
-    if (
-      !value &&
-      beneficiaryFieldRef.current &&
-      beneficiaryFieldRef.current.resetAllBeneficiaries
-    ) {
-      beneficiaryFieldRef.current.resetAllBeneficiaries();
-    }
-  };
-
-  /**
-   * Handles the amount field change
-   * Normalizes the value and triggers validation for beneficiaries if needed
-   */
-  const handleAmountChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-    onChange: (...event: Array<unknown>) => void
-  ) => {
-    const filteredValue = e.target.value.replace(/[^0-9.,]/g, '');
-    const normalizedValue = filteredValue.replace(',', '.');
-    onChange(normalizedValue);
-
-    if (isMultibeneficiary && beneficiaries.length > 0) {
-      setTimeout(() => {
-        triggerValidationForAllBeneficiaries(beneficiaries, trigger);
-      }, 0);
-    }
-  };
-
-  /**
-   * Handles amount field blur event
-   * Formats the value with two decimals when the field loses focus
-   */
-  const handleAmountBlur = (
-    e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>,
-    field: { onChange: (...event: Array<unknown>) => void; onBlur: () => void }
-  ) => {
-    const value = e.target.value.replace(',', '.');
-    if (value && !isNaN(parseFloat(value))) {
-      const formatted = parseFloat(value).toFixed(2);
-      field.onChange(formatted);
-    }
-    field.onBlur();
-  };
-
-  /**
-   * Handles payment option changes
-   * Resets fields when changing from one payment mode to another
-   */
-  const handlePaymentOptionChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-    field: { onChange: (...event: Array<unknown>) => void }
-  ) => {
-    const value = e.target.value;
-    field.onChange(value);
-
-    // Reset hasClickedFinalCTA and submissionCount when payment mode changes
-    // Each mode should start "clean" without premature errors
-    setHasClickedFinalCTA(false);
-    setSubmissionCount(0);
-
-    switch (value) {
-      case DebtPositionTypeEnum.INSTALLMENTS:
-        reset({
-          ...initialData,
-          paymentOption: {
-            ...initialData.paymentOption,
-            value: DebtPositionTypeEnum.INSTALLMENTS as PaymentOption
-          },
-          isMultibeneficiary: {
-            ...initialData.isMultibeneficiary,
-            value: false
-          },
-          beneficiaries: [],
-          installments: []
-        });
-        break;
-      case PaymentOptionTypeEnum.SINGLE_INSTALLMENT:
-        if (paymentOption === DebtPositionTypeEnum.INSTALLMENTS) {
-          reset({
-            ...initialData,
-            paymentOption: {
-              ...initialData.paymentOption,
-              value: DebtPositionTypeEnum.SINGLE as PaymentOption
-            },
-            isMultibeneficiary: {
-              ...initialData.isMultibeneficiary,
-              value: false
-            },
-            beneficiaries: [],
-            installments: []
-          });
-        }
-        break;
-    }
-
-    setTimeout(() => {
-      if (
-        beneficiaryFieldRef.current &&
-        beneficiaryFieldRef.current.resetAllBeneficiaries
-      ) {
-        beneficiaryFieldRef.current.resetAllBeneficiaries();
-      }
-    }, 0);
-  };
-
-  /**
-   * Validates installments and their beneficiaries
-   * @returns An object with the validation result and synchronized installments
-   */
-  const validateInstallmentsData = async (): Promise<{
-    isValid: boolean;
-    syncedInstallments?: Array<Installment>;
-  }> => {
-    const installments = getValues('installments') || [];
-
-    const cleanedInstallments = installments.map((installment) => {
-      if (!installment.isMultibeneficiary) {
-        return {
-          ...installment,
-          beneficiaries: []
-        };
-      }
-      return installment;
-    });
-
-    const { installments: syncedInstallments, modified } =
-      syncInstallmentBeneficiaries(cleanedInstallments as Array<Installment>);
-
-    if (modified) {
-      setValue('installments', syncedInstallments);
-    }
-
-    const validationResults = validateInstallments(syncedInstallments, trigger);
-
-    const hasValidationFailure = Object.values(validationResults).some(
-      (value) => value
-    );
-
-    if (hasValidationFailure) {
-      handleInstallmentValidationFailure(
-        syncedInstallments,
-        validationResults,
-        trigger
-      );
-      return { isValid: false };
-    }
-
-    return { isValid: true, syncedInstallments };
-  };
+  // Create the validateInstallmentsData function with the form parameters
+  const validateInstallmentsDataFn = createValidateInstallmentsData({
+    getValues,
+    setValue,
+    trigger
+  });
 
   const handleCreateClick = () => {
     setHasClickedFinalCTA(true);
@@ -540,175 +287,68 @@ const Step3 = ({
     isDraft = false,
     shouldPublish = false
   ) => {
-    // Check due date field if mandatory
-    if (!isInstallment && values.flagMandatoryDueDate) {
-      if (!values.dueDate.value) {
-        setValue('dueDate.value', null, { shouldValidate: true });
-        await trigger('dueDate.value');
-        return;
-      }
-    }
-
-    // Validate all fields before proceeding
-    const isValid = await trigger();
-
-    if (!isValid) {
+    // Validate form fields including mandatory due date
+    const isFormValid = await validateFormFields({
+      values,
+      isInstallment,
+      setValue,
+      trigger
+    });
+    if (!isFormValid) {
       return;
     }
 
-    // For single payment, validate beneficiaries
-    if (!isInstallment) {
-      const beneficiariesValid = validateMultiBeneficiary(
-        () => getValues('beneficiaries') || [],
+    // Validate business logic (beneficiaries or installments)
+    const { isValid: isBusinessValid, syncedInstallments } =
+      await validateBusinessLogic({
+        isInstallment,
         isMultibeneficiary,
         totalAmount,
-        (name) => trigger(`beneficiaries.${name}` as Path<Step3FormValues>)
-      );
+        getValues,
+        trigger,
+        setValue,
+        validateInstallmentsData: validateInstallmentsDataFn
+      });
 
-      if (!beneficiariesValid) {
-        return;
-      }
+    if (!isBusinessValid) {
+      return;
     }
 
-    // Validate beneficiaries for each installment if payment is installment-based
-    if (isInstallment) {
-      const { isValid, syncedInstallments } = await validateInstallmentsData();
-
-      if (!isValid || !syncedInstallments) {
-        return;
-      }
-
-      if (
-        JSON.stringify(getValues('installments')) !==
-        JSON.stringify(syncedInstallments)
-      ) {
-        setValue('installments', syncedInstallments);
-      }
-    }
-
-    // Transform form values using conversion function
-    const formattedValues: Step3Data = convertFormValuesToStep3Data({
-      ...values,
-      flagMandatoryDueDate: values.flagMandatoryDueDate,
+    // Transform form values and save data
+    const formattedData = prepareFormData({
+      values,
+      syncedInstallments,
       step1Data,
-      step2Data
+      step2Data,
+      setData
     });
-
-    // Save data
-    setData(formattedValues);
 
     // In edit mode, call manage installments API
     if (isEditing && debtPositionId && debtPositionDetail) {
-      const firstPaymentOption = debtPositionDetail.paymentOptions?.[0];
-      if (!firstPaymentOption?.paymentOptionId) {
-        utils.notify.emit(
-          t('debtPositionCreateWizard.step3.error.missingPaymentOption'),
-          'error'
-        );
-        return;
-      }
-
-      // Validate debtPositionId
-      if (!debtPositionId || isNaN(Number(debtPositionId))) {
-        console.error('Invalid debtPositionId:', debtPositionId);
-        utils.notify.emit(
-          t('debtPositionCreateWizard.errorMissingId'),
-          'error'
-        );
-        return;
-      }
-
-      try {
-        const manageBody = convertFormDataToManageDebtPositionDTO(
-          values,
-          step2Data,
-          firstPaymentOption.paymentOptionId,
-          debtPositionDetail,
-          step1Data
-        );
-
-        const shouldPublishPosition = shouldPublish;
-        lastActionWasPublish.current = shouldPublishPosition && isDraftInEdit;
-
-        try {
-          const response = await manageInstallmentsMutation.mutateAsync({
-            organizationId,
-            debtPositionId: Number(debtPositionId),
-            body: manageBody,
-            publish: shouldPublishPosition
-          });
-          navigate(PageRoutes.DEBT_POSITION_CREATE_WIZARD_COMPLETED, {
-            state: {
-              ...response,
-              isEditing: true,
-              wasPublished: lastActionWasPublish.current
-            },
-            replace: true
-          });
-        } catch (error) {
-          console.error(error);
-          navigate(PageRoutes.RESPONSES_ERROR);
-        }
-      } catch (error) {
-        console.error('Error converting form data:', error);
-        utils.notify.emit(
-          t('debtPositionCreateWizard.step3.error.conversionError'),
-          'error'
-        );
-      }
+      await handleEditModeFlow({
+        values,
+        step1Data,
+        step2Data,
+        debtPositionId,
+        debtPositionDetail,
+        shouldPublish,
+        isDraftInEdit,
+        organizationId,
+        manageInstallmentsMutation
+      });
       return;
     }
 
-    const postBody: DebtPositionDTO = {
-      description: formattedValues.step1Data?.description.value || '',
-      status: isDraft ? DebtPositionStatus.DRAFT : DebtPositionStatus.UNPAID,
-      organizationId: organizationId,
-      debtPositionTypeOrgId: Number(
-        formattedValues.step1Data?.debtPositionType.value || 0
-      ),
-      flagIuvVolatile: DEFAULT_VALUES.FLAG_IUV_VOLATILE,
-      debtPositionOrigin: DebtPositionOrigin.ORDINARY,
-      multiDebtor: DEFAULT_VALUES.MULTI_DEBTOR,
-      flagPuPagoPaPayment: DEFAULT_VALUES.FLAG_PAGO_PA_PU_PAYMENT,
-      paymentOptions: [
-        {
-          totalAmountCents: Math.round(
-            parseFloat(formattedValues.amount.value || '0') * 100
-          ),
-          description: isInstallment
-            ? t('debtPositionCreateWizard.step3.paymentOption.installments')
-            : t('debtPositionCreateWizard.step3.paymentOption.single'),
-          paymentOptionType: isInstallment
-            ? PaymentOptionTypeEnum.INSTALLMENTS
-            : PaymentOptionTypeEnum.SINGLE_INSTALLMENT,
-          paymentOptionIndex: DEFAULT_VALUES.PAYMENT_OPTION_INDEX,
-          installments: isInstallment
-            ? formattedValues.installments?.map((installment) =>
-                createInstallmentObject(installment, step2Data, formattedValues)
-              ) || []
-            : [createSingleInstallmentObject(formattedValues, step2Data)]
-        }
-      ]
-    };
-    try {
-      const response = await createDebtPositionMutation.mutateAsync({
-        body: postBody,
-        paymentObject: postBody.description
-      });
-      navigate(PageRoutes.DEBT_POSITION_CREATE_WIZARD_COMPLETED, {
-        state: {
-          description: response.paymentObject,
-          status: response.response?.status,
-          debtPositionId: response.response?.debtPositionId,
-          isEditing: false,
-          wasPublished: !isDraft
-        },
-        replace: true
-      });
-    } catch (error) {
-      console.error(error);
-      navigate(PageRoutes.RESPONSES_ERROR);
-    }
+    // Create new debt position
+    await handleCreateModeFlow({
+      formattedData,
+      step1Data,
+      step2Data,
+      isInstallment,
+      isDraft,
+      organizationId,
+      createDebtPositionMutation
+    });
   };
 
   return (

--- a/src/routes/DebtPositionCreateWizard/components/Step/Step3.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step/Step3.tsx
@@ -13,7 +13,7 @@ import SectionBox from '../../../../components/Wizard/SectionBox';
 import ArticleIcon from '@mui/icons-material/Article';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import BeneficiaryField from '../Beneficiary/BeneficiaryField';
 import InstallmentField from '../Installment/InstallmentField';
 import type { PaymentOption } from '../../../../models/paymentTypes';
@@ -34,11 +34,7 @@ import {
 } from '../../../../models/Step3Schema';
 import { useStep3ApiOperations } from '../../../../hooks/useStep3ApiOperations';
 import { useStep3FormHandlers } from '../../../../hooks/useStep3FormHandlers';
-import {
-  validateFormFields,
-  validateBusinessLogic,
-  createValidateInstallmentsData
-} from '../../../../utils/step3ValidationUtils';
+import { useStep3Validation } from '../../../../hooks/useStep3Validation';
 import {
   hasActualDataToPopulate,
   populateAllFormFields,
@@ -83,13 +79,6 @@ const Step3 = ({
 
   // Ref to avoid executing the setup logic more than once
   const hasSetupStep3Data = useRef(false);
-
-  // State to track if a final CTA (Create or Save draft) has been clicked
-  const [hasClickedFinalCTA, setHasClickedFinalCTA] = useState(false);
-
-  // Counter to track the number of submissions
-  // It is incremented on each final CTA click to distinguish between subsequent submissions
-  const [submissionCount, setSubmissionCount] = useState(0);
 
   const isDraftInEdit =
     isEditing && debtPositionDetail?.status === DebtPositionStatus.DRAFT;
@@ -139,6 +128,21 @@ const Step3 = ({
     reValidateMode: 'onChange',
     criteriaMode: 'all',
     context: { flagMandatoryDueDate: data.flagMandatoryDueDate }
+  });
+
+  // Centralized validation hook - manages hasClickedFinalCTA, submissionCount, and validation logic
+  const {
+    hasClickedFinalCTA,
+    submissionCount,
+    markFinalCTAClicked,
+    resetValidationState,
+    validateStep3Form,
+    shouldShowErrors
+  } = useStep3Validation({
+    setValue,
+    trigger,
+    getValues,
+    flagMandatoryDueDate: data.flagMandatoryDueDate
   });
 
   // Effect to populate form fields when data is available in edit mode
@@ -196,8 +200,7 @@ const Step3 = ({
     beneficiaries,
     paymentOption,
     beneficiaryFieldRef,
-    setHasClickedFinalCTA,
-    setSubmissionCount
+    resetValidationState
   });
 
   // Effect to handle beneficiaries initialization
@@ -238,16 +241,8 @@ const Step3 = ({
     setValue('amount.value', totalAmount);
   };
 
-  // Create the validateInstallmentsData function with the form parameters
-  const validateInstallmentsDataFn = createValidateInstallmentsData({
-    getValues,
-    setValue,
-    trigger
-  });
-
   const handleCreateClick = () => {
-    setHasClickedFinalCTA(true);
-    setSubmissionCount((prev) => prev + 1);
+    markFinalCTAClicked();
 
     // Force a re-render and then submit
     setTimeout(() => {
@@ -256,8 +251,7 @@ const Step3 = ({
   };
 
   const handleSaveDraftClick = () => {
-    setHasClickedFinalCTA(true);
-    setSubmissionCount((prev) => prev + 1);
+    markFinalCTAClicked();
 
     // Force a re-render and then submit
     setTimeout(() => {
@@ -287,30 +281,14 @@ const Step3 = ({
     isDraft = false,
     shouldPublish = false
   ) => {
-    // Validate form fields including mandatory due date
-    const isFormValid = await validateFormFields({
-      values,
+    // Use centralized validation
+    const { isValid, syncedInstallments } = await validateStep3Form({
       isInstallment,
-      setValue,
-      trigger
+      isMultibeneficiary,
+      totalAmount
     });
-    if (!isFormValid) {
-      return;
-    }
 
-    // Validate business logic (beneficiaries or installments)
-    const { isValid: isBusinessValid, syncedInstallments } =
-      await validateBusinessLogic({
-        isInstallment,
-        isMultibeneficiary,
-        totalAmount,
-        getValues,
-        trigger,
-        setValue,
-        validateInstallmentsData: validateInstallmentsDataFn
-      });
-
-    if (!isBusinessValid) {
+    if (!isValid) {
       return;
     }
 
@@ -597,7 +575,7 @@ const Step3 = ({
                   trigger={trigger}
                   onToggleMultibeneficiary={handleMultibeneficiaryToggle}
                   isEditing={isEditing}
-                  hasClickedFinalCTA={hasClickedFinalCTA}
+                  shouldShowErrors={shouldShowErrors}
                   submissionCount={submissionCount}
                 />
               </Grid>
@@ -620,7 +598,7 @@ const Step3 = ({
             trigger={trigger}
             onInstallmentsChange={handleInstallmentsChange}
             isEditing={isEditing}
-            hasClickedFinalCTA={hasClickedFinalCTA}
+            shouldShowErrors={shouldShowErrors}
             submissionCount={submissionCount}
           />
         </div>

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -1210,7 +1210,7 @@
           "required": "Il campo conto corrente postale è obbligatorio"
         },
         "sumMustBeLessThanTotal": "La somma degli importi dei beneficiari deve essere minore dell'importo totale",
-        "sumMustBeLessThanTotalInstallments": "La somma degli importi dei beneficiari deve essere minore dell'importo totale, clicca su No per modificare",
+        "sumMustBeLessThanTotalInstallments": "La somma degli importi dei beneficiari deve essere minore dell'importo totale della rata.",
         "taxCodeOrVat": {
           "invalid": "Codice fiscale o partita IVA non validi",
           "label": "Codice Fiscale o Partita IVA",

--- a/src/utils/__tests__/beneficiaryValidation.test.ts
+++ b/src/utils/__tests__/beneficiaryValidation.test.ts
@@ -14,26 +14,26 @@ import {
   checkPaymentFields,
   validateSingleAmount,
   createBaseValidationRule,
-  createPaymentMethodValidator,
-  ValidationContext
+  createPaymentMethodValidator
 } from '../beneficiaryValidation';
+import type { BeneficiaryValidationContext } from '../../models/paymentTypes';
 
 describe('beneficiaryValidation', () => {
   describe('isEmpty', () => {
-    it('restituisce true per valori vuoti', () => {
+    it('returns true for empty values', () => {
       expect(isEmpty('')).toBe(true);
       expect(isEmpty('   ')).toBe(true);
       expect(isEmpty()).toBe(true);
       expect(isEmpty(null)).toBe(true);
     });
 
-    it('restituisce false per valori non vuoti', () => {
+    it('returns false for non-empty values', () => {
       expect(isEmpty('test')).toBe(false);
       expect(isEmpty('0')).toBe(false);
       expect(isEmpty(' test ')).toBe(false);
     });
 
-    it('restituisce true per valori non stringa', () => {
+    it('returns true for non-string values', () => {
       expect(isEmpty(0)).toBe(true);
       expect(isEmpty(123)).toBe(true);
       expect(isEmpty({})).toBe(true);
@@ -42,7 +42,7 @@ describe('beneficiaryValidation', () => {
   });
 
   describe('getErrorData', () => {
-    it('restituisce dati di errore corretti', () => {
+    it('returns correct error data', () => {
       const mockErrors = {
         beneficiaries: {
           0: {
@@ -60,7 +60,7 @@ describe('beneficiaryValidation', () => {
       });
     });
 
-    it('gestisce correttamente gli errori mancanti', () => {
+    it('handles missing errors correctly', () => {
       const mockErrors = {} as FieldErrors<Record<string, unknown>>;
 
       const result = getErrorData(mockErrors, 'beneficiaries', 0, 'entityName');
@@ -70,7 +70,7 @@ describe('beneficiaryValidation', () => {
       });
     });
 
-    it('gestisce correttamente un errore senza messaggio', () => {
+    it('correctly handles an error without a message', () => {
       const mockErrors = {
         beneficiaries: {
           0: {
@@ -88,7 +88,7 @@ describe('beneficiaryValidation', () => {
   });
 
   describe('isBeneficiaryNew', () => {
-    it('restituisce true se il beneficiario è nuovo', () => {
+    it('returns true if the beneficiary is new', () => {
       const mockWasSubmittedRef = { current: true };
       const mockExistingBeneficiaries = { 'id-1': true };
 
@@ -97,7 +97,7 @@ describe('beneficiaryValidation', () => {
       ).toBe(true);
     });
 
-    it('restituisce false se il beneficiario esiste già', () => {
+    it('returns false if the beneficiary already exists', () => {
       const mockWasSubmittedRef = { current: true };
       const mockExistingBeneficiaries = { 'id-1': true };
 
@@ -106,7 +106,7 @@ describe('beneficiaryValidation', () => {
       ).toBe(false);
     });
 
-    it('restituisce false se wasSubmittedRef è false', () => {
+    it('returns false if wasSubmittedRef is false', () => {
       const mockWasSubmittedRef = { current: false };
       const mockExistingBeneficiaries = {};
 
@@ -117,7 +117,7 @@ describe('beneficiaryValidation', () => {
   });
 
   describe('isRecentlyCreated', () => {
-    it('restituisce true se wasSubmittedRef è false', () => {
+    it('returns true if wasSubmittedRef is false', () => {
       const mockWasSubmittedRef = { current: false };
       const mockExistingBeneficiaries = {};
 
@@ -130,7 +130,7 @@ describe('beneficiaryValidation', () => {
       ).toBe(true);
     });
 
-    it('restituisce true se il beneficiario non è tra quelli esistenti', () => {
+    it('returns true if the beneficiary is not in existing beneficiaries', () => {
       const mockWasSubmittedRef = { current: true };
       const mockExistingBeneficiaries = { 'id-1': true };
 
@@ -143,7 +143,7 @@ describe('beneficiaryValidation', () => {
       ).toBe(true);
     });
 
-    it('restituisce false se il beneficiario è tra quelli esistenti e wasSubmittedRef è true', () => {
+    it('returns false if the beneficiary is among existing ones and wasSubmittedRef is true', () => {
       const mockWasSubmittedRef = { current: true };
       const mockExistingBeneficiaries = { 'id-1': true };
 
@@ -158,7 +158,7 @@ describe('beneficiaryValidation', () => {
   });
 
   describe('shouldShowValidationErrors', () => {
-    it('restituisce true se isSubmitted è true e il beneficiario esiste', () => {
+    it('returns true if isSubmitted is true and the beneficiary exists', () => {
       const mockWasSubmittedRef = { current: true };
       const mockExistingBeneficiaries = { 'id-1': true };
 
@@ -172,7 +172,7 @@ describe('beneficiaryValidation', () => {
       ).toBe(true);
     });
 
-    it('restituisce false se isSubmitted è false', () => {
+    it('returns false if isSubmitted is false', () => {
       const mockWasSubmittedRef = { current: true };
       const mockExistingBeneficiaries = { 'id-1': true };
 
@@ -186,7 +186,7 @@ describe('beneficiaryValidation', () => {
       ).toBe(false);
     });
 
-    it('restituisce false se il beneficiario è nuovo e wasSubmittedRef è false', () => {
+    it('returns false if the beneficiary is new and wasSubmittedRef is false', () => {
       const mockWasSubmittedRef = { current: false };
       const mockExistingBeneficiaries = {};
 
@@ -202,7 +202,7 @@ describe('beneficiaryValidation', () => {
   });
 
   describe('shouldSkipValidation', () => {
-    it('restituisce true se non si devono mostrare errori di validazione', () => {
+    it('returns true if validation errors should not be shown', () => {
       const mockContext = {
         id: 'id-1',
         isSubmitted: false,
@@ -212,13 +212,15 @@ describe('beneficiaryValidation', () => {
         fieldNamePrefix: 'beneficiaries',
         index: 0,
         getValues: vi.fn(),
-        t: vi.fn()
-      } as unknown as ValidationContext<Record<string, unknown>>;
+        t: vi.fn(),
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
       expect(shouldSkipValidation(mockContext)).toBe(true);
     });
 
-    it('restituisce false se si devono mostrare errori di validazione', () => {
+    it('returns false if validation errors should be shown', () => {
       const mockContext = {
         id: 'id-1',
         isSubmitted: true,
@@ -228,15 +230,17 @@ describe('beneficiaryValidation', () => {
         fieldNamePrefix: 'beneficiaries',
         index: 0,
         getValues: vi.fn(),
-        t: vi.fn()
-      } as unknown as ValidationContext<Record<string, unknown>>;
+        t: vi.fn(),
+        submissionCount: 2,
+        creationSubmissionCount: 1
+      } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
       expect(shouldSkipValidation(mockContext)).toBe(false);
     });
   });
 
   describe('buildFieldPath', () => {
-    it('costruisce correttamente il path del campo', () => {
+    it('builds the field path correctly', () => {
       expect(buildFieldPath('beneficiaries', 0, 'entityName')).toBe(
         'beneficiaries.0.entityName'
       );
@@ -245,7 +249,7 @@ describe('beneficiaryValidation', () => {
   });
 
   describe('hasFieldError', () => {
-    it('restituisce false se shouldSkipValidation è true', () => {
+    it('returns false if shouldSkipValidation is true', () => {
       const mockContext = {
         id: 'id-1',
         isSubmitted: false,
@@ -255,13 +259,15 @@ describe('beneficiaryValidation', () => {
         fieldNamePrefix: 'beneficiaries',
         index: 0,
         getValues: vi.fn(),
-        t: vi.fn()
-      } as unknown as ValidationContext<Record<string, unknown>>;
+        t: vi.fn(),
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
       expect(hasFieldError('entityName', mockContext)).toBe(false);
     });
 
-    it('restituisce true se il campo ha un errore', () => {
+    it('returns true if the field has an error', () => {
       const mockContext = {
         id: 'id-1',
         isSubmitted: true,
@@ -279,13 +285,15 @@ describe('beneficiaryValidation', () => {
         fieldNamePrefix: 'beneficiaries',
         index: 0,
         getValues: vi.fn(),
-        t: vi.fn()
-      } as unknown as ValidationContext<Record<string, unknown>>;
+        t: vi.fn(),
+        submissionCount: 2,
+        creationSubmissionCount: 1
+      } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
       expect(hasFieldError('entityName', mockContext)).toBe(true);
     });
 
-    it('restituisce false se il campo non ha errori', () => {
+    it('returns false if the field has no errors', () => {
       const mockContext = {
         id: 'id-1',
         isSubmitted: true,
@@ -295,15 +303,17 @@ describe('beneficiaryValidation', () => {
         fieldNamePrefix: 'beneficiaries',
         index: 0,
         getValues: vi.fn(),
-        t: vi.fn()
-      } as unknown as ValidationContext<Record<string, unknown>>;
+        t: vi.fn(),
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
       expect(hasFieldError('entityName', mockContext)).toBe(false);
     });
   });
 
   describe('getFieldErrorMessage', () => {
-    it('restituisce stringa vuota se shouldSkipValidation è true', () => {
+    it('returns empty string if shouldSkipValidation is true', () => {
       const mockContext = {
         id: 'id-1',
         isSubmitted: false,
@@ -313,13 +323,15 @@ describe('beneficiaryValidation', () => {
         fieldNamePrefix: 'beneficiaries',
         index: 0,
         getValues: vi.fn(),
-        t: vi.fn()
-      } as unknown as ValidationContext<Record<string, unknown>>;
+        t: vi.fn(),
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
       expect(getFieldErrorMessage('entityName', mockContext)).toBe('');
     });
 
-    it('restituisce il messaggio di errore per un campo con errore', () => {
+    it('returns the error message for a field with an error', () => {
       const mockContext = {
         id: 'id-1',
         isSubmitted: true,
@@ -337,15 +349,17 @@ describe('beneficiaryValidation', () => {
         fieldNamePrefix: 'beneficiaries',
         index: 0,
         getValues: vi.fn(),
-        t: vi.fn()
-      } as unknown as ValidationContext<Record<string, unknown>>;
+        t: vi.fn(),
+        submissionCount: 2,
+        creationSubmissionCount: 1
+      } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
       expect(getFieldErrorMessage('entityName', mockContext)).toBe(
         'Campo obbligatorio'
       );
     });
 
-    it('restituisce stringa vuota se isSubmitted è false', () => {
+    it('returns empty string if isSubmitted is false', () => {
       const mockContext = {
         id: 'id-1',
         isSubmitted: false,
@@ -363,15 +377,17 @@ describe('beneficiaryValidation', () => {
         fieldNamePrefix: 'beneficiaries',
         index: 0,
         getValues: vi.fn(),
-        t: vi.fn()
-      } as unknown as ValidationContext<Record<string, unknown>>;
+        t: vi.fn(),
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
       expect(getFieldErrorMessage('entityName', mockContext)).toBe('');
     });
   });
 
   describe('getFieldValue', () => {
-    it('recupera il valore di un campo dal contesto', () => {
+    it('retrieves the value of a field from the context', () => {
       const mockGetValues = vi.fn().mockReturnValue('Test Entity');
 
       const mockContext = {
@@ -383,8 +399,10 @@ describe('beneficiaryValidation', () => {
         fieldNamePrefix: 'beneficiaries',
         index: 0,
         getValues: mockGetValues,
-        t: vi.fn()
-      } as unknown as ValidationContext<Record<string, unknown>>;
+        t: vi.fn(),
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
       const result = getFieldValue(mockContext, 'entityName');
 
@@ -394,7 +412,7 @@ describe('beneficiaryValidation', () => {
   });
 
   describe('checkPaymentFields', () => {
-    it('restituisce i valori dei campi di pagamento e lo stato bothEmpty=true se entrambi vuoti', () => {
+    it('returns payment field values and bothEmpty=true when both are empty', () => {
       const mockContext = {
         id: 'id-1',
         isSubmitted: false,
@@ -408,8 +426,10 @@ describe('beneficiaryValidation', () => {
           if (path.includes('postalAccount')) return '';
           return 'default-value';
         }),
-        t: vi.fn()
-      } as unknown as ValidationContext<Record<string, unknown>>;
+        t: vi.fn(),
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
       const result = checkPaymentFields(mockContext);
 
@@ -420,7 +440,7 @@ describe('beneficiaryValidation', () => {
       });
     });
 
-    it('restituisce i valori dei campi di pagamento e lo stato bothEmpty=false se almeno uno è valorizzato', () => {
+    it('returns payment field values and bothEmpty=false when at least one is filled', () => {
       const mockContext = {
         id: 'id-1',
         isSubmitted: false,
@@ -434,8 +454,10 @@ describe('beneficiaryValidation', () => {
           if (path.includes('postalAccount')) return '';
           return 'default-value';
         }),
-        t: vi.fn()
-      } as unknown as ValidationContext<Record<string, unknown>>;
+        t: vi.fn(),
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
       const result = checkPaymentFields(mockContext);
 
@@ -448,7 +470,7 @@ describe('beneficiaryValidation', () => {
   });
 
   describe('validateSingleAmount', () => {
-    it('restituisce undefined se il beneficiario è nuovo e wasSubmittedRef è false', () => {
+    it('returns undefined if the beneficiary is new and wasSubmittedRef is false', () => {
       const mockContext = {
         id: 'id-1',
         isSubmitted: false,
@@ -458,13 +480,15 @@ describe('beneficiaryValidation', () => {
         fieldNamePrefix: 'beneficiaries',
         index: 0,
         getValues: vi.fn(),
-        t: vi.fn()
-      } as unknown as ValidationContext<Record<string, unknown>>;
+        t: vi.fn(),
+        submissionCount: 1,
+        creationSubmissionCount: 0
+      } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
       expect(validateSingleAmount('100', mockContext)).toBeUndefined();
     });
 
-    it('restituisce undefined se il valore è valido', () => {
+    it('returns undefined if the value is valid', () => {
       const mockContext = {
         id: 'id-1',
         isSubmitted: true,
@@ -475,12 +499,12 @@ describe('beneficiaryValidation', () => {
         index: 0,
         getValues: vi.fn(),
         t: vi.fn().mockReturnValue('Importo non valido')
-      } as unknown as ValidationContext<Record<string, unknown>>;
+      } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
       expect(validateSingleAmount('100', mockContext)).toBeUndefined();
     });
 
-    it('restituisce un messaggio di errore se il valore non è valido', () => {
+    it('returns an error message if the value is invalid', () => {
       const mockT = vi.fn().mockReturnValue('Importo non valido');
       const mockContext = {
         id: 'id-1',
@@ -492,7 +516,7 @@ describe('beneficiaryValidation', () => {
         index: 0,
         getValues: vi.fn(),
         t: mockT
-      } as unknown as ValidationContext<Record<string, unknown>>;
+      } as unknown as BeneficiaryValidationContext<Record<string, unknown>>;
 
       expect(validateSingleAmount('-10', mockContext)).toBe(
         'Importo non valido'
@@ -508,7 +532,7 @@ describe('beneficiaryValidation', () => {
   });
 
   describe('createBaseValidationRule', () => {
-    it('esegue la validazione solo se wasSubmittedRef è true', () => {
+    it('runs validation only if wasSubmittedRef is true', () => {
       const mockWasSubmittedRef = { current: false };
       const mockValidator = vi.fn().mockReturnValue('Errore');
 
@@ -521,7 +545,7 @@ describe('beneficiaryValidation', () => {
       expect(mockValidator).not.toHaveBeenCalled();
     });
 
-    it('restituisce il risultato del validator quando wasSubmittedRef è true', () => {
+    it('returns the validator result when wasSubmittedRef is true', () => {
       const mockWasSubmittedRef = { current: true };
       const mockValidator = vi.fn().mockReturnValue('Errore');
 
@@ -536,7 +560,7 @@ describe('beneficiaryValidation', () => {
   });
 
   describe('createPaymentMethodValidator', () => {
-    it('restituisce undefined se uno dei due campi è valorizzato', () => {
+    it('returns undefined if either field is filled', () => {
       const getOtherFieldValue = vi.fn().mockReturnValue('valorizzato');
       const validator = vi.fn();
 
@@ -549,7 +573,7 @@ describe('beneficiaryValidation', () => {
       expect(validator).not.toHaveBeenCalled();
     });
 
-    it('restituisce il risultato del validator quando entrambi i campi sono vuoti', () => {
+    it('returns the validator result when both fields are empty', () => {
       const getOtherFieldValue = vi.fn().mockReturnValue('');
       const validator = vi.fn().mockReturnValue('Errore pagamento richiesto');
 

--- a/src/utils/__tests__/paymentUtility.test.tsx
+++ b/src/utils/__tests__/paymentUtility.test.tsx
@@ -188,7 +188,9 @@ describe('hasFieldError and getFieldErrorMessage', () => {
       errors: {} as FieldErrors<FieldValues>,
       fieldNamePrefix: 'beneficiaries',
       getValues: vi.fn(),
-      t: vi.fn()
+      t: vi.fn(),
+      submissionCount: 1,
+      creationSubmissionCount: 0
     };
   });
 

--- a/src/utils/__tests__/step3FormDataUtils.test.ts
+++ b/src/utils/__tests__/step3FormDataUtils.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  hasActualDataToPopulate,
+  populateBasicFields,
+  populateDueDateField,
+  populateMultiBeneficiaryField,
+  populateComplexFields,
+  populateAllFormFields,
+  prepareFormData,
+  isNotEmptyString,
+  safeSetValue
+} from '../step3FormDataUtils';
+import type { Step3FormValues } from '../../models/Step3Schema';
+import type {
+  Step1Data,
+  Step2Data,
+  Step3Data
+} from '../../models/DebtPositionType';
+import { DebtPositionTypeEnum } from '../../models/DebtPositionType';
+import type { UseFormSetValue } from 'react-hook-form';
+import type { Installment } from '../../models/paymentTypes';
+
+vi.mock('../../models/Step3Schema', () => ({
+  convertFormValuesToStep3Data: vi.fn()
+}));
+
+describe('step3FormDataUtils', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('hasActualDataToPopulate', () => {
+    it('returns false when all fields are empty', () => {
+      const data: Step3Data = {
+        paymentObject: { value: '', readonly: false },
+        paymentOption: { value: '', readonly: false },
+        amount: { value: '', readonly: false },
+        dueDate: { value: '', readonly: false },
+        beneficiaries: [],
+        installments: []
+      } as unknown as Step3Data;
+
+      expect(hasActualDataToPopulate(data)).toBe(false);
+    });
+
+    it('returns true when any relevant field has data', () => {
+      const data: Step3Data = {
+        paymentObject: { value: 'PO', readonly: false },
+        paymentOption: { value: '', readonly: false },
+        amount: { value: '', readonly: false },
+        dueDate: { value: '', readonly: false },
+        beneficiaries: [],
+        installments: []
+      } as unknown as Step3Data;
+
+      expect(hasActualDataToPopulate(data)).toBe(true);
+    });
+  });
+
+  describe('populateBasicFields', () => {
+    it('sets non-empty paymentObject, paymentOption, amount and returns true', () => {
+      const setValue = vi.fn() as unknown as UseFormSetValue<Step3FormValues>;
+      const data: Step3Data = {
+        paymentObject: { value: 'PO', readonly: false },
+        paymentOption: { value: 'SINGLE', readonly: false },
+        amount: { value: '100.00', readonly: false }
+      } as unknown as Step3Data;
+
+      const result = populateBasicFields({ data, setValue });
+
+      expect(result).toBe(true);
+      expect(setValue).toHaveBeenCalledWith('paymentObject.value', 'PO');
+      expect(setValue).toHaveBeenCalledWith('paymentOption.value', 'SINGLE');
+      expect(setValue).toHaveBeenCalledWith('amount.value', '100.00');
+    });
+
+    it('returns false when nothing is populated', () => {
+      const setValue = vi.fn() as unknown as UseFormSetValue<Step3FormValues>;
+      const data: Step3Data = {
+        paymentObject: { value: '   ', readonly: false },
+        paymentOption: { value: '', readonly: false },
+        amount: { value: '', readonly: false }
+      } as unknown as Step3Data;
+
+      const result = populateBasicFields({ data, setValue });
+      expect(result).toBe(false);
+      expect(setValue).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('populateDueDateField', () => {
+    it('converts string to Date and sets the field', () => {
+      const setValue = vi.fn() as unknown as UseFormSetValue<Step3FormValues>;
+      const data: Step3Data = {
+        dueDate: { value: '2023-12-31', readonly: false }
+      } as unknown as Step3Data;
+
+      const result = populateDueDateField({ data, setValue });
+      expect(result).toBe(true);
+      expect(setValue).toHaveBeenCalledWith(
+        'dueDate.value',
+        new Date('2023-12-31')
+      );
+    });
+
+    it('returns false when due date empty', () => {
+      const setValue = vi.fn() as unknown as UseFormSetValue<Step3FormValues>;
+      const data: Step3Data = {
+        dueDate: { value: '   ', readonly: false }
+      } as unknown as Step3Data;
+
+      const result = populateDueDateField({ data, setValue });
+      expect(result).toBe(false);
+      expect(setValue).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('populateMultiBeneficiaryField', () => {
+    it('sets isMultibeneficiary when provided and returns true', () => {
+      const setValue = vi.fn() as unknown as UseFormSetValue<Step3FormValues>;
+      const data: Step3Data = {
+        isMultibeneficiary: { value: true, readonly: false }
+      } as unknown as Step3Data;
+
+      const result = populateMultiBeneficiaryField({ data, setValue });
+      expect(result).toBe(true);
+      expect(setValue).toHaveBeenCalledWith('isMultibeneficiary.value', true);
+    });
+
+    it('returns false when not provided', () => {
+      const setValue = vi.fn() as unknown as UseFormSetValue<Step3FormValues>;
+      const data: Step3Data = {} as unknown as Step3Data;
+      const result = populateMultiBeneficiaryField({ data, setValue });
+      expect(result).toBe(false);
+      expect(setValue).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('populateComplexFields', () => {
+    it('sets beneficiaries and installments when provided', () => {
+      const setValue = vi.fn() as unknown as UseFormSetValue<Step3FormValues>;
+      const beneficiaries = [{ id: 'b1' }];
+      const installments: Array<Installment> = [
+        {
+          id: 'i1',
+          amount: '10.00',
+          dueDate: '2023-12-31',
+          remittance: 'r',
+          isMultibeneficiary: false,
+          beneficiaries: [],
+          isNew: false
+        }
+      ];
+      const data: Step3Data = {
+        beneficiaries,
+        installments
+      } as unknown as Step3Data;
+
+      const result = populateComplexFields({ data, setValue });
+      expect(result).toBe(true);
+      expect(setValue).toHaveBeenCalledWith('beneficiaries', beneficiaries);
+      expect(setValue).toHaveBeenCalledWith('installments', installments);
+    });
+
+    it('returns false when neither beneficiaries nor installments provided', () => {
+      const setValue = vi.fn() as unknown as UseFormSetValue<Step3FormValues>;
+      const data: Step3Data = {
+        beneficiaries: [],
+        installments: []
+      } as unknown as Step3Data;
+
+      const result = populateComplexFields({ data, setValue });
+      expect(result).toBe(false);
+      expect(setValue).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('populateAllFormFields', () => {
+    it('returns hasPopulatedSomething true when any sub-population occurs', () => {
+      const setValue = vi.fn() as unknown as UseFormSetValue<Step3FormValues>;
+      const data: Step3Data = {
+        paymentObject: { value: 'PO', readonly: false }
+      } as unknown as Step3Data;
+
+      const res = populateAllFormFields({ data, setValue });
+      expect(res).toEqual({ hasPopulatedSomething: true });
+    });
+
+    it('returns hasPopulatedSomething false when nothing is populated', () => {
+      const setValue = vi.fn() as unknown as UseFormSetValue<Step3FormValues>;
+      const data: Step3Data = {
+        paymentObject: { value: '   ', readonly: false },
+        beneficiaries: [],
+        installments: []
+      } as unknown as Step3Data;
+
+      const res = populateAllFormFields({ data, setValue });
+      expect(res).toEqual({ hasPopulatedSomething: false });
+    });
+  });
+
+  describe('prepareFormData', () => {
+    it('calls convertFormValuesToStep3Data with merged values and returns formatted data', async () => {
+      const { convertFormValuesToStep3Data } = await import(
+        '../../models/Step3Schema'
+      );
+      const formatted: Step3Data = {
+        paymentObject: { value: 'PO', readonly: false }
+      } as unknown as Step3Data;
+      vi.mocked(convertFormValuesToStep3Data).mockReturnValue(formatted);
+
+      const values: Step3FormValues = {
+        paymentObject: { value: 'PO', readonly: false },
+        paymentOption: { value: DebtPositionTypeEnum.SINGLE, readonly: false },
+        amount: { value: '100.00', readonly: false },
+        dueDate: { value: null, readonly: false },
+        isMultibeneficiary: { value: false, readonly: false },
+        installments: [],
+        flagMandatoryDueDate: true,
+        step1Data: {} as Step1Data,
+        step2Data: {} as Step2Data
+      } as unknown as Step3FormValues;
+
+      const syncedInstallments: Array<Installment> = [
+        {
+          id: 'i1',
+          amount: '10.00',
+          dueDate: '2023-12-31',
+          remittance: 'r',
+          isMultibeneficiary: false,
+          beneficiaries: [],
+          isNew: false
+        }
+      ];
+
+      const setData = vi.fn();
+
+      const res = prepareFormData({
+        values,
+        syncedInstallments,
+        step1Data: {} as Step1Data,
+        step2Data: {} as Step2Data,
+        setData
+      });
+
+      expect(convertFormValuesToStep3Data).toHaveBeenCalledWith(
+        expect.objectContaining({
+          flagMandatoryDueDate: true,
+          step1Data: expect.any(Object),
+          step2Data: expect.any(Object),
+          installments: syncedInstallments
+        })
+      );
+      expect(setData).toHaveBeenCalledWith(formatted);
+      expect(res).toBe(formatted);
+    });
+  });
+
+  describe('isNotEmptyString', () => {
+    it('returns true only for non-empty trimmed strings', () => {
+      expect(isNotEmptyString('a')).toBe(true);
+      expect(isNotEmptyString('  a ')).toBe(true);
+      expect(isNotEmptyString('   ')).toBe(false);
+      expect(isNotEmptyString('')).toBe(false);
+      expect(isNotEmptyString()).toBe(false);
+    });
+  });
+
+  describe('safeSetValue', () => {
+    it('sets value and returns true when condition is true and value defined', () => {
+      type F = { a: { b: string } };
+      const setValue = vi.fn() as unknown as UseFormSetValue<F>;
+      const result = safeSetValue<F, 'a.b'>(setValue, 'a.b', 'x', true);
+      expect(result).toBe(true);
+      expect(setValue).toHaveBeenCalledWith('a.b', 'x');
+    });
+
+    it('does not set when condition false or value nullish', () => {
+      type F = { a: { b?: string | null } };
+      const setValue = vi.fn() as unknown as UseFormSetValue<F>;
+
+      const r1 = safeSetValue<F, 'a.b'>(
+        setValue,
+        'a.b',
+        null as unknown as string,
+        true
+      );
+      const r2 = safeSetValue<F, 'a.b'>(
+        setValue,
+        'a.b',
+        undefined as unknown as string,
+        true
+      );
+      const r3 = safeSetValue<F, 'a.b'>(setValue, 'a.b', 'x', false);
+
+      expect(r1).toBe(false);
+      expect(r2).toBe(false);
+      expect(r3).toBe(false);
+      expect(setValue).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/utils/__tests__/step3ValidationUtils.test.ts
+++ b/src/utils/__tests__/step3ValidationUtils.test.ts
@@ -1,0 +1,650 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  UseFormSetValue,
+  UseFormTrigger,
+  UseFormGetValues
+} from 'react-hook-form';
+import {
+  validateFormFields,
+  validateBusinessLogic,
+  validateInstallmentsData,
+  createValidateInstallmentsData,
+  type ValidateFormFieldsParams,
+  type ValidateBusinessLogicParams,
+  type ValidateInstallmentsDataParams
+} from '../step3ValidationUtils';
+import { Step3FormValues } from '../../models/Step3Schema';
+import type { Installment, Beneficiary } from '../../models/paymentTypes';
+import { DebtPositionTypeEnum } from '../../models/DebtPositionType';
+
+vi.mock('../paymentUtility', () => ({
+  syncInstallmentBeneficiaries: vi.fn(),
+  validateInstallments: vi.fn(),
+  validateMultiBeneficiary: vi.fn(),
+  handleInstallmentValidationFailure: vi.fn()
+}));
+
+describe('step3ValidationUtils', () => {
+  let mockSetValue: UseFormSetValue<Step3FormValues>;
+  let mockTrigger: UseFormTrigger<Step3FormValues>;
+  let mockGetValues: UseFormGetValues<Step3FormValues>;
+
+  const mockBeneficiary: Beneficiary = {
+    id: '1',
+    entityName: 'Test Entity',
+    amount: '100.00',
+    taxCode: 'TESTCODE123',
+    remittance: 'Test Remittance',
+    iban: 'IT60X0542811101000000123456',
+    taxonomyCode: '9/123456789',
+    isNew: false
+  };
+
+  const mockInstallment: Installment = {
+    id: '1',
+    amount: '100.00',
+    dueDate: '2023-12-31',
+    remittance: 'Test Remittance',
+    isMultibeneficiary: false,
+    beneficiaries: [],
+    isNew: false
+  };
+
+  const mockFormValues: Step3FormValues = {
+    paymentObject: { value: 'Test Payment', readonly: false },
+    paymentOption: { value: DebtPositionTypeEnum.SINGLE, readonly: false },
+    amount: { value: '100.00', readonly: false },
+    dueDate: { value: null, readonly: false },
+    isMultibeneficiary: { value: false, readonly: false },
+    beneficiaries: [],
+    installments: []
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSetValue = vi.fn();
+    mockTrigger = vi.fn();
+    mockGetValues = vi.fn();
+  });
+
+  describe('validateFormFields', () => {
+    it('should return false when due date is mandatory but missing for single payment', async () => {
+      const params: ValidateFormFieldsParams = {
+        values: {
+          ...mockFormValues,
+          flagMandatoryDueDate: true,
+          dueDate: { value: null, readonly: false }
+        },
+        isInstallment: false,
+        setValue: mockSetValue,
+        trigger: mockTrigger
+      };
+
+      vi.mocked(mockTrigger).mockResolvedValue(false);
+
+      const result = await validateFormFields(params);
+
+      expect(result).toBe(false);
+      expect(mockSetValue).toHaveBeenCalledWith('dueDate.value', null, {
+        shouldValidate: true
+      });
+      expect(mockTrigger).toHaveBeenCalledWith('dueDate.value');
+    });
+
+    it('should continue validation when due date is provided for single payment with mandatory due date', async () => {
+      const params: ValidateFormFieldsParams = {
+        values: {
+          ...mockFormValues,
+          flagMandatoryDueDate: true,
+          dueDate: { value: new Date('2023-12-31'), readonly: false }
+        },
+        isInstallment: false,
+        setValue: mockSetValue,
+        trigger: mockTrigger
+      };
+
+      vi.mocked(mockTrigger).mockResolvedValue(true);
+
+      const result = await validateFormFields(params);
+
+      expect(result).toBe(true);
+      expect(mockSetValue).not.toHaveBeenCalled();
+      expect(mockTrigger).toHaveBeenCalledWith();
+    });
+
+    it('should skip due date validation for installment payments', async () => {
+      const params: ValidateFormFieldsParams = {
+        values: {
+          ...mockFormValues,
+          flagMandatoryDueDate: true,
+          dueDate: { value: null, readonly: false }
+        },
+        isInstallment: true,
+        setValue: mockSetValue,
+        trigger: mockTrigger
+      };
+
+      vi.mocked(mockTrigger).mockResolvedValue(true);
+
+      const result = await validateFormFields(params);
+
+      expect(result).toBe(true);
+      expect(mockSetValue).not.toHaveBeenCalled();
+      expect(mockTrigger).toHaveBeenCalledWith();
+    });
+
+    it('should return trigger result when all validations pass', async () => {
+      const params: ValidateFormFieldsParams = {
+        values: mockFormValues,
+        isInstallment: false,
+        setValue: mockSetValue,
+        trigger: mockTrigger
+      };
+
+      vi.mocked(mockTrigger).mockResolvedValue(true);
+
+      const result = await validateFormFields(params);
+
+      expect(result).toBe(true);
+      expect(mockTrigger).toHaveBeenCalledWith();
+    });
+
+    it('should return false when form validation fails', async () => {
+      const params: ValidateFormFieldsParams = {
+        values: mockFormValues,
+        isInstallment: false,
+        setValue: mockSetValue,
+        trigger: mockTrigger
+      };
+
+      vi.mocked(mockTrigger).mockResolvedValue(false);
+
+      const result = await validateFormFields(params);
+
+      expect(result).toBe(false);
+      expect(mockTrigger).toHaveBeenCalledWith();
+    });
+  });
+
+  describe('validateBusinessLogic', () => {
+    it('should validate beneficiaries for single payment', async () => {
+      const { validateMultiBeneficiary } = await import('../paymentUtility');
+      vi.mocked(validateMultiBeneficiary).mockReturnValue(true);
+
+      const mockValidateInstallmentsData = vi.fn();
+      const params: ValidateBusinessLogicParams = {
+        isInstallment: false,
+        isMultibeneficiary: false,
+        totalAmount: '100.00',
+        getValues: mockGetValues,
+        trigger: mockTrigger,
+        setValue: mockSetValue,
+        validateInstallmentsData: mockValidateInstallmentsData
+      };
+
+      vi.mocked(mockGetValues).mockReturnValue([mockBeneficiary]);
+
+      const result = await validateBusinessLogic(params);
+
+      expect(result).toEqual({ isValid: true });
+      expect(validateMultiBeneficiary).toHaveBeenCalled();
+      expect(mockValidateInstallmentsData).not.toHaveBeenCalled();
+    });
+
+    it('should return invalid when beneficiary validation fails for single payment', async () => {
+      const { validateMultiBeneficiary } = await import('../paymentUtility');
+      vi.mocked(validateMultiBeneficiary).mockReturnValue(false);
+
+      const mockValidateInstallmentsData = vi.fn();
+      const params: ValidateBusinessLogicParams = {
+        isInstallment: false,
+        isMultibeneficiary: false,
+        totalAmount: '100.00',
+        getValues: mockGetValues,
+        trigger: mockTrigger,
+        setValue: mockSetValue,
+        validateInstallmentsData: mockValidateInstallmentsData
+      };
+
+      vi.mocked(mockGetValues).mockReturnValue([]);
+
+      const result = await validateBusinessLogic(params);
+
+      expect(result).toEqual({ isValid: false });
+      expect(validateMultiBeneficiary).toHaveBeenCalled();
+    });
+
+    it('should validate installments for installment payment', async () => {
+      const syncedInstallments = [mockInstallment];
+      const mockValidateInstallmentsData = vi
+        .fn()
+        .mockResolvedValue({ isValid: true, syncedInstallments });
+
+      const params: ValidateBusinessLogicParams = {
+        isInstallment: true,
+        isMultibeneficiary: false,
+        totalAmount: '100.00',
+        getValues: mockGetValues,
+        trigger: mockTrigger,
+        setValue: mockSetValue,
+        validateInstallmentsData: mockValidateInstallmentsData
+      };
+
+      vi.mocked(mockGetValues).mockReturnValue([mockInstallment]);
+
+      const result = await validateBusinessLogic(params);
+
+      expect(result).toEqual({ isValid: true, syncedInstallments });
+      expect(mockValidateInstallmentsData).toHaveBeenCalled();
+      expect(mockSetValue).not.toHaveBeenCalled(); // Same data, no setValue needed
+    });
+
+    it('should update form values when installments are modified', async () => {
+      const originalInstallments = [mockInstallment];
+      const syncedInstallments = [{ ...mockInstallment, amount: '150.00' }];
+      const mockValidateInstallmentsData = vi
+        .fn()
+        .mockResolvedValue({ isValid: true, syncedInstallments });
+
+      const params: ValidateBusinessLogicParams = {
+        isInstallment: true,
+        isMultibeneficiary: false,
+        totalAmount: '100.00',
+        getValues: mockGetValues,
+        trigger: mockTrigger,
+        setValue: mockSetValue,
+        validateInstallmentsData: mockValidateInstallmentsData
+      };
+
+      vi.mocked(mockGetValues).mockReturnValue(originalInstallments);
+
+      const result = await validateBusinessLogic(params);
+
+      expect(result).toEqual({ isValid: true, syncedInstallments });
+      expect(mockSetValue).toHaveBeenCalledWith(
+        'installments',
+        syncedInstallments
+      );
+    });
+
+    it('should return invalid when installment validation fails', async () => {
+      const mockValidateInstallmentsData = vi
+        .fn()
+        .mockResolvedValue({ isValid: false });
+
+      const params: ValidateBusinessLogicParams = {
+        isInstallment: true,
+        isMultibeneficiary: false,
+        totalAmount: '100.00',
+        getValues: mockGetValues,
+        trigger: mockTrigger,
+        setValue: mockSetValue,
+        validateInstallmentsData: mockValidateInstallmentsData
+      };
+
+      const result = await validateBusinessLogic(params);
+
+      expect(result).toEqual({ isValid: false });
+      expect(mockValidateInstallmentsData).toHaveBeenCalled();
+    });
+
+    it('should return invalid when installment validation returns no synced installments', async () => {
+      const mockValidateInstallmentsData = vi
+        .fn()
+        .mockResolvedValue({ isValid: true, syncedInstallments: undefined });
+
+      const params: ValidateBusinessLogicParams = {
+        isInstallment: true,
+        isMultibeneficiary: false,
+        totalAmount: '100.00',
+        getValues: mockGetValues,
+        trigger: mockTrigger,
+        setValue: mockSetValue,
+        validateInstallmentsData: mockValidateInstallmentsData
+      };
+
+      const result = await validateBusinessLogic(params);
+
+      expect(result).toEqual({ isValid: false });
+    });
+
+    it('should return valid for edge case when neither installment nor single payment', async () => {
+      const mockValidateInstallmentsData = vi.fn();
+      const params: ValidateBusinessLogicParams = {
+        isInstallment: false,
+        isMultibeneficiary: false,
+        totalAmount: '100.00',
+        getValues: mockGetValues,
+        trigger: mockTrigger,
+        setValue: mockSetValue,
+        validateInstallmentsData: mockValidateInstallmentsData
+      };
+
+      // Mock to simulate no beneficiaries validation path
+      const { validateMultiBeneficiary } = await import('../paymentUtility');
+      vi.mocked(validateMultiBeneficiary).mockReturnValue(true);
+      vi.mocked(mockGetValues).mockReturnValue([]);
+
+      const result = await validateBusinessLogic(params);
+
+      expect(result).toEqual({ isValid: true });
+    });
+  });
+
+  describe('validateInstallmentsData', () => {
+    it('should clean installments by removing beneficiaries when not multibeneficiary', async () => {
+      const { syncInstallmentBeneficiaries, validateInstallments } =
+        await import('../paymentUtility');
+
+      const installmentWithBeneficiaries = {
+        ...mockInstallment,
+        isMultibeneficiary: false,
+        beneficiaries: [mockBeneficiary]
+      };
+
+      const cleanedInstallments = [
+        {
+          ...installmentWithBeneficiaries,
+          beneficiaries: []
+        }
+      ];
+
+      vi.mocked(syncInstallmentBeneficiaries).mockReturnValue({
+        installments: cleanedInstallments,
+        modified: false
+      });
+      vi.mocked(validateInstallments).mockReturnValue({
+        hasInvalidBeneficiaries: false,
+        hasInvalidPaymentFields: false,
+        hasInvalidAmounts: false,
+        hasEmptyRemittance: false
+      });
+
+      const params: ValidateInstallmentsDataParams = {
+        getValues: mockGetValues,
+        setValue: mockSetValue,
+        trigger: mockTrigger
+      };
+
+      vi.mocked(mockGetValues).mockReturnValue([installmentWithBeneficiaries]);
+
+      const result = await validateInstallmentsData(params);
+
+      expect(result).toEqual({
+        isValid: true,
+        syncedInstallments: cleanedInstallments
+      });
+      expect(syncInstallmentBeneficiaries).toHaveBeenCalledWith(
+        cleanedInstallments
+      );
+    });
+
+    it('should preserve beneficiaries when installment is multibeneficiary', async () => {
+      const { syncInstallmentBeneficiaries, validateInstallments } =
+        await import('../paymentUtility');
+
+      const multibeneficiaryInstallment = {
+        ...mockInstallment,
+        isMultibeneficiary: true,
+        beneficiaries: [mockBeneficiary]
+      };
+
+      vi.mocked(syncInstallmentBeneficiaries).mockReturnValue({
+        installments: [multibeneficiaryInstallment],
+        modified: false
+      });
+      vi.mocked(validateInstallments).mockReturnValue({
+        hasInvalidBeneficiaries: false,
+        hasInvalidPaymentFields: false,
+        hasInvalidAmounts: false,
+        hasEmptyRemittance: false
+      });
+
+      const params: ValidateInstallmentsDataParams = {
+        getValues: mockGetValues,
+        setValue: mockSetValue,
+        trigger: mockTrigger
+      };
+
+      vi.mocked(mockGetValues).mockReturnValue([multibeneficiaryInstallment]);
+
+      const result = await validateInstallmentsData(params);
+
+      expect(result).toEqual({
+        isValid: true,
+        syncedInstallments: [multibeneficiaryInstallment]
+      });
+      expect(syncInstallmentBeneficiaries).toHaveBeenCalledWith([
+        multibeneficiaryInstallment
+      ]);
+    });
+
+    it('should update form values when installments are modified during sync', async () => {
+      const { syncInstallmentBeneficiaries, validateInstallments } =
+        await import('../paymentUtility');
+
+      const syncedInstallments = [mockInstallment];
+
+      vi.mocked(syncInstallmentBeneficiaries).mockReturnValue({
+        installments: syncedInstallments,
+        modified: true
+      });
+      vi.mocked(validateInstallments).mockReturnValue({
+        hasInvalidBeneficiaries: false,
+        hasInvalidPaymentFields: false,
+        hasInvalidAmounts: false,
+        hasEmptyRemittance: false
+      });
+
+      const params: ValidateInstallmentsDataParams = {
+        getValues: mockGetValues,
+        setValue: mockSetValue,
+        trigger: mockTrigger
+      };
+
+      vi.mocked(mockGetValues).mockReturnValue([mockInstallment]);
+
+      const result = await validateInstallmentsData(params);
+
+      expect(result).toEqual({ isValid: true, syncedInstallments });
+      expect(mockSetValue).toHaveBeenCalledWith(
+        'installments',
+        syncedInstallments
+      );
+    });
+
+    it('should not update form values when installments are not modified during sync', async () => {
+      const { syncInstallmentBeneficiaries, validateInstallments } =
+        await import('../paymentUtility');
+
+      const syncedInstallments = [mockInstallment];
+
+      vi.mocked(syncInstallmentBeneficiaries).mockReturnValue({
+        installments: syncedInstallments,
+        modified: false
+      });
+      vi.mocked(validateInstallments).mockReturnValue({
+        hasInvalidBeneficiaries: false,
+        hasInvalidPaymentFields: false,
+        hasInvalidAmounts: false,
+        hasEmptyRemittance: false
+      });
+
+      const params: ValidateInstallmentsDataParams = {
+        getValues: mockGetValues,
+        setValue: mockSetValue,
+        trigger: mockTrigger
+      };
+
+      vi.mocked(mockGetValues).mockReturnValue([mockInstallment]);
+
+      const result = await validateInstallmentsData(params);
+
+      expect(result).toEqual({ isValid: true, syncedInstallments });
+      expect(mockSetValue).not.toHaveBeenCalled();
+    });
+
+    it('should return invalid and handle validation failures', async () => {
+      const {
+        syncInstallmentBeneficiaries,
+        validateInstallments,
+        handleInstallmentValidationFailure
+      } = await import('../paymentUtility');
+
+      const syncedInstallments = [mockInstallment];
+      const validationResults = {
+        hasInvalidBeneficiaries: true,
+        hasInvalidPaymentFields: false,
+        hasInvalidAmounts: false,
+        hasEmptyRemittance: false
+      };
+
+      vi.mocked(syncInstallmentBeneficiaries).mockReturnValue({
+        installments: syncedInstallments,
+        modified: false
+      });
+      vi.mocked(validateInstallments).mockReturnValue(validationResults);
+
+      const params: ValidateInstallmentsDataParams = {
+        getValues: mockGetValues,
+        setValue: mockSetValue,
+        trigger: mockTrigger
+      };
+
+      vi.mocked(mockGetValues).mockReturnValue([mockInstallment]);
+
+      const result = await validateInstallmentsData(params);
+
+      expect(result).toEqual({ isValid: false });
+      expect(handleInstallmentValidationFailure).toHaveBeenCalledWith(
+        syncedInstallments,
+        validationResults,
+        mockTrigger
+      );
+    });
+
+    it('should handle empty installments array', async () => {
+      const { syncInstallmentBeneficiaries, validateInstallments } =
+        await import('../paymentUtility');
+
+      vi.mocked(syncInstallmentBeneficiaries).mockReturnValue({
+        installments: [],
+        modified: false
+      });
+      vi.mocked(validateInstallments).mockReturnValue({
+        hasInvalidBeneficiaries: false,
+        hasInvalidPaymentFields: false,
+        hasInvalidAmounts: false,
+        hasEmptyRemittance: false
+      });
+
+      const params: ValidateInstallmentsDataParams = {
+        getValues: mockGetValues,
+        setValue: mockSetValue,
+        trigger: mockTrigger
+      };
+
+      vi.mocked(mockGetValues).mockReturnValue([]);
+
+      const result = await validateInstallmentsData(params);
+
+      expect(result).toEqual({ isValid: true, syncedInstallments: [] });
+    });
+
+    it('should handle undefined installments from getValues', async () => {
+      const { syncInstallmentBeneficiaries, validateInstallments } =
+        await import('../paymentUtility');
+
+      vi.mocked(syncInstallmentBeneficiaries).mockReturnValue({
+        installments: [],
+        modified: false
+      });
+      vi.mocked(validateInstallments).mockReturnValue({
+        hasInvalidBeneficiaries: false,
+        hasInvalidPaymentFields: false,
+        hasInvalidAmounts: false,
+        hasEmptyRemittance: false
+      });
+
+      const params: ValidateInstallmentsDataParams = {
+        getValues: mockGetValues,
+        setValue: mockSetValue,
+        trigger: mockTrigger
+      };
+
+      vi.mocked(mockGetValues).mockReturnValue([]);
+
+      const result = await validateInstallmentsData(params);
+
+      expect(result).toEqual({ isValid: true, syncedInstallments: [] });
+    });
+  });
+
+  describe('createValidateInstallmentsData', () => {
+    it('should create a function that calls validateInstallmentsData with provided params', async () => {
+      const { syncInstallmentBeneficiaries, validateInstallments } =
+        await import('../paymentUtility');
+
+      vi.mocked(syncInstallmentBeneficiaries).mockReturnValue({
+        installments: [mockInstallment],
+        modified: false
+      });
+      vi.mocked(validateInstallments).mockReturnValue({
+        hasInvalidBeneficiaries: false,
+        hasInvalidPaymentFields: false,
+        hasInvalidAmounts: false,
+        hasEmptyRemittance: false
+      });
+
+      const params: ValidateInstallmentsDataParams = {
+        getValues: mockGetValues,
+        setValue: mockSetValue,
+        trigger: mockTrigger
+      };
+
+      vi.mocked(mockGetValues).mockReturnValue([mockInstallment]);
+
+      const validateFunction = createValidateInstallmentsData(params);
+      const result = await validateFunction();
+
+      expect(result).toEqual({
+        isValid: true,
+        syncedInstallments: [mockInstallment]
+      });
+      expect(mockGetValues).toHaveBeenCalled();
+    });
+
+    it('should return a reusable function that maintains parameter closure', async () => {
+      const { syncInstallmentBeneficiaries, validateInstallments } =
+        await import('../paymentUtility');
+
+      vi.mocked(syncInstallmentBeneficiaries).mockReturnValue({
+        installments: [mockInstallment],
+        modified: false
+      });
+      vi.mocked(validateInstallments).mockReturnValue({
+        hasInvalidBeneficiaries: false,
+        hasInvalidPaymentFields: false,
+        hasInvalidAmounts: false,
+        hasEmptyRemittance: false
+      });
+
+      const params: ValidateInstallmentsDataParams = {
+        getValues: mockGetValues,
+        setValue: mockSetValue,
+        trigger: mockTrigger
+      };
+
+      vi.mocked(mockGetValues).mockReturnValue([mockInstallment]);
+
+      const validateFunction = createValidateInstallmentsData(params);
+
+      // Call the function multiple times
+      const result1 = await validateFunction();
+      const result2 = await validateFunction();
+
+      expect(result1).toEqual(result2);
+      expect(mockGetValues).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/utils/beneficiaryValidation.ts
+++ b/src/utils/beneficiaryValidation.ts
@@ -1,9 +1,5 @@
-import {
-  FieldErrors,
-  FieldValues,
-  Path,
-  UseFormGetValues
-} from 'react-hook-form';
+import { FieldErrors, FieldValues, Path } from 'react-hook-form';
+import type { BeneficiaryValidationContext } from '../models/paymentTypes';
 
 // ===== VALIDATION TYPES =====
 export type BeneficiaryFieldValidators = {
@@ -14,18 +10,6 @@ export type BeneficiaryFieldValidators = {
     iban: string,
     postalAccount: string
   ) => string | undefined;
-};
-
-export type ValidationContext<T extends FieldValues> = {
-  id: string;
-  index: number;
-  isSubmitted: boolean;
-  wasSubmittedRef: React.RefObject<boolean>;
-  existingBeneficiaries: Record<string, boolean>;
-  errors: FieldErrors<T>;
-  fieldNamePrefix: string;
-  getValues: UseFormGetValues<T>;
-  t: (key: string) => string;
 };
 
 // ===== UTILITY FUNCTIONS =====
@@ -135,23 +119,25 @@ export function shouldShowValidationErrors(
 ): boolean {
   return (
     isSubmitted &&
-    !(
-      isRecentlyCreated(id, wasSubmittedRef, existingBeneficiaries) &&
-      !wasSubmittedRef.current
-    )
+    !isRecentlyCreated(id, wasSubmittedRef, existingBeneficiaries)
+  );
+}
+
+// Enhanced version with context for checking isNew property
+export function shouldShowValidationErrorsWithContext<T extends FieldValues>(
+  context: BeneficiaryValidationContext<T>
+): boolean {
+  return (
+    context.isSubmitted &&
+    context.creationSubmissionCount < context.submissionCount
   );
 }
 
 // Checks if validation should be skipped
 export function shouldSkipValidation<T extends FieldValues>(
-  context: ValidationContext<T>
+  context: BeneficiaryValidationContext<T>
 ): boolean {
-  return !shouldShowValidationErrors(
-    context.id,
-    context.isSubmitted,
-    context.wasSubmittedRef,
-    context.existingBeneficiaries
-  );
+  return !shouldShowValidationErrorsWithContext(context);
 }
 
 // Helper to build a typed path for form fields
@@ -166,7 +152,7 @@ export function buildFieldPath<T extends FieldValues, K extends string>(
 // Checks if a field has errors
 export function hasFieldError<T extends FieldValues>(
   fieldName: string,
-  context: ValidationContext<T>
+  context: BeneficiaryValidationContext<T>
 ): boolean {
   if (shouldSkipValidation(context)) {
     return false;
@@ -201,7 +187,7 @@ export function hasFieldError<T extends FieldValues>(
 // Gets the error message for a field
 export function getFieldErrorMessage<T extends FieldValues>(
   fieldName: string,
-  context: ValidationContext<T>
+  context: BeneficiaryValidationContext<T>
 ): string {
   if (shouldSkipValidation(context)) {
     return '';
@@ -234,7 +220,7 @@ export function getFieldErrorMessage<T extends FieldValues>(
 
 // Gets a field value from the form
 export function getFieldValue<T extends FieldValues, K extends string>(
-  context: ValidationContext<T>,
+  context: BeneficiaryValidationContext<T>,
   field: K
 ): string {
   return context.getValues(
@@ -244,7 +230,7 @@ export function getFieldValue<T extends FieldValues, K extends string>(
 
 // Checks payment fields (IBAN and postal account)
 export function checkPaymentFields<T extends FieldValues>(
-  context: ValidationContext<T>
+  context: BeneficiaryValidationContext<T>
 ): { iban: string; postalAccount: string; bothEmpty: boolean } {
   const iban = getFieldValue(context, 'iban');
   const postalAccount = getFieldValue(context, 'postalAccount');
@@ -256,7 +242,7 @@ export function checkPaymentFields<T extends FieldValues>(
 // Validates a single amount
 export function validateSingleAmount<T extends FieldValues>(
   value: string,
-  context: ValidationContext<T>
+  context: BeneficiaryValidationContext<T>
 ): string | undefined {
   const amount = parseFloat(value);
   if (

--- a/src/utils/step3FormDataUtils.ts
+++ b/src/utils/step3FormDataUtils.ts
@@ -1,0 +1,215 @@
+import { UseFormSetValue, FieldValues, Path, PathValue } from 'react-hook-form';
+import {
+  Step3FormValues,
+  convertFormValuesToStep3Data
+} from '../models/Step3Schema';
+import { Step3Data, Step1Data, Step2Data } from '../models/DebtPositionType';
+import type { Installment } from '../models/paymentTypes';
+
+/**
+ * Parameters for populating form fields
+ */
+export type PopulateFormFieldsParams = {
+  data: Step3Data;
+  setValue: UseFormSetValue<Step3FormValues>;
+};
+
+/**
+ * Parameters for preparing form data
+ */
+export type PrepareFormDataParams = {
+  values: Step3FormValues;
+  syncedInstallments?: Array<Installment>;
+  step1Data: Step1Data;
+  step2Data: Step2Data;
+  setData: (data: Step3Data) => void;
+};
+
+/**
+ * Result of form population operations
+ */
+export type PopulationResult = {
+  hasPopulatedSomething: boolean;
+};
+
+/**
+ * Checks if there's actual data to populate in the form (not just empty strings)
+ * @param data - Step3 data to check
+ * @returns boolean - true if there's actual data to populate
+ */
+export const hasActualDataToPopulate = (data: Step3Data): boolean => {
+  return Boolean(
+    (data.paymentObject?.value && data.paymentObject.value.trim() !== '') ||
+      (data.paymentOption?.value && data.paymentOption.value.trim() !== '') ||
+      (data.amount?.value && data.amount.value.trim() !== '') ||
+      (data.dueDate?.value && data.dueDate.value.trim() !== '') ||
+      (data.beneficiaries && data.beneficiaries.length > 0) ||
+      (data.installments && data.installments.length > 0)
+  );
+};
+
+/**
+ * Populates the basic form fields with available data
+ * @param params - Parameters for populating basic fields
+ * @returns boolean - true if something was populated
+ */
+export const populateBasicFields = (
+  params: PopulateFormFieldsParams
+): boolean => {
+  const { data, setValue } = params;
+  let hasPopulatedSomething = false;
+
+  if (data.paymentObject?.value && data.paymentObject.value.trim() !== '') {
+    setValue('paymentObject.value', data.paymentObject.value);
+    hasPopulatedSomething = true;
+  }
+
+  if (data.paymentOption?.value && data.paymentOption.value.trim() !== '') {
+    setValue('paymentOption.value', data.paymentOption.value);
+    hasPopulatedSomething = true;
+  }
+
+  if (data.amount?.value && data.amount.value.trim() !== '') {
+    setValue('amount.value', data.amount.value);
+    hasPopulatedSomething = true;
+  }
+
+  return hasPopulatedSomething;
+};
+
+/**
+ * Populates the due date field converting from string to Date if necessary
+ * @param params - Parameters for populating due date field
+ * @returns boolean - true if the field was populated
+ */
+export const populateDueDateField = (
+  params: PopulateFormFieldsParams
+): boolean => {
+  const { data, setValue } = params;
+
+  if (data.dueDate?.value && data.dueDate.value.trim() !== '') {
+    const dateValue =
+      typeof data.dueDate.value === 'string'
+        ? new Date(data.dueDate.value)
+        : data.dueDate.value;
+    setValue('dueDate.value', dateValue);
+    return true;
+  }
+  return false;
+};
+
+/**
+ * Populates the multi-beneficiary field
+ * @param params - Parameters for populating multi-beneficiary field
+ * @returns boolean - true if the field was populated
+ */
+export const populateMultiBeneficiaryField = (
+  params: PopulateFormFieldsParams
+): boolean => {
+  const { data, setValue } = params;
+
+  if (data.isMultibeneficiary?.value != null) {
+    setValue('isMultibeneficiary.value', data.isMultibeneficiary.value);
+    return true;
+  }
+  return false;
+};
+
+/**
+ * Populates the beneficiaries and installments fields
+ * @param params - Parameters for populating complex fields
+ * @returns boolean - true if something was populated
+ */
+export const populateComplexFields = (
+  params: PopulateFormFieldsParams
+): boolean => {
+  const { data, setValue } = params;
+  let hasPopulatedSomething = false;
+
+  if (data.beneficiaries && data.beneficiaries.length > 0) {
+    setValue('beneficiaries', data.beneficiaries);
+    hasPopulatedSomething = true;
+  }
+
+  if (data.installments && data.installments.length > 0) {
+    setValue('installments', data.installments);
+    hasPopulatedSomething = true;
+  }
+
+  return hasPopulatedSomething;
+};
+
+/**
+ * Populates all form fields with available data
+ * Combines all population functions for convenience
+ * @param params - Parameters for populating all fields
+ * @returns PopulationResult - Result with information about what was populated
+ */
+export const populateAllFormFields = (
+  params: PopulateFormFieldsParams
+): PopulationResult => {
+  const basicFieldsPopulated = populateBasicFields(params);
+  const dueDatePopulated = populateDueDateField(params);
+  const multiBeneficiaryPopulated = populateMultiBeneficiaryField(params);
+  const complexFieldsPopulated = populateComplexFields(params);
+
+  const hasPopulatedSomething =
+    basicFieldsPopulated ||
+    dueDatePopulated ||
+    multiBeneficiaryPopulated ||
+    complexFieldsPopulated;
+
+  return { hasPopulatedSomething };
+};
+
+/**
+ * Transforms form values to Step3Data and updates component state
+ * @param params - Parameters for preparing form data
+ * @returns Step3Data - Transformed form data
+ */
+export const prepareFormData = (params: PrepareFormDataParams): Step3Data => {
+  const { values, syncedInstallments, step1Data, step2Data, setData } = params;
+
+  // Transform form values using conversion function
+  const formattedValues: Step3Data = convertFormValuesToStep3Data({
+    ...values,
+    // Use syncedInstallments if available from validation
+    ...(syncedInstallments && { installments: syncedInstallments }),
+    flagMandatoryDueDate: values.flagMandatoryDueDate,
+    step1Data,
+    step2Data
+  });
+
+  setData(formattedValues);
+  return formattedValues;
+};
+
+/**
+ * Utility function to check if a string value is not empty
+ * @param value - String value to check
+ * @returns boolean - true if the value is not empty
+ */
+export const isNotEmptyString = (value?: string): boolean => {
+  return Boolean(value && value.trim() !== '');
+};
+
+/**
+ * Utility function to safely set form field value if data exists
+ * @param setValue - React Hook Form setValue function
+ * @param fieldName - Name of the field to set
+ * @param value - Value to set
+ * @param condition - Optional condition to check before setting
+ * @returns boolean - true if the value was set
+ */
+export const safeSetValue = <T extends FieldValues, P extends Path<T>>(
+  setValue: UseFormSetValue<T>,
+  fieldName: P,
+  value: PathValue<T, P>,
+  condition = true
+): boolean => {
+  if (condition && value != null) {
+    setValue(fieldName, value);
+    return true;
+  }
+  return false;
+};

--- a/src/utils/step3ValidationUtils.ts
+++ b/src/utils/step3ValidationUtils.ts
@@ -1,0 +1,193 @@
+import {
+  UseFormSetValue,
+  UseFormTrigger,
+  UseFormGetValues,
+  Path
+} from 'react-hook-form';
+import { Step3FormValues } from '../models/Step3Schema';
+import type { Installment } from '../models/paymentTypes';
+import {
+  syncInstallmentBeneficiaries,
+  validateInstallments,
+  validateMultiBeneficiary,
+  handleInstallmentValidationFailure
+} from './paymentUtility';
+
+/**
+ * Parameters for the form fields validation
+ */
+export type ValidateFormFieldsParams = {
+  values: Step3FormValues;
+  isInstallment: boolean;
+  setValue: UseFormSetValue<Step3FormValues>;
+  trigger: UseFormTrigger<Step3FormValues>;
+};
+
+/**
+ * Parameters for the business logic validation
+ */
+export type ValidateBusinessLogicParams = {
+  isInstallment: boolean;
+  isMultibeneficiary: boolean;
+  totalAmount: string;
+  getValues: UseFormGetValues<Step3FormValues>;
+  trigger: UseFormTrigger<Step3FormValues>;
+  setValue: UseFormSetValue<Step3FormValues>;
+  validateInstallmentsData: () => Promise<{
+    isValid: boolean;
+    syncedInstallments?: Array<Installment>;
+  }>;
+};
+
+/**
+ * Parameters for the installments validation
+ */
+export type ValidateInstallmentsDataParams = {
+  getValues: UseFormGetValues<Step3FormValues>;
+  setValue: UseFormSetValue<Step3FormValues>;
+  trigger: UseFormTrigger<Step3FormValues>;
+};
+
+/**
+ * Validation result
+ */
+export type ValidationResult = {
+  isValid: boolean;
+  syncedInstallments?: Array<Installment>;
+};
+
+/**
+ * Validates the form fields including the validation of the mandatory due date
+ * @param params - Parameters for the form fields validation
+ * @returns Promise<boolean> - true if the validation passes, false if early return is needed
+ */
+export const validateFormFields = async (
+  params: ValidateFormFieldsParams
+): Promise<boolean> => {
+  const { values, isInstallment, setValue, trigger } = params;
+
+  // Check the due date field if mandatory
+  if (!isInstallment && values.flagMandatoryDueDate) {
+    if (!values.dueDate.value) {
+      setValue('dueDate.value', null, { shouldValidate: true });
+      await trigger('dueDate.value');
+      return false;
+    }
+  }
+
+  // Validate all fields before proceeding
+  return await trigger();
+};
+
+/**
+ * Validates the business logic for beneficiaries or installments based on the payment type
+ * @param params - Parameters for the business logic validation
+ * @returns Promise<ValidationResult> - Validation result with optional synced installments
+ */
+export const validateBusinessLogic = async (
+  params: ValidateBusinessLogicParams
+): Promise<ValidationResult> => {
+  const {
+    isInstallment,
+    isMultibeneficiary,
+    totalAmount,
+    getValues,
+    trigger,
+    setValue,
+    validateInstallmentsData
+  } = params;
+
+  // For single payment, validate the beneficiaries
+  if (!isInstallment) {
+    const beneficiariesValid = validateMultiBeneficiary(
+      () => getValues('beneficiaries') || [],
+      isMultibeneficiary,
+      totalAmount,
+      (name) => trigger(`beneficiaries.${name}` as Path<Step3FormValues>)
+    );
+
+    if (!beneficiariesValid) {
+      return { isValid: false };
+    }
+
+    return { isValid: true };
+  }
+
+  // Validate the beneficiaries for each installment if the payment is based on installments
+  if (isInstallment) {
+    const { isValid, syncedInstallments } = await validateInstallmentsData();
+
+    if (!isValid || !syncedInstallments) {
+      return { isValid: false };
+    }
+
+    if (
+      JSON.stringify(getValues('installments')) !==
+      JSON.stringify(syncedInstallments)
+    ) {
+      setValue('installments', syncedInstallments);
+    }
+
+    return { isValid: true, syncedInstallments };
+  }
+
+  return { isValid: true };
+};
+
+/**
+ * Validates the installments and their beneficiaries
+ * @param params - Parameters for the installments validation
+ * @returns Promise<ValidationResult> - Object with the validation result and synced installments
+ */
+export const validateInstallmentsData = async (
+  params: ValidateInstallmentsDataParams
+): Promise<ValidationResult> => {
+  const { getValues, setValue, trigger } = params;
+
+  const installments = getValues('installments') || [];
+
+  const cleanedInstallments = installments.map((installment) => {
+    if (!installment.isMultibeneficiary) {
+      return {
+        ...installment,
+        beneficiaries: []
+      };
+    }
+    return installment;
+  });
+
+  const { installments: syncedInstallments, modified } =
+    syncInstallmentBeneficiaries(cleanedInstallments as Array<Installment>);
+
+  if (modified) {
+    setValue('installments', syncedInstallments);
+  }
+
+  const validationResults = validateInstallments(syncedInstallments, trigger);
+
+  const hasValidationFailure = Object.values(validationResults).some(
+    (value) => value
+  );
+
+  if (hasValidationFailure) {
+    handleInstallmentValidationFailure(
+      syncedInstallments,
+      validationResults,
+      trigger
+    );
+    return { isValid: false };
+  }
+
+  return { isValid: true, syncedInstallments };
+};
+
+/**
+ * Factory function to create the validateInsta
+ * llmentsData function with the form parameters
+ * Useful to maintain compatibility with the existing interface
+ */
+export const createValidateInstallmentsData = (
+  params: ValidateInstallmentsDataParams
+) => {
+  return () => validateInstallmentsData(params);
+};


### PR DESCRIPTION
In this PR, the error handling in Step 3 of the "Create Debt Position" wizard has been revised. Error messages are now displayed only after clicking the final CTA.
Additionally, Step 3 has been refactored with the creation of new custom hooks to improve code quality and maintainability.

#### List of Changes

Refactored the code and introduced new hooks to enhance quality and maintainability.

New hooks:

- step3FormDataUtils.ts=> Transforms form values to Step3Data and updates component state
- step3ValidationUtils.ts= >Validates the form fields including the validation of the mandatory due date
- useStep3FormHandlers => manage all the event handlers of the Step3 form
- useStep3ApiOperations => manage the API operations of the Step3 component

#### How Has This Been Tested?

-visual testing
-unit tests

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
