### PR TITLE
fix: [P4ADEV-4010] Alert banner more resilient

### DIFF
--- a/src/routes/Organizations/components/OrganizationDetailAlert.tsx
+++ b/src/routes/Organizations/components/OrganizationDetailAlert.tsx
@@ -16,7 +16,7 @@ export const OrganizationDetailAlert: React.FC<
   organizationDetailData
 }: OrganizationDetailAlertProps) => {
   const { t } = useTranslation();
-  const [showAlert, setShowAlert] = useState<boolean>(false);
+  const [emptyFieldsString, setEmptyFieldsString] = useState<string>('');
 
   const mandatoryFields: Partial<Record<keyof OrganizationDetailDTO, string>> =
     {
@@ -24,17 +24,15 @@ export const OrganizationDetailAlert: React.FC<
       orgLogo: t('organizations.orgLogo'),
       segregationCode: t('commons.segregationCode')
     };
-  const missingKeys = (
-    Object.keys(mandatoryFields) as Array<keyof OrganizationDetailDTO>
-  )
-    .filter((key) => !(key in organizationDetailData))
-    .map((key) => mandatoryFields[key] ?? key);
-
-  const emptyFieldsString = missingKeys.join(', ');
 
   useEffect(() => {
-    if (missingKeys.length > 0) setShowAlert(true);
-  }, [missingKeys]);
+    const missingKeys = (
+      Object.keys(mandatoryFields) as Array<keyof OrganizationDetailDTO>
+    )
+      .filter((key) => !(key in organizationDetailData))
+      .map((key) => mandatoryFields[key] ?? key);
+    setEmptyFieldsString(missingKeys.join(', '));
+  }, [organizationDetailData]);
 
   const editButton: ReactNode = (
     <Button startIcon={<EditIcon />} onClick={editFunction}>
@@ -44,7 +42,7 @@ export const OrganizationDetailAlert: React.FC<
 
   return (
     <>
-      {showAlert && (
+      {emptyFieldsString && (
         <Alert
           severity="info"
           data-testid="org-empty-fields-error"


### PR DESCRIPTION
This PR fix the banner in the Org detail. 
The bug : It consists of displaying the banner immediately after having correctly modified the organization data.
After the fix: the banner will not rendered when all the mandatory fields are filled.

#### List of Changes
- refact visibility condition

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
