### PR TITLE
feat: [P4ADEV-4066]  home shared components

### DIFF
--- a/src/routes/Home/components/HomeDrawerBody.test.tsx
+++ b/src/routes/Home/components/HomeDrawerBody.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '../../../__tests__/renderers';
+import { HomeDrawerBody } from './HomeDrawerBody';
+import { i18nTestSetup } from '../../../__tests__/i18nTestSetup';
+
+describe('HomeDrawerBody', () => {
+  beforeEach(() => {
+    i18nTestSetup({
+      'home.tabs.1.label': 'Label for tab 1'
+    });
+  });
+
+  it('HomeDrawerBody renders correctly', () => {
+    const searchLabel = '1';
+    const searchValue = 'testValue';
+
+    render(
+      <HomeDrawerBody searchLabel={searchLabel} searchValue={searchValue} />
+    );
+
+    expect(screen.getByText('Label for tab 1')).toBeInTheDocument();
+    expect(screen.getByText('testValue')).toBeInTheDocument();
+    expect(screen.getByText('Visit the link')).toBeInTheDocument();
+    expect(screen.getByText('Download the file')).toBeInTheDocument();
+  });
+});

--- a/src/routes/Home/components/HomeDrawerBody.tsx
+++ b/src/routes/Home/components/HomeDrawerBody.tsx
@@ -1,0 +1,55 @@
+import { Box, MenuList, Typography, useTheme } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
+import { HomeDrawerListItem } from './HomeDrawerListItem';
+
+type HomeDrawerBodyProps = {
+  searchLabel: string;
+  searchValue: string;
+};
+
+export const HomeDrawerBody = ({
+  searchLabel,
+  searchValue
+}: HomeDrawerBodyProps) => {
+  const theme = useTheme();
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Box my={2}>
+        <Typography component={'p'} variant={'body2'}>
+          {t(`home.tabs.${searchLabel}.label`)}
+        </Typography>
+        <Typography component={'p'} variant={'body1'} fontWeight={600}>
+          {searchValue}
+        </Typography>
+      </Box>
+      <Box my={2}>
+        <Typography
+          variant={'button'}
+          textTransform={'uppercase'}
+          color={theme.palette.grey[700]}
+          id="home-drawer-actions"
+        >
+          {t('home.drawer.actions')}
+        </Typography>
+        <MenuList dense={false} aria-labelledby="home-drawer-actions">
+          {/* TO-DO: put here the cycle of results */}
+          <HomeDrawerListItem
+            actionIcon="visit"
+            actionFunction={() => console.log('visit')}
+            icon={<ReceiptLongIcon fontSize="small" color={'primary'} />}
+            label={'Visit the link'} // TODO: set a proper label
+          />
+          <HomeDrawerListItem
+            actionIcon="download"
+            actionFunction={() => console.log('download')}
+            icon={<ReceiptLongIcon fontSize="small" color={'primary'} />}
+            label={'Download the file'} // TODO: set a proper label
+          />
+        </MenuList>
+      </Box>
+    </>
+  );
+};

--- a/src/routes/Home/components/HomeDrawerListItem.test.tsx
+++ b/src/routes/Home/components/HomeDrawerListItem.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '../../../__tests__/renderers';
+import { HomeDrawerListItem } from './HomeDrawerListItem';
+
+describe('HomeDrawerListItem', () => {
+  it('HomeDrawerListItem renders correctly', () => {
+    const logSpy = vi.spyOn(console, 'log');
+
+    render(
+      <HomeDrawerListItem
+        actionIcon="visit"
+        actionFunction={() => {
+          console.log('clicked');
+        }}
+        icon={<div>Icon</div>}
+        label="Test Label"
+      />
+    );
+
+    const menuItem = screen.getByTestId('home-drawer-list-item');
+    expect(menuItem).toBeInTheDocument();
+    expect(screen.getByText('Test Label')).toBeInTheDocument();
+    expect(screen.getByText('Icon')).toBeInTheDocument();
+
+    fireEvent.click(menuItem);
+    expect(logSpy).toHaveBeenCalledWith('clicked');
+  });
+
+  it('HomeDrawerListItem renders with a download icon', () => {
+    render(
+      <HomeDrawerListItem
+        actionIcon="download"
+        actionFunction={() => {
+          console.log('clicked');
+        }}
+        icon={<div>Icon</div>}
+        label="Test Label"
+      />
+    );
+
+    expect(screen.getByTestId('DownloadIcon')).toBeInTheDocument();
+  });
+});

--- a/src/routes/Home/components/HomeDrawerListItem.tsx
+++ b/src/routes/Home/components/HomeDrawerListItem.tsx
@@ -1,0 +1,42 @@
+import { ListItemIcon, ListItemText, MenuItem, useTheme } from '@mui/material';
+import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
+import DownloadIcon from '@mui/icons-material/Download';
+
+type HomeDrawerListItemProps = {
+  actionIcon?: 'visit' | 'download';
+  actionFunction: () => void;
+  icon: React.ReactNode;
+  label: string;
+};
+
+export const HomeDrawerListItem = ({
+  actionIcon = 'visit',
+  actionFunction,
+  icon,
+  label
+}: HomeDrawerListItemProps) => {
+  const theme = useTheme();
+
+  return (
+    <>
+      <MenuItem
+        divider
+        sx={{
+          py: 1,
+          px: 0,
+          '&:hover': { backgroundColor: theme.palette.background.paper }
+        }}
+        onClick={actionFunction}
+        data-testid="home-drawer-list-item"
+      >
+        <ListItemIcon>{icon}</ListItemIcon>
+        <ListItemText>{label}</ListItemText>
+        {actionIcon === 'visit' ? (
+          <KeyboardArrowRightIcon color={'primary'} />
+        ) : (
+          <DownloadIcon color={'primary'} />
+        )}
+      </MenuItem>
+    </>
+  );
+};

--- a/src/routes/Home/index.test.tsx
+++ b/src/routes/Home/index.test.tsx
@@ -11,13 +11,13 @@ vi.mock('../../utils', () => ({
       emit: vi.fn()
     },
     config: {
-      deployPath: '/test',
+      deployPath: '/test'
     }
   }
 }));
 vi.mock('react-router', async (importOriginal) => ({
   ...(await importOriginal()),
-  useNavigate: vi.fn(),
+  useNavigate: vi.fn()
 }));
 
 describe('Home page', () => {
@@ -29,22 +29,22 @@ describe('Home page', () => {
   };
 
   const user = {
-          userId: 'userId',
-          familyName: 'Polo',
-          name: 'Marco',
-          fiscalCode: 'XXXXXXX',
-          canManageUsers: false,
-          issuer: 'Issuer',
-          organizations: [],
-          mappedExternalUserId: 'mappedExternalUserId'
-        };
+    userId: 'userId',
+    familyName: 'Polo',
+    name: 'Marco',
+    fiscalCode: 'XXXXXXX',
+    canManageUsers: false,
+    issuer: 'Issuer',
+    organizations: [],
+    mappedExternalUserId: 'mappedExternalUserId'
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
 
     i18nTestSetup({
-      home : {
-        opening: "Ciao, {{user}}"
+      home: {
+        opening: 'Ciao, {{user}}'
       }
     });
     setUserInfo(user);
@@ -63,7 +63,9 @@ describe('Home page', () => {
     mockSessionStorage.getItem.mockReturnValue(null);
     renderHome();
 
-    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(`${user.name} ${user.familyName}`);
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      `${user.name} ${user.familyName}`
+    );
   });
 
   it('handles pending notification when present in sessionStorage', () => {

--- a/src/routes/Home/index.test.tsx
+++ b/src/routes/Home/index.test.tsx
@@ -3,13 +3,21 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import utils from '../../utils';
 import { i18nTestSetup } from '../../__tests__/i18nTestSetup';
 import { render, screen } from '../../__tests__/renderers';
+import { setUserInfo } from '../../store/UserInfoStore';
 
 vi.mock('../../utils', () => ({
   default: {
     notify: {
       emit: vi.fn()
+    },
+    config: {
+      deployPath: '/test',
     }
   }
+}));
+vi.mock('react-router', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useNavigate: vi.fn(),
 }));
 
 describe('Home page', () => {
@@ -20,12 +28,26 @@ describe('Home page', () => {
     clear: vi.fn()
   };
 
+  const user = {
+          userId: 'userId',
+          familyName: 'Polo',
+          name: 'Marco',
+          fiscalCode: 'XXXXXXX',
+          canManageUsers: false,
+          issuer: 'Issuer',
+          organizations: [],
+          mappedExternalUserId: 'mappedExternalUserId'
+        };
+
   beforeEach(() => {
     vi.clearAllMocks();
 
     i18nTestSetup({
-      HOME: 'HOME'
+      home : {
+        opening: "Ciao, {{user}}"
+      }
     });
+    setUserInfo(user);
 
     Object.defineProperty(window, 'sessionStorage', {
       value: mockSessionStorage,
@@ -37,11 +59,11 @@ describe('Home page', () => {
     return render(<Home />);
   };
 
-  it('renders Home without crashing', () => {
+  it('renders Home with the name of the user', () => {
     mockSessionStorage.getItem.mockReturnValue(null);
     renderHome();
 
-    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('HOME');
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(`${user.name} ${user.familyName}`);
   });
 
   it('handles pending notification when present in sessionStorage', () => {

--- a/src/routes/Home/index.tsx
+++ b/src/routes/Home/index.tsx
@@ -24,6 +24,8 @@ import TabPanel from '@mui/lab/TabPanel';
 import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
 import PersonIcon from '@mui/icons-material/Person';
 import AltRouteIcon from '@mui/icons-material/AltRoute';
+import { Drawer } from '../../components/Drawer';
+import { HomeDrawerBody } from './components/HomeDrawerBody';
 
 const Home = () => {
   const { t } = useTranslation();
@@ -34,6 +36,9 @@ const Home = () => {
 
   const [value, setValue] = useState('1');
   const [error, setError] = useState(false);
+  const [showDrawer, setShowDrawer] = useState(false);
+  const [searchLabel, setSearchLabel] = useState('');
+  const [searchValue, setSearchValue] = useState('');
 
   useEffect(() => {
     const pendingNotification = sessionStorage.getItem('pendingNotification');
@@ -90,25 +95,22 @@ const Home = () => {
    *
    * @param event Form event
    * @param formData Data extracted by the form submitted
-   * @param searchName Distinguish name between the different type of search
    */
   const searchHandler = (
     event: React.FormEvent<HTMLFormElement>,
-    formData: FormData,
-    searchName: string
+    formData: FormData
   ) => {
     event?.preventDefault();
-    const searchValue = formData.get('searchValue');
+    const searchValue = formData.get('searchValue')?.toString() || '';
 
     if (!searchValue) {
       setError(true);
       return;
     }
-
     setError(false);
-
-    // TO-DO
-    console.log(searchValue, searchName);
+    setSearchLabel(value);
+    setSearchValue(searchValue);
+    setShowDrawer(true);
   };
 
   return (
@@ -162,11 +164,7 @@ const Home = () => {
                 name={tab.searchName}
                 data-testid={`home-form-${tab.value}`}
                 onSubmit={(event) =>
-                  searchHandler(
-                    event,
-                    new FormData(event.currentTarget),
-                    tab.searchName
-                  )
+                  searchHandler(event, new FormData(event.currentTarget))
                 }
               >
                 <Stack
@@ -196,6 +194,18 @@ const Home = () => {
           ))}
         </TabContext>
       </Box>
+      <Drawer
+        open={showDrawer}
+        onClose={() => {
+          setShowDrawer(false);
+        }}
+        title={t('commons.results')}
+      >
+        <HomeDrawerBody
+          searchLabel={searchLabel}
+          searchValue={searchValue}
+        ></HomeDrawerBody>
+      </Drawer>
     </>
   );
 };

--- a/src/routes/Home/index.tsx
+++ b/src/routes/Home/index.tsx
@@ -1,10 +1,40 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import utils from '../../utils';
-import TitleComponent from '../../components/TitleComponent/TitleComponent';
+import TitleComponent, {
+  ActionMenuItem
+} from '../../components/TitleComponent/TitleComponent';
 import { useTranslation } from 'react-i18next';
+import { useStore } from '../../store/GlobalStore';
+import { PageRoutes } from '..';
+import { useNavigate } from 'react-router';
+import AddIcon from '@mui/icons-material/Add';
+import SearchIcon from '@mui/icons-material/Search';
+import {
+  Alert,
+  Box,
+  Button,
+  FormControl,
+  Stack,
+  Tab,
+  TextField
+} from '@mui/material';
+import TabContext from '@mui/lab/TabContext';
+import TabList from '@mui/lab/TabList';
+import TabPanel from '@mui/lab/TabPanel';
+import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
+import PersonIcon from '@mui/icons-material/Person';
+import AltRouteIcon from '@mui/icons-material/AltRoute';
 
 const Home = () => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const {
+    state: { userInfo }
+  } = useStore();
+
+  const [value, setValue] = useState('1');
+  const [error, setError] = useState(false);
+
   useEffect(() => {
     const pendingNotification = sessionStorage.getItem('pendingNotification');
     if (pendingNotification) {
@@ -14,9 +44,158 @@ const Home = () => {
     }
   }, []);
 
+  const handleChange = (_event: React.SyntheticEvent, newValue: string) => {
+    setValue(newValue);
+    setError(false);
+  };
+
+  const user = userInfo ? `${userInfo.name} ${userInfo.familyName} ` : '';
+
+  const cta: ActionMenuItem = {
+    variant: 'contained',
+    buttonText: t('home.cta'),
+    icon: <AddIcon></AddIcon>,
+    onActionClick: () => navigate(PageRoutes.DEBT_POSITION_CREATE_WIZARD)
+  };
+
+  const RotatedAltRouteIcon = () => {
+    return <AltRouteIcon sx={{ transform: 'rotate(90deg)', mr: 1 }} />;
+  };
+
+  const tabsConfig = [
+    {
+      value: '1',
+      label: t('home.tabs.1.label'),
+      icon: <ReceiptLongIcon />,
+      searchLabel: t('home.tabs.1.fieldLabel'),
+      searchName: 'iuv'
+    },
+    {
+      value: '2',
+      label: t('home.tabs.2.label'),
+      icon: <PersonIcon />,
+      searchLabel: t('home.tabs.2.fieldLabel'),
+      searchName: 'cf'
+    },
+    {
+      value: '3',
+      label: t('home.tabs.3.label'),
+      icon: <RotatedAltRouteIcon />,
+      searchLabel: t('home.tabs.3.fieldLabel'),
+      searchName: 'iuf'
+    }
+  ];
+
+  /**
+   *
+   * @param event Form event
+   * @param formData Data extracted by the form submitted
+   * @param searchName Distinguish name between the different type of search
+   */
+  const searchHandler = (
+    event: React.FormEvent<HTMLFormElement>,
+    formData: FormData,
+    searchName: string
+  ) => {
+    event?.preventDefault();
+    const searchValue = formData.get('searchValue');
+
+    if (!searchValue) {
+      setError(true);
+      return;
+    }
+
+    setError(false);
+
+    // TO-DO
+    console.log(searchValue, searchName);
+  };
+
   return (
     <>
-      <TitleComponent title={t('commons.routes.HOME')}></TitleComponent>
+      <TitleComponent
+        title={t('home.opening', { user: user })}
+        accessibleTitle={t('commons.routes.HOME')}
+        callToAction={[cta]}
+      ></TitleComponent>
+
+      <Box>
+        <TabContext value={value}>
+          <Box>
+            <TabList
+              onChange={handleChange}
+              aria-label={t('home.tabsType')}
+              variant="fullWidth"
+              data-testid="home-tabs-list"
+            >
+              {tabsConfig.map((tab) => (
+                <Tab
+                  key={tab.value}
+                  icon={tab.icon}
+                  iconPosition={'start'}
+                  label={tab.label}
+                  value={tab.value}
+                  data-testid={`home-tab-${tab.value}`}
+                />
+              ))}
+            </TabList>
+          </Box>
+          {tabsConfig.map((tab) => (
+            <TabPanel
+              key={tab.value}
+              value={tab.value}
+              sx={{ bgcolor: 'background.paper' }}
+              data-testid={`home-tabpanel-${tab.value}`}
+            >
+              {error && (
+                <Alert
+                  severity="error"
+                  data-testid="home-tabs-error"
+                  sx={{ mb: 2 }}
+                >
+                  {t('home.fillAtLeast')}
+                </Alert>
+              )}
+              <FormControl
+                fullWidth={true}
+                component={'form'}
+                name={tab.searchName}
+                data-testid={`home-form-${tab.value}`}
+                onSubmit={(event) =>
+                  searchHandler(
+                    event,
+                    new FormData(event.currentTarget),
+                    tab.searchName
+                  )
+                }
+              >
+                <Stack
+                  direction={'row'}
+                  spacing={2}
+                  alignItems={'center'}
+                  justifyContent={'space-between'}
+                >
+                  <TextField
+                    label={tab.searchLabel}
+                    name={'searchValue'}
+                    data-testid={`home-form-input-${tab.value}`}
+                    size="small"
+                    sx={{ flexGrow: 1 }}
+                  ></TextField>
+                  <Button
+                    variant="contained"
+                    type={'submit'}
+                    startIcon={<SearchIcon />}
+                    data-testid={`home-form-btn-${tab.value}`}
+                  >
+                    {t('commons.search')}
+                  </Button>
+                </Stack>
+              </FormControl>
+            </TabPanel>
+          ))}
+        </TabContext>
+      </Box>
     </>
   );
 };

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -933,6 +933,7 @@
     "remove": "Rimuovi",
     "required": "Campo obbligatorio",
     "requiredFieldDescription": "* Indica un campo obbligatorio",
+    "results": "Risultati",
     "roles": {
       "ROLE_ADMIN": "Amministratore",
       "ROLE_OPER": "Operatore"
@@ -1835,10 +1836,12 @@
     "uploadDate": "Data Caricamento"
   },
   "home": {
-    "opening": "Ciao, {{user}}",
     "cta": "Crea Posizione Debitoria",
-    "tabsTypes": "Tipi di ricerca",
+    "drawer": {
+      "actions": "Azioni disponibili"
+    },
     "fillAtLeast": "Inserisci un valore per avviare la ricerca",
+    "opening": "Ciao, {{user}}",
     "tabs": {
       "1": {
         "label": "Avviso",
@@ -1852,7 +1855,8 @@
         "label": "Rendicontazione",
         "fieldLabel": "IUF"
       }
-    }
+    },
+    "tabsTypes": "Tipi di ricerca"
   },
   "notificationPreview": {
     "byOrg": "Ente mittente*",

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -1834,6 +1834,26 @@
     "reservationDate": "Data prenotazione",
     "uploadDate": "Data Caricamento"
   },
+  "home": {
+    "opening": "Ciao, {{user}}",
+    "cta": "Crea Posizione Debitoria",
+    "tabsTypes": "Tipi di ricerca",
+    "fillAtLeast": "Inserisci un valore per avviare la ricerca",
+    "tabs": {
+      "1": {
+        "label": "Avviso",
+        "fieldLabel": "IUV"
+      },
+      "2": {
+        "label": "Cittadino",
+        "fieldLabel": "CF / Partita IVA"
+      },
+      "3": {
+        "label": "Rendicontazione",
+        "fieldLabel": "IUF"
+      }
+    }
+  },
   "notificationPreview": {
     "byOrg": "Ente mittente*",
     "byService": "Servizio mittente*"


### PR DESCRIPTION
This PR adds shared components to render a detailed drawer when in homepage

#### List of Changes
- add two components in the home routes family: Body and List item
- edit the main drawer
- added unit tests
- 
#### Motivation and Context
To have a shared components and render-logic to show info ho the home.

#### How Has This Been Tested?
- visual tests
- unit tests
- 
#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
