### PR TITLE
fix: [P4ADEV-3965] edit organization check iban

### DIFF
--- a/src/routes/DebtTypeOrgCreate/steps/Step3Accounting/Step3Accounting.test.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step3Accounting/Step3Accounting.test.tsx
@@ -118,7 +118,7 @@ describe('Step3Accounting', () => {
     await waitFor(() => expect(ibanInput).toBeEnabled());
 
     // Fill iban disables postalIban
-    fireEvent.change(ibanInput, { target: { value: 'CH9300762011623852957' } });
+    fireEvent.change(ibanInput, { target: { value: 'IT60X0542811101000000123456' } });
     await waitFor(() => expect(postalIbanInput).toBeDisabled());
 
     // Clear iban enables postalIban
@@ -132,7 +132,7 @@ describe('Step3Accounting', () => {
     renderWithForm(<Step3Accounting />, onSubmit);
 
     fillField('debtTypeOrgCreate.accounting.postalIban', '123456');
-    fillField('debtTypeOrgCreate.accounting.pspIban', 'CH9300762011623852958');
+    fillField('debtTypeOrgCreate.accounting.pspIban', 'IT60X0542811101000000123456');
     fillField('debtTypeOrgCreate.accounting.postalAccount', '123456789');
     fillField('debtTypeOrgCreate.accounting.postalAccountHolder', 'John Doe');
     fillField(
@@ -148,7 +148,7 @@ describe('Step3Accounting', () => {
       expect(onSubmit).toHaveBeenCalledWith(
         {
           postalIban: '123456',
-          iban: 'CH9300762011623852958',
+          iban: 'IT60X0542811101000000123456',
           postalAccountCode: '123456789',
           holderPostalCc: 'John Doe',
           balance: 'Budget structure text',

--- a/src/routes/DebtTypeOrgCreate/steps/Step3Accounting/schema.test.ts
+++ b/src/routes/DebtTypeOrgCreate/steps/Step3Accounting/schema.test.ts
@@ -18,7 +18,7 @@ describe('step3Schema validation', () => {
   it('accepts valid IBANs', () => {
     const validData = {
       postalIban: '123456',
-      iban: 'DE89370400440532013000'
+      iban: 'IT60X0542811101000000123456'
     };
     const result = step3Schema.safeParse(validData);
     expect(result.success).toBe(true);

--- a/src/utils/__tests__/fieldValidation.test.tsx
+++ b/src/utils/__tests__/fieldValidation.test.tsx
@@ -93,9 +93,6 @@ describe('isValidIBAN', () => {
 
     it('validates IBAN with different formats that match the regex pattern', () => {
       expect(isValidIBAN('IT60X0542811101000000123456')).toBe(true);
-      expect(isValidIBAN('DE89370400440532013000')).toBe(true);
-      expect(isValidIBAN('IT60A1234512345')).toBe(true);
-      expect(isValidIBAN('IT60A12345123451234567890123456789')).toBe(true);
     });
   });
 
@@ -110,12 +107,15 @@ describe('isValidIBAN', () => {
 
     it('rejects IBAN with wrong length (too short)', () => {
       expect(isValidIBAN('IT60X05428111')).toBe(false);
+      expect(isValidIBAN('DE89370400440532013000')).toBe(false);
+      expect(isValidIBAN('IT60A1234512345')).toBe(false);
     });
 
     it('rejects IBAN with wrong length (too long)', () => {
       expect(isValidIBAN('IT60X0542811101000000123456789012345678901234')).toBe(
         false
       );
+      expect(isValidIBAN('IT60A123451234512345678901234567890')).toBe(false);
     });
 
     it('rejects IBAN with invalid format', () => {

--- a/src/utils/fieldValidation.tsx
+++ b/src/utils/fieldValidation.tsx
@@ -259,12 +259,12 @@ export const isValidIBAN = (iban: string): boolean => {
   // Normalizes the IBAN by removing spaces and converting to uppercase
   iban = iban.replace(/\s/g, '').toUpperCase();
 
-  // Basic length check (between 15 and 34 characters according to ISO 13616 standard)
-  if (iban.length < 15 || iban.length > 34) return false;
+  // Basic length check (minimum 27 characters, maximum 34 according to ISO 13616 standard)
+  if (iban.length < 27 || iban.length > 34) return false;
 
   // Basic format for IBAN: two letters for country code, two check digits,
   // and then the BBAN (Basic Bank Account Number)
-  const regex = /^[A-Z]{2}\d{2}[A-Z0-9]{1,30}$/;
+  const regex = /^[A-Z]{2}\d{2}[A-Z0-9]{23,30}$/;
 
   // Verification with regular expression
   return regex.test(iban);


### PR DESCRIPTION
This PR updates the IBAN validation function. The function now checks that the IBAN length is at least 27 characters.

Below are the current checks performed by the isValidIban function:

-Check if IBAN exists: Ensures that the iban parameter is not empty, null, or undefined.
-Normalize format: Removes all spaces and converts all characters to uppercase.
-Check length: Verifies that the IBAN length is between 27 and 34 characters (according to ISO 13616 standard).

Validate structure using regex: Ensures that the IBAN follows the correct format:
-First 2 letters: country code (A–Z)
-Characters 3–4: two check digits (0–9)
-Remaining characters: 23–30 alphanumeric characters (A–Z, 0–9) representing the BBAN


#### How Has This Been Tested?

-visual testing
-unit tests

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
