### PR TITLE
fix: [P4ADEV-3889] import immediate redirect to home

### DIFF
--- a/src/components/ExportFlowPage/ExportFlowPage.test.tsx
+++ b/src/components/ExportFlowPage/ExportFlowPage.test.tsx
@@ -215,7 +215,6 @@ describe('ExportFlow', () => {
         expect(mockNavigate).toHaveBeenCalledWith(PageRoutes.RESPONSES_ERROR, {
           state: {
             category: 'conservation-export',
-            errorType: '4xx',
             statusCode: 403
           }
         });
@@ -308,7 +307,6 @@ describe('ExportFlow', () => {
         expect(mockNavigate).toHaveBeenCalledWith(PageRoutes.RESPONSES_ERROR, {
           state: {
             category: 'telematic-receipt-export',
-            errorType: '4xx',
             statusCode: 400
           }
         });

--- a/src/components/ExportFlowPage/ExportFlowPage.tsx
+++ b/src/components/ExportFlowPage/ExportFlowPage.tsx
@@ -93,7 +93,6 @@ export const ExportFlowPage = () => {
               category === 'receipt'
                 ? 'telematic-receipt-export'
                 : 'conservation-export',
-            errorType: '4xx',
             statusCode
           }
         });

--- a/src/components/ImportFlowPage/ImportFlowPage.test.tsx
+++ b/src/components/ImportFlowPage/ImportFlowPage.test.tsx
@@ -135,7 +135,6 @@ describe('ImportFlow', () => {
         expect(mockNavigate).toHaveBeenCalledWith(PageRoutes.RESPONSES_ERROR, {
           state: {
             category: 'reporting-import',
-            errorType: '4xx',
             statusCode: 400
           }
         });
@@ -367,7 +366,6 @@ describe('ImportFlow', () => {
         expect(mockNavigate).toHaveBeenCalledWith(PageRoutes.RESPONSES_ERROR, {
           state: {
             category: 'treasury-import',
-            errorType: '4xx',
             statusCode: 403
           }
         });

--- a/src/components/ImportFlowPage/ImportFlowPage.tsx
+++ b/src/components/ImportFlowPage/ImportFlowPage.tsx
@@ -64,7 +64,6 @@ const ImportFlow = () => {
           navigate(PageRoutes.RESPONSES_ERROR, {
             state: {
               category: config.category,
-              errorType: '4xx',
               statusCode
             }
           });


### PR DESCRIPTION
In this PR, the issue has been fixed where, when uploading a file in the import flow and the API returned a 400 or 409 error, the user was redirected to the home page after just one second on the error page.
Now, if the file upload fails, the user is correctly redirected to the error page.

#### List of Changes

Remove invalid errorType '4xx' from error state navigation in ImportFlowPage
and ExportFlowPage components. The errorType value was not configured in
ErrorPageConfig, causing pageConfig to be undefined and triggering an
immediate redirect to home via useEffect.

Changes:
- Remove errorType: '4xx' from navigate state in ImportFlowPage.tsx
- Remove errorType: '4xx' from navigate state in ExportFlowPage.tsx
- Update ImportFlowPage.test.tsx to reflect state changes
- Update ExportFlowPage.test.tsx to reflect state changes

#### How Has This Been Tested?

-visual testing
-unit tests


#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
