### PR TITLE
feat: [P4ADEV-3922]  debt position edit cta from detail page

### DIFF
--- a/src/routes/DebtPositionCreateWizard/components/Step/Step3.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step/Step3.tsx
@@ -85,7 +85,7 @@ const Step3 = ({
 
   const getNextButtonLabel = (): string => {
     if (isEditing) {
-      return isDraftInEdit ? 'commons.create' : 'commons.save';
+      return isDraftInEdit ? 'commons.edit' : 'commons.save';
     }
     return 'commons.create';
   };

--- a/src/routes/DebtPositionDetail/DebtPositionDetail.test.tsx
+++ b/src/routes/DebtPositionDetail/DebtPositionDetail.test.tsx
@@ -790,6 +790,7 @@ describe('DebtPositionDetail Component', () => {
     const mockData = { ...mockDebtPositionDetail };
     mockData.status = DebtPositionStatus.DRAFT;
     mockData.debtPositionOrigin = DebtPositionOrigin.ORDINARY;
+    mockData.paymentOptions = [mockData.paymentOptions![0]];
 
     vi.mocked(debtPositions.getDebtPositionDetail).mockReturnValue({
       data: mockData,
@@ -1061,6 +1062,7 @@ describe('DebtPositionDetail Component', () => {
     const mockData = { ...mockDebtPositionDetail };
     mockData.status = DebtPositionStatus.TO_SYNC;
     mockData.debtPositionOrigin = DebtPositionOrigin.ORDINARY;
+    mockData.paymentOptions = [mockData.paymentOptions![0]];
 
     vi.mocked(debtPositions.getDebtPositionDetail).mockReturnValue({
       data: mockData,

--- a/src/routes/DebtPositionDetail/DebtPositionDetail.tsx
+++ b/src/routes/DebtPositionDetail/DebtPositionDetail.tsx
@@ -167,9 +167,14 @@ const DebtPositionDetail = () => {
 
   const showDeleteOption =
     debtPositionDetail?.status !== DebtPositionStatus.CANCELLED;
+
+  const hasSinglePaymentOption =
+    (debtPositionDetail?.paymentOptions?.length || 0) === 1;
   const showEditOption =
-    debtPositionDetail?.debtPositionOrigin === DebtPositionOrigin.ORDINARY ||
-    debtPositionDetail?.debtPositionOrigin === DebtPositionOrigin.ORDINARY_SIL;
+    hasSinglePaymentOption &&
+    (debtPositionDetail?.debtPositionOrigin === DebtPositionOrigin.ORDINARY ||
+      debtPositionDetail?.debtPositionOrigin ===
+        DebtPositionOrigin.ORDINARY_SIL);
 
   const showDownloadCTA =
     debtPositionDetail?.status !== DebtPositionStatus.DRAFT &&


### PR DESCRIPTION
In this PR, an additional condition has been added to enable the editing of a debt position.
A debt position can now be edited only if it has a single Payment Option.
If multiple Payment Options are present, the Edit CTA is disabled.

In the final step of the wizard, when editing a debt position, the CTA label is now “Edit” instead of “Create”.

#### How Has This Been Tested?

-visual testing
-unit tests


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
