### PR TITLE
feat: [P4ADEV-3880] add field email in operator detail

### DIFF
--- a/src/routes/OperatorsDetail/index.tsx
+++ b/src/routes/OperatorsDetail/index.tsx
@@ -88,6 +88,10 @@ export const OperatorDetail = () => {
         {
           label: t('commons.fiscalCode'),
           value: data?.operatorFiscalCode
+        },
+        {
+          label: t('commons.email'),
+          value: data?.operatorEmail
         }
       ]
     }

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -828,6 +828,7 @@
       "operatingYear": "Anno esercizio"
     },
     "fiscalCode": "Codice Fiscale",
+    "email": "Email",
     "fiscalCodeorVat": "CF / Partita IVA",
     "fiscalCodeorVatExecutor": "CF / Partita IVA",
     "flowImport": {


### PR DESCRIPTION
Added the email field to the operator detail page.

#### How Has This Been Tested?

-visual testing
-unit tests

#### Screenshots (if appropriate):
<img width="1742" height="994" alt="Screenshot 2025-10-13 095007" src="https://github.com/user-attachments/assets/084dc181-81ec-46e6-b2e3-d26aab4c3251" />


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
