### PR TITLE
fix: [P4ADEV-3881] reporting error click breadcrumb link detail

### DIFF
--- a/src/routes/Reporting/ReportingDetail/ReportingDetail.tsx
+++ b/src/routes/Reporting/ReportingDetail/ReportingDetail.tsx
@@ -37,20 +37,6 @@ export const ReportingDetail = () => {
     state: { organizationId }
   } = useStore();
   const location = useLocation();
-  const { ingestionFlowFileId } = location.state;
-
-  const mutation = getIngestionFlowFile(organizationId);
-
-  const downloadIngestionFlowFile = async () => {
-    try {
-      const { fileName, data } =
-        await mutation.mutateAsync(ingestionFlowFileId);
-      downloadBlob(data, fileName);
-    } catch (error) {
-      console.error('Error downloading file:', error);
-      utils.notify.emit(t('commons.files.downloadFailed'));
-    }
-  };
 
   const initialFilters: FieldValues = utils.URI.decode(window.location.hash);
   const [appliedFilters, setAppliedFilters] = useState(initialFilters);
@@ -61,6 +47,9 @@ export const ReportingDetail = () => {
   }
 
   const [detailItem, setDetailItem] = useState<PaymentsReporting | null>(null);
+  const [currentIngestionFlowFileId, setCurrentIngestionFlowFileId] = useState<
+    number | undefined
+  >(location.state?.ingestionFlowFileId);
 
   const query = getPaymentsReportingRows(organizationId, iuf, {
     enabled: !!organizationId && !!iuf
@@ -86,6 +75,35 @@ export const ReportingDetail = () => {
       setDetailItem(reportingRows.query.data.content[0]);
     }
   }, [reportingRows.query.data, detailItem]);
+
+  useEffect(() => {
+    if (
+      !currentIngestionFlowFileId &&
+      reportingRows.query.data?.content?.[0]?.ingestionFlowFileId
+    ) {
+      setCurrentIngestionFlowFileId(
+        reportingRows.query.data.content[0].ingestionFlowFileId
+      );
+    }
+  }, [reportingRows.query.data, currentIngestionFlowFileId]);
+
+  const mutation = getIngestionFlowFile(organizationId);
+
+  const downloadIngestionFlowFile = async () => {
+    if (!currentIngestionFlowFileId) {
+      utils.notify.emit(t('commons.files.downloadFailed'));
+      return;
+    }
+    try {
+      const { fileName, data } = await mutation.mutateAsync(
+        currentIngestionFlowFileId
+      );
+      downloadBlob(data, fileName);
+    } catch (error) {
+      console.error('Error downloading file:', error);
+      utils.notify.emit(t('commons.files.downloadFailed'));
+    }
+  };
 
   const handleFiltersApplied = () => {
     reportingRows.applyFilters(appliedFilters);


### PR DESCRIPTION
This PR fixes the bug that occurred when navigating within the payment detail of a reporting record. Clicking on the breadcrumb to return to the previous detail page caused a navigation error.

#### List of Changes

-Fixed crash: Use location.state?.ingestionFlowFileId instead of direct destructuring
-Added fallback: Retrieve ingestionFlowFileId from API data if not present in the state
-Added validation: Check that the ID exists before download
-Consistent pattern: Follows the same approach as TelematicReceiptDetail


#### How Has This Been Tested?

-visual testing
-unit tests

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
