### PR TITLE
feat: [P4ADEV-3917] Operator's actions: only when own org

### DIFF
--- a/src/routes/OperatorsDetail/components/ActionMenu.tsx
+++ b/src/routes/OperatorsDetail/components/ActionMenu.tsx
@@ -10,11 +10,13 @@ import utils from '../../../utils';
 type ActionMenuProps = {
   row: DebtPositionTypeOrgDTO;
   onDelete: (row: DebtPositionTypeOrgDTO) => void;
+  canDelete: boolean;
 };
 
 export const GridActionMenu = ({
   row,
-  onDelete: onDeleteProp
+  onDelete: onDeleteProp,
+  canDelete
 }: ActionMenuProps) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -34,35 +36,35 @@ export const GridActionMenu = ({
     }
   };
 
-  return (
-    <ActionMenu
-      rowId={row.debtPositionTypeId}
-      menuItems={[
-        {
-          icon: (
-            <RemoveCircleOutline
-              fontSize="small"
-              color="error"
-              aria-label="remove operator detail item"
-              data-testid={`remove-detail-${row.debtPositionTypeId}`}
-            />
-          ),
-          label: t('commons.onlyRemove'),
-          action: onDelete
-        },
-        {
-          icon: (
-            <OpenInNew
-              color="primary"
-              fontSize="small"
-              aria-label="go to operator detail item"
-              data-testid={`navigate-to-detail-${row.debtPositionTypeId}`}
-            />
-          ),
-          label: t('commons.goToDetail'),
-          action: onDetail
-        }
-      ]}
-    />
-  );
+  const menuItems = [
+    {
+      icon: (
+        <OpenInNew
+          color="primary"
+          fontSize="small"
+          aria-label="go to operator detail item"
+          data-testid={`navigate-to-detail-${row.debtPositionTypeId}`}
+        />
+      ),
+      label: t('commons.goToDetail'),
+      action: onDetail
+    }
+  ];
+
+  if (canDelete) {
+    menuItems.push({
+      icon: (
+        <RemoveCircleOutline
+          fontSize="small"
+          color="error"
+          aria-label="remove operator detail item"
+          data-testid={`remove-detail-${row.debtPositionTypeId}`}
+        />
+      ),
+      label: t('commons.onlyRemove'),
+      action: onDelete
+    });
+  }
+
+  return <ActionMenu rowId={row.debtPositionTypeId} menuItems={menuItems} />;
 };

--- a/src/routes/OperatorsDetail/components/OperatorDetailDataGrid.test.tsx
+++ b/src/routes/OperatorsDetail/components/OperatorDetailDataGrid.test.tsx
@@ -107,6 +107,7 @@ describe('OperatorDetailDataGrid', () => {
   it('renders column headers correctly', () => {
     render(
       <OperatorDetailDataGrid
+        isSameOrg={true}
         data={sampleData}
         onDelete={mockOnDelete}
         operatorName={operatorName}
@@ -170,6 +171,7 @@ describe('OperatorDetailDataGrid', () => {
         }}
         onDelete={mockOnDelete}
         operatorName={operatorName}
+        isSameOrg={true}
       />
     );
 
@@ -183,6 +185,7 @@ describe('OperatorDetailDataGrid', () => {
       <OperatorDetailDataGrid
         onDelete={mockOnDelete}
         operatorName={operatorName}
+        isSameOrg={true}
       />
     );
 
@@ -196,6 +199,7 @@ describe('OperatorDetailDataGrid', () => {
         data={sampleData}
         onDelete={mockOnDelete}
         operatorName={operatorName}
+        isSameOrg={true}
       />
     );
 
@@ -219,6 +223,7 @@ describe('OperatorDetailDataGrid', () => {
         data={sampleData}
         onDelete={mockOnDelete}
         operatorName={operatorName}
+        isSameOrg={true}
       />
     );
 
@@ -242,6 +247,7 @@ describe('OperatorDetailDataGrid', () => {
         data={sampleData}
         onDelete={mockOnDelete}
         operatorName={operatorName}
+        isSameOrg={true}
       />
     );
 
@@ -265,6 +271,7 @@ describe('OperatorDetailDataGrid', () => {
         data={sampleData}
         onDelete={mockOnDelete}
         operatorName={operatorName}
+        isSameOrg={true}
       />
     );
 
@@ -292,6 +299,7 @@ describe('OperatorDetailDataGrid', () => {
         data={dataWithoutId}
         onDelete={mockOnDelete}
         operatorName={operatorName}
+        isSameOrg={true}
       />
     );
 

--- a/src/routes/OperatorsDetail/components/OperatorDetailDataGrid.test.tsx
+++ b/src/routes/OperatorsDetail/components/OperatorDetailDataGrid.test.tsx
@@ -128,6 +128,7 @@ describe('OperatorDetailDataGrid', () => {
   it('renders rows correctly', () => {
     render(
       <OperatorDetailDataGrid
+        isSameOrg={true}
         data={sampleData}
         onDelete={mockOnDelete}
         operatorName={operatorName}

--- a/src/routes/OperatorsDetail/components/OperatorDetailDataGrid.tsx
+++ b/src/routes/OperatorsDetail/components/OperatorDetailDataGrid.tsx
@@ -13,12 +13,14 @@ type OperatorDetailDataGridProps = {
   data?: PagedDebtPositionTypeOrgDTO;
   onDelete: (row: DebtPositionTypeOrgDTO) => void;
   operatorName: string;
+  isSameOrg: boolean;
 };
 
 const OperatorDetailDataGrid = ({
   data,
   onDelete: propsOnDelete,
-  operatorName
+  operatorName,
+  isSameOrg
 }: OperatorDetailDataGridProps) => {
   const { t } = useTranslation();
 
@@ -69,7 +71,11 @@ const OperatorDetailDataGrid = ({
       align: 'right',
       headerAlign: 'right',
       renderCell: (params: GridRenderCellParams<DebtPositionTypeOrgDTO>) => (
-        <GridActionMenu row={params.row} onDelete={onDelete} />
+        <GridActionMenu
+          row={params.row}
+          onDelete={onDelete}
+          canDelete={isSameOrg}
+        />
       )
     }
   ];

--- a/src/routes/OperatorsDetail/index.tsx
+++ b/src/routes/OperatorsDetail/index.tsx
@@ -21,6 +21,7 @@ import { useDebtPositionTypesByOrg } from '../../hooks/useDebtPositionTypesByOrg
 import { useBreadcrumbs } from './hooks/useBreadcrumbs';
 import { DebtPositionTypeOrgDTO } from '../../../generated/data-contracts';
 import { removeDebtPositionTypeOrgFromOperator } from '../../api/debtPositionTypeOrgOperators';
+import { useStore } from '../../store/GlobalStore';
 
 export const OperatorDetail = () => {
   const { t } = useTranslation();
@@ -36,6 +37,12 @@ export const OperatorDetail = () => {
   } = useParams();
 
   const organizationId = Number(paramOrganizationId);
+
+  const {
+    state: { organizationId: organizationIdStored }
+  } = useStore();
+  // this is to check if the org selected is the same who want operate
+  const isSameOrg = organizationIdStored === organizationId;
 
   if (isNaN(organizationId) || !mappedExternalUserId) {
     navigate(PageRoutes.RESPONSES_ERROR);
@@ -193,14 +200,16 @@ export const OperatorDetail = () => {
           <Typography variant="h6">
             {t('OperatorDetail.associatedDebtPositionTypes')}
           </Typography>
-          <Button
-            variant="outlined"
-            color="primary"
-            startIcon={<Add />}
-            onClick={onAffiliateClick}
-          >
-            {t('commons.affiliateNew')}
-          </Button>
+          {isSameOrg && (
+            <Button
+              variant="outlined"
+              color="primary"
+              startIcon={<Add />}
+              onClick={onAffiliateClick}
+            >
+              {t('commons.affiliateNew')}
+            </Button>
+          )}
         </Box>
         <Grid
           container
@@ -231,6 +240,7 @@ export const OperatorDetail = () => {
             data={data?.pagedDebtPositionTypeOrg}
             operatorName={operatorName}
             onDelete={onDelete}
+            isSameOrg={isSameOrg}
           />
         </Grid>
       </Grid>


### PR DESCRIPTION
This PR adds a check in the Operator's page to show the actions ("new" and "delete") only if the Org is the same selected in the Switcher.

#### List of Changes
- Add a check in the OperatorDetail pages / components

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
