### PR TITLE
feat: [P4ADEV-3915] Test if the user and debt-type has the same orgid

### DIFF
--- a/src/routes/DebtTypeDetailView/DebtTypeDetailView.test.tsx
+++ b/src/routes/DebtTypeDetailView/DebtTypeDetailView.test.tsx
@@ -222,6 +222,7 @@ describe('DebtTypeDetailView', () => {
           code: 'TEST_CODE',
           debtPositionTypeDescription: 'Test Description',
           flagActive: true,
+          organizationId: 3,
           ...overrides.debtType
         }
       },
@@ -657,6 +658,24 @@ describe('DebtTypeDetailView', () => {
 
         expect(mockConfirmDialog.showDisableDialog).toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('No buttons when the org is not the same of detail', () => {
+    // cfr #P4ADEV-3915
+
+    beforeEach(() => {
+      setupDefaultMocks({
+        debtType: { flagActive: true, organizationId: 78 }
+      });
+    });
+
+    it('no edit button', async () => {
+      render(<DebtTypeDetailView />);
+
+      expect(
+        screen.queryByTestId('action-edit-button')
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/src/routes/DebtTypeDetailView/DebtTypeDetailView.tsx
+++ b/src/routes/DebtTypeDetailView/DebtTypeDetailView.tsx
@@ -236,6 +236,14 @@ export const DebtTypeDetailView = () => {
   const { titleActions, bottomActions } = useMemo(() => {
     const isActive = data?.response?.flagActive;
 
+    // no buttons it the org used != org owned
+    if (data?.response.organizationId !== organizationId) {
+      return {
+        titleActions: [],
+        bottomActions: []
+      };
+    }
+
     if (isActive) {
       const actionMenuButton = {
         icon: <MoreVert />,
@@ -251,6 +259,7 @@ export const DebtTypeDetailView = () => {
         buttonText: t('commons.edit'),
         color: 'primary' as const,
         variant: 'contained' as const,
+        dataTestId: 'action-edit-button',
         disabled: false,
         onActionClick: handleEditClick
       };

--- a/src/routes/Organizations/OrganizationDetail.test.tsx
+++ b/src/routes/Organizations/OrganizationDetail.test.tsx
@@ -31,7 +31,7 @@ vi.mock('../../utils', async () => {
     ...actual,
     default: {
       config: {
-        deployPath: '/test',
+        deployPath: '/test'
       },
       roles: {
         useIsSuperAdmin: vi.fn(() => false)
@@ -39,7 +39,6 @@ vi.mock('../../utils', async () => {
     }
   };
 });
-
 
 describe('OrganizationDetail Page', () => {
   const dataMock = {
@@ -88,7 +87,7 @@ describe('OrganizationDetail Page', () => {
       typeof vi.fn
     >;
     mockGetOrganizationDetail.mockReturnValue({
-      data: {...dataMock, status: 'DRAFT'}
+      data: { ...dataMock, status: 'DRAFT' }
     });
     mockUseIsSuperAdmin.mockReturnValue(true);
     render(<OrganizationDetail />);


### PR DESCRIPTION
This PR disable the action-buttons in the Debt Type detail when the user browse debtypes of another organization or rather a different org selected in the party switch.

#### List of Changes
- Set up a condition on the render of the buttons (check orgid)
- fix unit test and create a new one for this scenario

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
