### PR TITLE
feat: [P4ADEV-3862] Org detail: add links to own debtypes ad operators

### DIFF
--- a/src/components/DetailContainer/DetailContainer.tsx
+++ b/src/components/DetailContainer/DetailContainer.tsx
@@ -8,7 +8,8 @@ import {
   ChipOwnProps,
   Button,
   Divider,
-  TypographyOwnProps
+  TypographyOwnProps,
+  Stack
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import {
@@ -21,13 +22,16 @@ import React from 'react';
 export type DetailData = {
   label?: string;
   value?: string | number;
-  valueType?: 'amount' | 'date' | 'dateTime' | 'status';
+  valueType?: 'amount' | 'date' | 'dateTime' | 'status' | 'withicon';
   variant?: 'body1' | 'body2' | 'h6' | 'subtitle1' | 'monospaced';
   chipConfig?: {
     color?: ChipOwnProps['color'];
     variant?: ChipOwnProps['variant'];
   };
   childrenComponent?: React.ReactNode;
+  iconConfig?: {
+    icon: React.ReactNode;
+  };
 };
 
 export type titleConfig = {
@@ -121,6 +125,17 @@ const DetailContainer = ({
 
                 const formattedDateTime = formatDateTime(`${item.value}`);
                 return formattedDateTime || '-';
+              }
+              if (
+                item.valueType === 'withicon' &&
+                item.iconConfig !== undefined
+              ) {
+                const iconConfig = item.iconConfig;
+                return (
+                  <Stack direction={'row'} justifyContent={'space-between'}>
+                    {item.value} {iconConfig.icon}
+                  </Stack>
+                );
               }
               return item.value || '-';
             })()

--- a/src/routes/Organizations/components/OrganizationDetailSections.tsx
+++ b/src/routes/Organizations/components/OrganizationDetailSections.tsx
@@ -5,6 +5,9 @@ import { TFunction } from 'i18next';
 import Appio from '../../../assets/appio.svg';
 import Send from '../../../assets/send.svg';
 import ShowSecretValue from '../../../components/ShowSecretValue';
+import LaunchIcon from '@mui/icons-material/Launch';
+import { generatePath, Link } from 'react-router';
+import { PageRoutes } from '../..';
 
 export const accountingInfo = (
   organizationDetailData: OrganizationDetailDTO,
@@ -91,11 +94,38 @@ export const info = (
   },
   {
     label: t('commons.operators'),
-    value: '0'
+    value: '00',
+    valueType: 'withicon',
+    iconConfig: {
+      icon: (
+        <Link
+          to={generatePath(PageRoutes.BROKER_OPERATORS, {
+            organizationId: organizationDetailData.organizationId,
+            orgName: organizationDetailData.orgName
+          })}
+          target={'_blank'}
+        >
+          <LaunchIcon color={'primary'} />
+        </Link>
+      )
+    }
   },
   {
     label: t('commons.debtTypes'),
-    value: '0'
+    value: '00',
+    valueType: 'withicon',
+    iconConfig: {
+      icon: (
+        <Link
+          to={generatePath(PageRoutes.DEBT_TYPES_DASHBOARD_BYORG, {
+            organizationId: organizationDetailData.organizationId
+          })}
+          target={'_blank'}
+        >
+          <LaunchIcon color={'primary'} />
+        </Link>
+      )
+    }
   }
 ];
 


### PR DESCRIPTION
This PR adds two different links to see operators and debtypes associated to the org viewed.

#### List of Changes
- add a new valueType for detail container to manage also icons & links
- add proper link to the view

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
