### PR TITLE
fix: [P4ADEV-3964] Edit-Organization-Additional-Language-Field

### DIFF
--- a/src/routes/Organizations/OrganizationEditWizard/OrganizationEditWizard.tsx
+++ b/src/routes/Organizations/OrganizationEditWizard/OrganizationEditWizard.tsx
@@ -9,7 +9,10 @@ import {
   updateOrganization
 } from '../../../api/organizations';
 import { OrganizationDetailDTO } from '../../../../generated/data-contracts';
-import { OrganizationEditFormData } from '../../../models/OrganizationEditTypes';
+import {
+  OrganizationEditFormData,
+  LANGUAGE_OPTIONS
+} from '../../../models/OrganizationEditTypes';
 
 import Step1AnagraficaEnte from './components/Step/Step1EntityProfile';
 import Step2ConfigurazioneEnte from './components/Step/Step2EntityConfiguration';
@@ -164,6 +167,13 @@ const OrganizationEditWizard = () => {
   const transformApiDataToFormData = (
     orgData: OrganizationDetailDTO
   ): OrganizationEditFormData => {
+    // Validate and sanitize additionalLanguage from API
+    const validLanguages = Object.values(LANGUAGE_OPTIONS);
+    const normalizedLanguage = orgData.additionalLanguage?.toLowerCase() || '';
+    const isValidLanguage = validLanguages.includes(
+      normalizedLanguage as (typeof validLanguages)[number]
+    );
+
     return {
       step1: {
         orgName: {
@@ -213,16 +223,11 @@ const OrganizationEditWizard = () => {
           readonly: false
         },
         additionalLanguage: {
-          value: !!(
-            orgData.additionalLanguage && orgData.additionalLanguage.trim()
-          ),
+          value: isValidLanguage,
           readonly: false
         },
         selectedLanguage: {
-          value:
-            orgData.additionalLanguage && orgData.additionalLanguage.trim()
-              ? orgData.additionalLanguage.toLowerCase()
-              : '',
+          value: isValidLanguage ? normalizedLanguage : '',
           readonly: false
         },
         flagNotifyOutcomePush: {

--- a/src/routes/Organizations/OrganizationEditWizard/components/Step/sections/PaymentsInfoSection.tsx
+++ b/src/routes/Organizations/OrganizationEditWizard/components/Step/sections/PaymentsInfoSection.tsx
@@ -1,12 +1,9 @@
 import {
-  FormControl,
   FormControlLabel,
   Grid,
-  InputLabel,
   MenuItem,
   Radio,
   RadioGroup,
-  Select,
   Switch,
   TextField,
   Typography,
@@ -149,51 +146,35 @@ export const PaymentsInfoSection = ({
                 }
               }}
               render={({ field }) => (
-                <FormControl fullWidth>
-                  <InputLabel id="selected-language-label">
-                    {t('organizationEditWizard.step2.selectedLanguage.label')}
-                    <Typography component="span" color="error.main">
-                      {' '}
-                      *
-                    </Typography>
-                  </InputLabel>
-                  <Select
-                    {...field}
-                    labelId="selected-language-label"
-                    label={t(
-                      'organizationEditWizard.step2.selectedLanguage.label'
-                    )}
-                    disabled={data.selectedLanguage.readonly}
-                    error={!!errors.selectedLanguage}
-                    required={watchAdditionalLanguage}
-                    data-testid="selected-language-select"
-                  >
-                    <MenuItem value={LANGUAGE_OPTIONS.EN}>
-                      {t(
-                        'organizationEditWizard.step2.selectedLanguage.options.en'
-                      )}
-                    </MenuItem>
-                    <MenuItem value={LANGUAGE_OPTIONS.FR}>
-                      {t(
-                        'organizationEditWizard.step2.selectedLanguage.options.fr'
-                      )}
-                    </MenuItem>
-                    <MenuItem value={LANGUAGE_OPTIONS.DE}>
-                      {t(
-                        'organizationEditWizard.step2.selectedLanguage.options.de'
-                      )}
-                    </MenuItem>
-                  </Select>
-                  {errors.selectedLanguage && (
-                    <Typography
-                      variant="caption"
-                      color="error"
-                      sx={{ mt: 0.5 }}
-                    >
-                      {errors.selectedLanguage.message}
-                    </Typography>
+                <TextField
+                  {...field}
+                  fullWidth
+                  select
+                  label={t(
+                    'organizationEditWizard.step2.selectedLanguage.label'
                   )}
-                </FormControl>
+                  disabled={data.selectedLanguage.readonly}
+                  error={!!errors.selectedLanguage}
+                  helperText={errors.selectedLanguage?.message}
+                  required={watchAdditionalLanguage}
+                  data-testid="selected-language-select"
+                >
+                  <MenuItem value={LANGUAGE_OPTIONS.EN}>
+                    {t(
+                      'organizationEditWizard.step2.selectedLanguage.options.en'
+                    )}
+                  </MenuItem>
+                  <MenuItem value={LANGUAGE_OPTIONS.FR}>
+                    {t(
+                      'organizationEditWizard.step2.selectedLanguage.options.fr'
+                    )}
+                  </MenuItem>
+                  <MenuItem value={LANGUAGE_OPTIONS.DE}>
+                    {t(
+                      'organizationEditWizard.step2.selectedLanguage.options.de'
+                    )}
+                  </MenuItem>
+                </TextField>
               )}
             />
           </Grid>


### PR DESCRIPTION
Add validation error display for additionalLanguage field in organization edit:

- Replace FormControl+Select with TextField select pattern for selectedLanguage field
- Add helperText to display validation errors when language is required but not selected
- Remove unused MUI imports (FormControl, InputLabel, Select)
- Sanitize additionalLanguage data from BE: only accept valid values (en, fr, de)
- If invalid language (e.g., "it") is received from BE, reset switch to false and field to empty
- Ensure form submission is blocked when additionalLanguage switch is on but no language selected
- Align select component implementation with project standards (TextField with select prop)


#### How Has This Been Tested?

-visual testing
-unit tests


#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
