### PR TITLE
feat: [P4ADEV-3991] entity detail entity insert count on operators and payment types

### DIFF
--- a/src/routes/Organizations/components/OrganizationDetailSections.test.tsx
+++ b/src/routes/Organizations/components/OrganizationDetailSections.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import {
-  OrganizationDetailDTO,
+  OrganizationDetail,
   OrganizationStatus
 } from '../../../../generated/data-contracts';
 import {
@@ -25,7 +25,6 @@ describe('OrganizationDetailSections helpers', () => {
     originalDisplayNames = (
       Intl as unknown as { DisplayNames?: typeof Intl.DisplayNames }
     ).DisplayNames;
-    // Simple mock for Intl.DisplayNames.of
     (Intl as unknown as { DisplayNames: DisplayNamesCtor }).DisplayNames = vi
       .fn()
       .mockImplementation(() => ({
@@ -41,25 +40,25 @@ describe('OrganizationDetailSections helpers', () => {
     }
   });
 
-  const baseOrganization: OrganizationDetailDTO = {
+  const baseOrganization: OrganizationDetail = {
     organizationId: 123,
     orgName: 'Comune di Test',
     status: OrganizationStatus.ACTIVE,
     ipaCode: 'IPA123',
     orgFiscalCode: 'CF123',
     orgTypeCode: 'COMUNE'
-  } as unknown as OrganizationDetailDTO;
+  } as unknown as OrganizationDetail;
 
   const tMock: TFunction = ((key: string) => key) as unknown as TFunction;
 
   it('accountingInfo maps accounting fields and treasury flag correctly', () => {
-    const data: OrganizationDetailDTO = {
+    const data: OrganizationDetail = {
       ...baseOrganization,
       iban: 'IT00A0000000000000000000000',
       postalIban: 'IT00B0000000000000000000000',
       cbillInterBankCode: 'ABCDE',
       flagTreasury: true
-    } as unknown as OrganizationDetailDTO;
+    } as unknown as OrganizationDetail;
 
     const result = accountingInfo(data, tMock);
 
@@ -71,14 +70,14 @@ describe('OrganizationDetailSections helpers', () => {
   });
 
   it('paymentInfo exposes additional language, flags and secret correctly', () => {
-    const data: OrganizationDetailDTO = {
+    const data: OrganizationDetail = {
       ...baseOrganization,
       segregationCode: 'SEG123',
       additionalLanguage: 'fr',
       flagNotifyOutcomePush: true,
       flagPaymentNotification: false,
       generateNoticeApiKey: 'secret-key'
-    } as unknown as OrganizationDetailDTO;
+    } as unknown as OrganizationDetail;
 
     const displayNames = new Intl.DisplayNames(['it'], { type: 'language' });
     const result = paymentInfo(data, tMock, displayNames);
@@ -96,44 +95,42 @@ describe('OrganizationDetailSections helpers', () => {
   });
 
   it('info builds state with label, chip color and action links', () => {
-    const data: OrganizationDetailDTO = {
+    const data: OrganizationDetail = {
       ...baseOrganization,
-      status: OrganizationStatus.ACTIVE
-    } as unknown as OrganizationDetailDTO;
+      status: OrganizationStatus.ACTIVE,
+      operatorsCount: 7,
+      debtPositionTypeOrgCount: 3
+    } as unknown as OrganizationDetail;
 
     const result = info(data, tMock);
 
-    // Stato
     expect(result[0].label).toBe('commons.state');
     expect(result[0].value).toBe('ENABLED');
     expect(result[0].valueType).toBe('status');
     expect(result[0].chipConfig?.color).toBe('success');
 
-    // Operatori
     const operators = result.find((r) => r.label === 'commons.operators');
-    expect(operators?.value).toBe('00');
+    expect(operators?.value).toBe(7);
     expect(operators?.valueType).toBe('withicon');
     expect(operators?.iconConfig?.icon).toBeDefined();
 
-    // Tipologie debito
     const debtTypes = result.find((r) => r.label === 'commons.debtTypes');
-    expect(debtTypes?.value).toBe('00');
+    expect(debtTypes?.value).toBe(3);
     expect(debtTypes?.valueType).toBe('withicon');
     expect(debtTypes?.iconConfig?.icon).toBeDefined();
   });
 
   it('integrationBox exposes IO/SEND flags and secret fields correctly', () => {
-    const data: OrganizationDetailDTO = {
+    const data: OrganizationDetail = {
       ...baseOrganization,
       flagNotifyIo: true,
       ioApiKey: 'io-secret',
       pdndEnabled: false,
       sendApiKey: 'send-secret'
-    } as unknown as OrganizationDetailDTO;
+    } as unknown as OrganizationDetail;
 
     const result = integrationBox(data, tMock);
 
-    // IO section values
     const ioEnabled = result.find(
       (r) => r.label === 'organizations.ioMessagge'
     );
@@ -141,7 +138,6 @@ describe('OrganizationDetailSections helpers', () => {
     const ioSecret = result.find((r) => r.childrenComponent && !r.label);
     expect(ioSecret).toBeDefined();
 
-    // SEND section values
     const pdnd = result.find(
       (r) => r.label === 'organizations.pdndIntegration'
     );

--- a/src/routes/Organizations/components/OrganizationDetailSections.test.tsx
+++ b/src/routes/Organizations/components/OrganizationDetailSections.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import {
+  OrganizationDetailDTO,
+  OrganizationStatus
+} from '../../../../generated/data-contracts';
+import {
+  accountingInfo,
+  paymentInfo,
+  info,
+  integrationBox
+} from './OrganizationDetailSections';
+import { i18nTestSetup } from '../../../__tests__/i18nTestSetup';
+import translationIT from '../../../translations/it/translations.json';
+import type { TFunction } from 'i18next';
+
+describe('OrganizationDetailSections helpers', () => {
+  let originalDisplayNames: typeof Intl.DisplayNames | undefined;
+  type DisplayNamesCtor = new (
+    locales: Array<string> | string,
+    options: { type: 'language' }
+  ) => { of: (code: string) => string };
+
+  beforeAll(() => {
+    i18nTestSetup(translationIT as unknown as object);
+    originalDisplayNames = (
+      Intl as unknown as { DisplayNames?: typeof Intl.DisplayNames }
+    ).DisplayNames;
+    // Simple mock for Intl.DisplayNames.of
+    (Intl as unknown as { DisplayNames: DisplayNamesCtor }).DisplayNames = vi
+      .fn()
+      .mockImplementation(() => ({
+        of: (code: string) => (code === 'fr' ? 'French' : code)
+      })) as unknown as DisplayNamesCtor;
+  });
+
+  afterAll(() => {
+    if (originalDisplayNames) {
+      (
+        Intl as unknown as { DisplayNames: typeof originalDisplayNames }
+      ).DisplayNames = originalDisplayNames;
+    }
+  });
+
+  const baseOrganization: OrganizationDetailDTO = {
+    organizationId: 123,
+    orgName: 'Comune di Test',
+    status: OrganizationStatus.ACTIVE,
+    ipaCode: 'IPA123',
+    orgFiscalCode: 'CF123',
+    orgTypeCode: 'COMUNE'
+  } as unknown as OrganizationDetailDTO;
+
+  const tMock: TFunction = ((key: string) => key) as unknown as TFunction;
+
+  it('accountingInfo maps accounting fields and treasury flag correctly', () => {
+    const data: OrganizationDetailDTO = {
+      ...baseOrganization,
+      iban: 'IT00A0000000000000000000000',
+      postalIban: 'IT00B0000000000000000000000',
+      cbillInterBankCode: 'ABCDE',
+      flagTreasury: true
+    } as unknown as OrganizationDetailDTO;
+
+    const result = accountingInfo(data, tMock);
+
+    expect(result).toHaveLength(4);
+    expect(result[0].label).toBe('commons.iban');
+    expect(result[0].value).toBe('IT00A0000000000000000000000');
+    expect(result[3].label).toBe('commons.cashJournal');
+    expect(result[3].value).toBe('commons.enabled');
+  });
+
+  it('paymentInfo exposes additional language, flags and secret correctly', () => {
+    const data: OrganizationDetailDTO = {
+      ...baseOrganization,
+      segregationCode: 'SEG123',
+      additionalLanguage: 'fr',
+      flagNotifyOutcomePush: true,
+      flagPaymentNotification: false,
+      generateNoticeApiKey: 'secret-key'
+    } as unknown as OrganizationDetailDTO;
+
+    const displayNames = new Intl.DisplayNames(['it'], { type: 'language' });
+    const result = paymentInfo(data, tMock, displayNames);
+
+    expect(result).toHaveLength(5);
+    expect(result[0].label).toBe('commons.segregationCode');
+    expect(result[0].value).toBe('SEG123');
+    expect(result[1].label).toBe('commons.additionalLanguage');
+    expect(result[1].value).toBe('French');
+    expect(result[2].label).toBe('organizations.paymentPushNotification');
+    expect(result[2].value).toBe('commons.enabled');
+    expect(result[3].label).toBe('organizations.paymentNotified');
+    expect(result[3].value).toBe('commons.disabled');
+    expect(result[4].childrenComponent).toBeDefined();
+  });
+
+  it('info builds state with label, chip color and action links', () => {
+    const data: OrganizationDetailDTO = {
+      ...baseOrganization,
+      status: OrganizationStatus.ACTIVE
+    } as unknown as OrganizationDetailDTO;
+
+    const result = info(data, tMock);
+
+    // Stato
+    expect(result[0].label).toBe('commons.state');
+    expect(result[0].value).toBe('ENABLED');
+    expect(result[0].valueType).toBe('status');
+    expect(result[0].chipConfig?.color).toBe('success');
+
+    // Operatori
+    const operators = result.find((r) => r.label === 'commons.operators');
+    expect(operators?.value).toBe('00');
+    expect(operators?.valueType).toBe('withicon');
+    expect(operators?.iconConfig?.icon).toBeDefined();
+
+    // Tipologie debito
+    const debtTypes = result.find((r) => r.label === 'commons.debtTypes');
+    expect(debtTypes?.value).toBe('00');
+    expect(debtTypes?.valueType).toBe('withicon');
+    expect(debtTypes?.iconConfig?.icon).toBeDefined();
+  });
+
+  it('integrationBox exposes IO/SEND flags and secret fields correctly', () => {
+    const data: OrganizationDetailDTO = {
+      ...baseOrganization,
+      flagNotifyIo: true,
+      ioApiKey: 'io-secret',
+      pdndEnabled: false,
+      sendApiKey: 'send-secret'
+    } as unknown as OrganizationDetailDTO;
+
+    const result = integrationBox(data, tMock);
+
+    // IO section values
+    const ioEnabled = result.find(
+      (r) => r.label === 'organizations.ioMessagge'
+    );
+    expect(ioEnabled?.value).toBe('commons.enabled');
+    const ioSecret = result.find((r) => r.childrenComponent && !r.label);
+    expect(ioSecret).toBeDefined();
+
+    // SEND section values
+    const pdnd = result.find(
+      (r) => r.label === 'organizations.pdndIntegration'
+    );
+    expect(pdnd?.value).toBe('commons.disabled');
+    const sendSecret = result[result.length - 1];
+    expect(sendSecret.childrenComponent).toBeDefined();
+  });
+});

--- a/src/routes/Organizations/components/OrganizationDetailSections.tsx
+++ b/src/routes/Organizations/components/OrganizationDetailSections.tsx
@@ -1,6 +1,9 @@
-import { OrganizationDetailDTO } from '../../../../generated/data-contracts';
+import {
+  OrganizationDetail,
+  OrganizationStatus
+} from '../../../../generated/data-contracts';
 import { DetailData } from '../../../components/DetailContainer/DetailContainer';
-import { Box, Divider, Stack, Typography } from '@mui/material';
+import { Box, ChipOwnProps, Divider, Stack, Typography } from '@mui/material';
 import { TFunction } from 'i18next';
 import Appio from '../../../assets/appio.svg';
 import Send from '../../../assets/send.svg';
@@ -9,8 +12,26 @@ import LaunchIcon from '@mui/icons-material/Launch';
 import { generatePath, Link } from 'react-router';
 import { PageRoutes } from '../..';
 
+const organizationStatusColors: Record<
+  OrganizationStatus,
+  ChipOwnProps['color']
+> = {
+  [OrganizationStatus.ACTIVE]: 'success',
+  [OrganizationStatus.DRAFT]: 'default',
+  [OrganizationStatus.CANCELLED]: 'error'
+};
+
+const getOrganizationStatusValue = (status: OrganizationStatus): string => {
+  const statusValueMap: Record<OrganizationStatus, string> = {
+    [OrganizationStatus.ACTIVE]: 'ENABLED',
+    [OrganizationStatus.DRAFT]: 'DRAFT',
+    [OrganizationStatus.CANCELLED]: 'CANCELLED'
+  };
+  return statusValueMap[status];
+};
+
 export const accountingInfo = (
-  organizationDetailData: OrganizationDetailDTO,
+  organizationDetailData: OrganizationDetail,
   t: TFunction
 ): Array<DetailData> => [
   {
@@ -33,7 +54,7 @@ export const accountingInfo = (
   }
 ];
 export const paymentInfo = (
-  organizationDetailData: OrganizationDetailDTO,
+  organizationDetailData: OrganizationDetail,
   t: TFunction,
   displayNames: Intl.DisplayNames
 ): Array<DetailData> => [
@@ -70,9 +91,17 @@ export const paymentInfo = (
 ];
 
 export const info = (
-  organizationDetailData: OrganizationDetailDTO,
+  organizationDetailData: OrganizationDetail,
   t: TFunction
 ): Array<DetailData> => [
+  {
+    label: t('commons.state'),
+    value: getOrganizationStatusValue(organizationDetailData?.status),
+    valueType: 'status',
+    chipConfig: {
+      color: organizationStatusColors[organizationDetailData?.status]
+    }
+  },
   {
     label: t('commons.ipaCode'),
     value: organizationDetailData?.ipaCode
@@ -94,7 +123,7 @@ export const info = (
   },
   {
     label: t('commons.operators'),
-    value: '00',
+    value: organizationDetailData?.operatorsCount,
     valueType: 'withicon',
     iconConfig: {
       icon: (
@@ -112,7 +141,7 @@ export const info = (
   },
   {
     label: t('commons.debtTypes'),
-    value: '00',
+    value: organizationDetailData?.debtPositionTypeOrgCount,
     valueType: 'withicon',
     iconConfig: {
       icon: (
@@ -130,7 +159,7 @@ export const info = (
 ];
 
 export const integrationBox = (
-  organizationDetailData: OrganizationDetailDTO,
+  organizationDetailData: OrganizationDetail,
   t: TFunction
 ): Array<DetailData> => [
   {

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -1038,6 +1038,7 @@
     "status": {
       "ALL": "Tutti",
       "ACTIVE": "Attivo",
+      "ENABLED": "Abilitato",
       "INACTIVE": "Disattivo",
       "COMPLETED": "Elaborato",
       "DISABLED": "Disabilitato",


### PR DESCRIPTION
In this PR, the status field with its related chip has been added, along with the fields debtPositionTypeOrgCount and operatorsCount.


#### How Has This Been Tested?

-visual testing
-unit tests

#### Screenshots (if appropriate):
<img width="1890" height="843" alt="Screenshot 2025-10-13 124118" src="https://github.com/user-attachments/assets/751b4ad6-70e2-4bb4-98b6-c1369b887aac" />


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
