### PR TITLE
fix: [P4ADEV-3929] client sil confirmation page

### DIFF
--- a/src/components/BackButton/index.test.tsx
+++ b/src/components/BackButton/index.test.tsx
@@ -14,9 +14,17 @@ vi.mock('react-router', async () => {
   };
 });
 
+vi.mock('../../hooks/useSmartBack', () => ({
+  useSmartBack: vi.fn()
+}));
+
 const mockNavigate = vi.fn();
+const mockHandleSmartBack = vi.fn();
 const mockUseNavigate = useNavigate as ReturnType<typeof vi.fn>;
 const mockUseLocation = vi.mocked(await import('react-router')).useLocation;
+const mockUseSmartBack = vi.mocked(
+  await import('../../hooks/useSmartBack')
+).useSmartBack;
 
 describe('BackButton', () => {
   beforeEach(() => {
@@ -25,7 +33,9 @@ describe('BackButton', () => {
     });
 
     mockNavigate.mockClear();
+    mockHandleSmartBack.mockClear();
     mockUseNavigate.mockReturnValue(mockNavigate);
+    mockUseSmartBack.mockReturnValue({ handleSmartBack: mockHandleSmartBack });
 
     Object.defineProperty(window, 'history', {
       value: { length: 2 },
@@ -61,17 +71,17 @@ describe('BackButton', () => {
       expect(button).toHaveTextContent(customText);
     });
 
-    it('should call navigate(-1) when clicked without fromSuccess flag', () => {
+    it('should call handleSmartBack when clicked (default Smart Back enabled)', () => {
       render(<BackButton />);
 
       const button = screen.getByRole('button', { name: 'Back' });
       fireEvent.click(button);
 
-      expect(mockNavigate).toHaveBeenCalledWith(-1);
-      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockHandleSmartBack).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).not.toHaveBeenCalled();
     });
 
-    it('should call navigate(-2) when fromSuccess flag is true', () => {
+    it('should call navigate(-2) when fromSuccess flag is true (legacy mode)', () => {
       mockUseLocation.mockReturnValue({
         key: 'some-key',
         pathname: '/current-path',
@@ -80,7 +90,7 @@ describe('BackButton', () => {
         state: { fromSuccess: true }
       });
 
-      render(<BackButton />);
+      render(<BackButton enableSmartBack={false} />);
 
       const button = screen.getByRole('button', { name: 'Back' });
       fireEvent.click(button);
@@ -89,7 +99,7 @@ describe('BackButton', () => {
       expect(mockNavigate).toHaveBeenCalledTimes(1);
     });
 
-    it('should call navigate(-2) when category includes success', () => {
+    it('should call navigate(-2) when category includes success (legacy mode)', () => {
       mockUseLocation.mockReturnValue({
         key: 'some-key',
         pathname: '/current-path',
@@ -98,7 +108,7 @@ describe('BackButton', () => {
         state: { category: 'assessment-create-success' }
       });
 
-      render(<BackButton />);
+      render(<BackButton enableSmartBack={false} />);
 
       const button = screen.getByRole('button', { name: 'Back' });
       fireEvent.click(button);
@@ -107,7 +117,7 @@ describe('BackButton', () => {
       expect(mockNavigate).toHaveBeenCalledTimes(1);
     });
 
-    it('should call navigate(-2) when both fromSuccess and category are present', () => {
+    it('should call navigate(-2) when both fromSuccess and category are present (legacy mode)', () => {
       mockUseLocation.mockReturnValue({
         key: 'some-key',
         pathname: '/current-path',
@@ -119,7 +129,7 @@ describe('BackButton', () => {
         }
       });
 
-      render(<BackButton />);
+      render(<BackButton enableSmartBack={false} />);
 
       const button = screen.getByRole('button', { name: 'Back' });
       fireEvent.click(button);
@@ -128,7 +138,7 @@ describe('BackButton', () => {
       expect(mockNavigate).toHaveBeenCalledTimes(1);
     });
 
-    it('should call navigate(-1) when category exists but does not include success', () => {
+    it('should call navigate(-1) when category exists but does not include success (legacy mode)', () => {
       mockUseLocation.mockReturnValue({
         key: 'some-key',
         pathname: '/current-path',
@@ -137,7 +147,7 @@ describe('BackButton', () => {
         state: { category: 'assessment-create-pending' }
       });
 
-      render(<BackButton />);
+      render(<BackButton enableSmartBack={false} />);
 
       const button = screen.getByRole('button', { name: 'Back' });
       fireEvent.click(button);
@@ -258,7 +268,7 @@ describe('BackButton', () => {
       expect(button).toHaveTextContent('');
     });
 
-    it('should handle null state gracefully', () => {
+    it('should handle null state gracefully with Smart Back', () => {
       mockUseLocation.mockReturnValue({
         key: 'some-key',
         pathname: '/current-path',
@@ -272,10 +282,11 @@ describe('BackButton', () => {
       const button = screen.getByRole('button', { name: 'Back' });
       fireEvent.click(button);
 
-      expect(mockNavigate).toHaveBeenCalledWith(-1);
+      expect(mockHandleSmartBack).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).not.toHaveBeenCalled();
     });
 
-    it('should handle undefined state gracefully', () => {
+    it('should handle undefined state gracefully with Smart Back', () => {
       mockUseLocation.mockReturnValue({
         key: 'some-key',
         pathname: '/current-path',
@@ -289,10 +300,11 @@ describe('BackButton', () => {
       const button = screen.getByRole('button', { name: 'Back' });
       fireEvent.click(button);
 
-      expect(mockNavigate).toHaveBeenCalledWith(-1);
+      expect(mockHandleSmartBack).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).not.toHaveBeenCalled();
     });
 
-    it('should handle state without fromSuccess or category', () => {
+    it('should handle state without fromSuccess or category with Smart Back', () => {
       mockUseLocation.mockReturnValue({
         key: 'some-key',
         pathname: '/current-path',
@@ -306,7 +318,8 @@ describe('BackButton', () => {
       const button = screen.getByRole('button', { name: 'Back' });
       fireEvent.click(button);
 
-      expect(mockNavigate).toHaveBeenCalledWith(-1);
+      expect(mockHandleSmartBack).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/BackButton/index.tsx
+++ b/src/components/BackButton/index.tsx
@@ -2,49 +2,77 @@ import { ArrowBack } from '@mui/icons-material';
 import Button from '@mui/material/Button';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useLocation } from 'react-router';
+import { useSmartBack } from '../../hooks/useSmartBack';
 
 export type BackButtonProps = {
   text?: string;
   onClick?: () => void;
+  /**
+   * Fallback route (full path) for smart back.
+   * If the history does not contain valid pages, navigates to this route.
+   *
+   * @example '/piattaformaunitaria/backoffice/client-sil'
+   */
+  fallbackRoute?: string;
+  /**
+   * Enables smart back navigation that automatically skips
+   * consecutive success pages in history.
+   * Default: true
+   *
+   * Set to false to use the legacy behavior (navigate -1 or -2)
+   */
+  enableSmartBack?: boolean;
 };
 
 export const BackButton = (props: BackButtonProps) => {
   const navigate = useNavigate();
   const location = useLocation();
   const { t } = useTranslation();
-  const { text = t('commons.back'), onClick } = props;
+  const {
+    text = t('commons.back'),
+    onClick,
+    fallbackRoute,
+    enableSmartBack = true
+  } = props;
 
   const hasHistory = location.key !== 'default' && window.history.length > 1;
+
+  const { handleSmartBack } = useSmartBack({
+    fallbackRoute
+  });
 
   if (!hasHistory) {
     return null;
   }
+
   /**
-   * Handles the back navigation with smart deduplication logic.
+   * Handles the back navigation.
    *
-   * When success pages use `navigate(route, { replace: true })`, they create
-   * duplicate consecutive entries in the browser history stack. This function
-   * detects such scenarios and skips the duplicate entry by navigating -2 steps
-   * instead of the standard -1, preventing navigation loops.
+   * If enableSmartBack is true (default), uses the useSmartBack hook which:
+   * - Automatically skips all consecutive success pages
+   * - Uses the fallbackRoute if the history is not valid
+   * - Has a safety cap to avoid infinite loops
    *
-   * @example
-   * Standard flow: Detail -> Edit -> Success (replace) -> Detail (replace)
-   * Browser stack becomes: [Detail, Detail] instead of [Detail, Edit, Success, Detail]
-   * Without this logic: navigate(-1) would go Detail -> Detail (same page)
-   * With this logic: navigate(-2) goes to the actual previous page
+   * If enableSmartBack is false, uses the legacy behavior which:
+   * - Skips only one success page (navigate -2)
+   * - Otherwise does navigate(-1)
    */
   const handleBack = () => {
-    // Check if current location comes from a success page navigation
-    const comesFromSuccess =
-      location.state?.fromSuccess ||
-      location.state?.category?.includes('success');
-
-    if (comesFromSuccess) {
-      // Skip duplicate entry caused by replace: true navigations
-      navigate(-2);
+    if (enableSmartBack) {
+      handleSmartBack();
     } else {
-      // Standard back navigation
-      navigate(-1);
+      // Fallback to legacy behavior for backward compatibility
+      const comesFromSuccess =
+        location.state?.fromSuccess ||
+        location.state?.category?.includes('success');
+
+      if (comesFromSuccess) {
+        // Skip duplicate entry caused by replace: true navigations
+        navigate(-2);
+      } else {
+        // Standard back navigation
+        navigate(-1);
+      }
     }
   };
 
@@ -55,7 +83,13 @@ export const BackButton = (props: BackButtonProps) => {
       size="medium"
       startIcon={<ArrowBack />}
       variant="text"
-      onClick={onClick || handleBack}
+      onClick={() => {
+        if (onClick) {
+          onClick();
+        } else {
+          handleBack();
+        }
+      }}
       sx={{ marginBottom: 3, paddingLeft: 0 }}
     >
       {text}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -24,13 +24,14 @@ import { useTranslation } from 'react-i18next';
 import GenericDialog from '../GenericDialog/GenericDialog';
 import '../../style.css';
 import { RouteChangeAnnouncement } from '../RouteChangeAnnouncement';
+import { PageRoutes } from '../../routes';
 
 const defaultRouteHandle: RouteHandleObject = {
   backButton: true,
   custom: false,
   hideBreadcrumbs: false,
   sidebar: { visible: true },
-  backButtonText: 'commons.back' // <- default: Indietro
+  backButtonText: 'commons.back'
 };
 
 export function Layout() {
@@ -55,7 +56,9 @@ export function Layout() {
     sidebar,
     backButton,
     backButtonText,
-    backButtonFunction
+    backButtonFunction,
+    backFallbackRoute,
+    enableSmartBack
   } = {
     ...defaultRouteHandle,
     ...(currentMatch.find((match) => Boolean(match.handle))?.handle || {})
@@ -131,6 +134,14 @@ export function Layout() {
                   <BackButton
                     onClick={backButtonFunction}
                     text={t(backButtonText ?? 'commons.back')}
+                    fallbackRoute={
+                      backFallbackRoute
+                        ? PageRoutes[
+                            backFallbackRoute as keyof typeof PageRoutes
+                          ]
+                        : undefined
+                    }
+                    enableSmartBack={enableSmartBack}
                   />
                 )}
 

--- a/src/hooks/useSmartBack.test.ts
+++ b/src/hooks/useSmartBack.test.ts
@@ -1,0 +1,582 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '../__tests__/renderers';
+import { useSmartBack } from './useSmartBack';
+import * as historyNavigation from '../utils/historyNavigation';
+
+// Mock delle utility di navigazione
+vi.mock('../utils/historyNavigation', () => ({
+  isPageToSkip: vi.fn(),
+  getCurrentHistoryState: vi.fn(),
+  hasValidHistory: vi.fn()
+}));
+
+// Mock di React Router
+const mockNavigate = vi.fn();
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate
+  };
+});
+
+describe('useSmartBack', () => {
+  const mockIsPageToSkip = vi.mocked(historyNavigation.isPageToSkip);
+  const mockGetCurrentHistoryState = vi.mocked(
+    historyNavigation.getCurrentHistoryState
+  );
+  const mockHasValidHistory = vi.mocked(historyNavigation.hasValidHistory);
+
+  // Mock window.history
+  const originalHistory = window.history;
+  const mockHistoryGo = vi.fn();
+  const mockAddEventListener = vi.fn();
+  const mockRemoveEventListener = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Mock window.history
+    Object.defineProperty(window, 'history', {
+      value: {
+        go: mockHistoryGo,
+        length: 5,
+        state: { usr: null }
+      },
+      writable: true,
+      configurable: true
+    });
+
+    // Mock window.location
+    Object.defineProperty(window, 'location', {
+      value: {
+        pathname: '/test-page',
+        search: '',
+        hash: ''
+      },
+      writable: true,
+      configurable: true
+    });
+
+    // Mock addEventListener e removeEventListener
+    vi.spyOn(window, 'addEventListener').mockImplementation(
+      mockAddEventListener
+    );
+    vi.spyOn(window, 'removeEventListener').mockImplementation(
+      mockRemoveEventListener
+    );
+
+    // Default mock values
+    mockHasValidHistory.mockReturnValue(true);
+    mockGetCurrentHistoryState.mockReturnValue(null);
+    mockIsPageToSkip.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(window, 'history', {
+      value: originalHistory,
+      writable: true,
+      configurable: true
+    });
+  });
+
+  describe('Initialization and configuration', () => {
+    it('returns handleSmartBack function', () => {
+      const { result } = renderHook(() => useSmartBack());
+
+      expect(result.current.handleSmartBack).toBeDefined();
+      expect(typeof result.current.handleSmartBack).toBe('function');
+    });
+
+    it('uses default maxIterations of 10', () => {
+      mockIsPageToSkip.mockReturnValue(true);
+      mockGetCurrentHistoryState.mockReturnValue({ fromSuccess: true });
+
+      const { result } = renderHook(() =>
+        useSmartBack({ fallbackRoute: '/test-fallback' })
+      );
+
+      act(() => {
+        result.current.handleSmartBack();
+      });
+
+      const popstateCall = mockAddEventListener.mock.calls.find(
+        (call) => call[0] === 'popstate'
+      );
+      expect(popstateCall).toBeDefined();
+
+      const popstateHandler = popstateCall?.[1] as () => void;
+
+      for (let i = 0; i < 10; i++) {
+        act(() => {
+          popstateHandler();
+        });
+      }
+
+      expect(mockNavigate).toHaveBeenCalledWith('/test-fallback', {
+        replace: true
+      });
+    });
+
+    it('accepts custom maxIterations', () => {
+      mockIsPageToSkip.mockReturnValue(true);
+      mockGetCurrentHistoryState.mockReturnValue({ fromSuccess: true });
+
+      const { result } = renderHook(() =>
+        useSmartBack({ maxIterations: 3, fallbackRoute: '/custom-fallback' })
+      );
+
+      act(() => {
+        result.current.handleSmartBack();
+      });
+
+      const popstateCall = mockAddEventListener.mock.calls.find(
+        (call) => call[0] === 'popstate'
+      );
+      expect(popstateCall).toBeDefined();
+
+      const popstateHandler = popstateCall?.[1] as () => void;
+
+      for (let i = 0; i < 3; i++) {
+        act(() => {
+          popstateHandler();
+        });
+      }
+
+      expect(mockNavigate).toHaveBeenCalledWith('/custom-fallback', {
+        replace: true
+      });
+    });
+  });
+
+  describe('Simple navigation (current page does not need skip)', () => {
+    it('executes navigate(-1) when current page does not need to be skipped', () => {
+      mockIsPageToSkip.mockReturnValue(false);
+      mockGetCurrentHistoryState.mockReturnValue(null);
+
+      const { result } = renderHook(() => useSmartBack());
+
+      act(() => {
+        result.current.handleSmartBack();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(-1);
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(mockAddEventListener).not.toHaveBeenCalledWith(
+        'popstate',
+        expect.any(Function)
+      );
+      expect(mockHistoryGo).not.toHaveBeenCalled();
+    });
+
+    it('calls onNavigationComplete after simple navigation', () => {
+      const onComplete = vi.fn();
+      mockIsPageToSkip.mockReturnValue(false);
+
+      const { result } = renderHook(() =>
+        useSmartBack({ onNavigationComplete: onComplete })
+      );
+
+      act(() => {
+        result.current.handleSmartBack();
+      });
+
+      expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Navigation to fallback route', () => {
+    it('navigates to fallback when history is not valid', () => {
+      mockHasValidHistory.mockReturnValue(false);
+
+      const { result } = renderHook(() =>
+        useSmartBack({ fallbackRoute: '/test-fallback' })
+      );
+
+      act(() => {
+        result.current.handleSmartBack();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith('/test-fallback', {
+        replace: true
+      });
+    });
+
+    it('does not navigate if fallbackRoute is not specified and history is invalid', () => {
+      mockHasValidHistory.mockReturnValue(false);
+
+      const { result } = renderHook(() => useSmartBack());
+
+      act(() => {
+        result.current.handleSmartBack();
+      });
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('calls onNavigationComplete after fallback', () => {
+      const onComplete = vi.fn();
+      mockHasValidHistory.mockReturnValue(false);
+
+      const { result } = renderHook(() =>
+        useSmartBack({
+          fallbackRoute: '/test-fallback',
+          onNavigationComplete: onComplete
+        })
+      );
+
+      act(() => {
+        result.current.handleSmartBack();
+      });
+
+      expect(onComplete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Smart Back with success pages', () => {
+    it('registers popstate listener when current page needs to be skipped', () => {
+      mockIsPageToSkip.mockReturnValue(true);
+      mockGetCurrentHistoryState.mockReturnValue({ fromSuccess: true });
+
+      const { result } = renderHook(() => useSmartBack());
+
+      act(() => {
+        result.current.handleSmartBack();
+      });
+
+      expect(mockAddEventListener).toHaveBeenCalledWith(
+        'popstate',
+        expect.any(Function)
+      );
+      expect(mockHistoryGo).toHaveBeenCalledWith(-1);
+    });
+
+    it('removes popstate listener when it finds a valid page', () => {
+      mockIsPageToSkip.mockReturnValueOnce(true);
+      mockGetCurrentHistoryState.mockReturnValue({ fromSuccess: true });
+
+      const { result } = renderHook(() => useSmartBack());
+
+      act(() => {
+        result.current.handleSmartBack();
+      });
+
+      mockIsPageToSkip.mockReturnValue(false);
+
+      const popstateHandler = mockAddEventListener.mock.calls.find(
+        (call) => call[0] === 'popstate'
+      )?.[1] as () => void;
+
+      if (popstateHandler) {
+        act(() => {
+          popstateHandler();
+        });
+      }
+
+      expect(mockRemoveEventListener).toHaveBeenCalledWith(
+        'popstate',
+        expect.any(Function)
+      );
+    });
+
+    it('continues skipping until it finds a valid page', () => {
+      mockIsPageToSkip.mockReturnValueOnce(true);
+      mockGetCurrentHistoryState.mockReturnValue({ fromSuccess: true });
+
+      const { result } = renderHook(() => useSmartBack());
+
+      act(() => {
+        result.current.handleSmartBack();
+      });
+
+      mockIsPageToSkip.mockReturnValueOnce(true);
+
+      let popstateHandler = mockAddEventListener.mock.calls.find(
+        (call) => call[0] === 'popstate'
+      )?.[1] as () => void;
+
+      act(() => {
+        popstateHandler();
+      });
+
+      expect(mockHistoryGo).toHaveBeenCalledTimes(2);
+
+      mockIsPageToSkip.mockReturnValue(false);
+
+      popstateHandler = mockAddEventListener.mock.calls.find(
+        (call) => call[0] === 'popstate'
+      )?.[1] as () => void;
+
+      act(() => {
+        popstateHandler();
+      });
+
+      expect(mockRemoveEventListener).toHaveBeenCalled();
+    });
+  });
+
+  describe('Initial state handling (iteration 1)', () => {
+    it('uses initialState when URL is equal to initial page', () => {
+      const initialState = { fromSuccess: true };
+      mockGetCurrentHistoryState.mockReturnValue(initialState);
+      mockIsPageToSkip.mockReturnValueOnce(true);
+
+      Object.defineProperty(window, 'location', {
+        value: {
+          pathname: '/test-page',
+          search: '',
+          hash: ''
+        },
+        writable: true,
+        configurable: true
+      });
+
+      const { result } = renderHook(() => useSmartBack());
+
+      act(() => {
+        result.current.handleSmartBack();
+      });
+
+      mockIsPageToSkip.mockReturnValue(true);
+
+      const popstateHandler = mockAddEventListener.mock.calls.find(
+        (call) => call[0] === 'popstate'
+      )?.[1] as () => void;
+
+      if (popstateHandler) {
+        act(() => {
+          popstateHandler();
+        });
+      }
+
+      expect(mockIsPageToSkip).toHaveBeenCalled();
+    });
+  });
+
+  describe('Wizard and form pages handling', () => {
+    it('marks hasSkippedWizardOrForm when skipping a wizard', () => {
+      mockIsPageToSkip.mockReturnValueOnce(true);
+      mockGetCurrentHistoryState.mockReturnValue({ fromSuccess: true });
+
+      Object.defineProperty(window, 'location', {
+        value: {
+          pathname: '/assessment/create',
+          search: '?mode=add',
+          hash: ''
+        },
+        writable: true,
+        configurable: true
+      });
+
+      const { result } = renderHook(() => useSmartBack());
+
+      act(() => {
+        result.current.handleSmartBack();
+      });
+
+      mockIsPageToSkip.mockReturnValue(true);
+
+      const popstateHandler = mockAddEventListener.mock.calls.find(
+        (call) => call[0] === 'popstate'
+      )?.[1] as () => void;
+
+      if (popstateHandler) {
+        act(() => {
+          popstateHandler();
+        });
+      }
+
+      expect(mockHistoryGo).toHaveBeenCalled();
+    });
+  });
+
+  describe('Cleanup and memory leaks', () => {
+    it('removes listener when component unmounts', () => {
+      mockIsPageToSkip.mockReturnValue(true);
+      mockGetCurrentHistoryState.mockReturnValue({ fromSuccess: true });
+
+      const { result, unmount } = renderHook(() => useSmartBack());
+
+      act(() => {
+        result.current.handleSmartBack();
+      });
+
+      expect(mockAddEventListener).toHaveBeenCalled();
+
+      unmount();
+
+      expect(mockAddEventListener).toHaveBeenCalledWith(
+        'popstate',
+        expect.any(Function)
+      );
+    });
+  });
+
+  describe('Safety cap to avoid infinite loops', () => {
+    it('uses fallback after maxIterations', () => {
+      mockIsPageToSkip.mockReturnValue(true);
+      mockGetCurrentHistoryState.mockReturnValue({ fromSuccess: true });
+
+      const { result } = renderHook(() =>
+        useSmartBack({
+          fallbackRoute: '/safety-fallback',
+          maxIterations: 2
+        })
+      );
+
+      act(() => {
+        result.current.handleSmartBack();
+      });
+
+      for (let i = 0; i < 2; i++) {
+        const popstateHandler = mockAddEventListener.mock.calls.find(
+          (call) => call[0] === 'popstate'
+        )?.[1] as () => void;
+
+        if (popstateHandler) {
+          act(() => {
+            popstateHandler();
+          });
+        }
+      }
+
+      expect(mockNavigate).toHaveBeenCalledWith('/safety-fallback', {
+        replace: true
+      });
+    });
+
+    it('resets counter between different calls', () => {
+      mockIsPageToSkip.mockReturnValueOnce(true);
+      mockGetCurrentHistoryState.mockReturnValue({ fromSuccess: true });
+
+      const { result } = renderHook(() => useSmartBack({ maxIterations: 2 }));
+
+      act(() => {
+        result.current.handleSmartBack();
+      });
+
+      mockIsPageToSkip.mockReturnValue(false);
+      const popstateHandler1 = mockAddEventListener.mock.calls.find(
+        (call) => call[0] === 'popstate'
+      )?.[1] as () => void;
+
+      if (popstateHandler1) {
+        act(() => {
+          popstateHandler1();
+        });
+      }
+
+      mockIsPageToSkip.mockReturnValueOnce(true);
+
+      act(() => {
+        result.current.handleSmartBack();
+      });
+
+      expect(mockHistoryGo).toHaveBeenCalled();
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('handles URLs with query params and hash', () => {
+      Object.defineProperty(window, 'location', {
+        value: {
+          pathname: '/test-page',
+          search: '?param=value',
+          hash: '#section'
+        },
+        writable: true,
+        configurable: true
+      });
+
+      mockIsPageToSkip.mockReturnValue(false);
+
+      const { result } = renderHook(() => useSmartBack());
+
+      act(() => {
+        result.current.handleSmartBack();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(-1);
+    });
+
+    it('handles multiple simultaneous calls', () => {
+      mockIsPageToSkip.mockReturnValue(true);
+      mockGetCurrentHistoryState.mockReturnValue({ fromSuccess: true });
+
+      const { result } = renderHook(() => useSmartBack());
+
+      act(() => {
+        result.current.handleSmartBack();
+        result.current.handleSmartBack();
+      });
+
+      expect(mockAddEventListener).toHaveBeenCalled();
+    });
+
+    it('handles currentState null or undefined', () => {
+      mockIsPageToSkip.mockReturnValue(false);
+      mockGetCurrentHistoryState.mockReturnValue(null);
+
+      const { result } = renderHook(() => useSmartBack());
+
+      act(() => {
+        result.current.handleSmartBack();
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(-1);
+    });
+  });
+
+  describe('Integration with isPageToSkip', () => {
+    it('passes correct URL and state to isPageToSkip', () => {
+      const testState = { fromSuccess: true };
+      mockGetCurrentHistoryState.mockReturnValue(testState);
+      mockIsPageToSkip.mockReturnValue(true);
+
+      Object.defineProperty(window, 'location', {
+        value: {
+          pathname: '/client-sil/123',
+          search: '',
+          hash: ''
+        },
+        writable: true,
+        configurable: true
+      });
+
+      const { result } = renderHook(() => useSmartBack());
+
+      act(() => {
+        result.current.handleSmartBack();
+      });
+
+      expect(mockIsPageToSkip).toHaveBeenCalledWith(
+        testState,
+        '/client-sil/123'
+      );
+    });
+
+    it('handles URLs without search params', () => {
+      mockGetCurrentHistoryState.mockReturnValue(null);
+      mockIsPageToSkip.mockReturnValue(false);
+
+      Object.defineProperty(window, 'location', {
+        value: {
+          pathname: '/simple-path',
+          search: '',
+          hash: ''
+        },
+        writable: true,
+        configurable: true
+      });
+
+      const { result } = renderHook(() => useSmartBack());
+
+      act(() => {
+        result.current.handleSmartBack();
+      });
+
+      expect(mockIsPageToSkip).toHaveBeenCalledWith(null, '/simple-path');
+    });
+  });
+});

--- a/src/hooks/useSmartBack.ts
+++ b/src/hooks/useSmartBack.ts
@@ -1,0 +1,287 @@
+import { useCallback, useRef } from 'react';
+import { useNavigate } from 'react-router';
+import {
+  isPageToSkip,
+  getCurrentHistoryState,
+  hasValidHistory
+} from '../utils/historyNavigation';
+
+/**
+ * Checks whether a URL represents a detail page.
+ * Analyzes the last path segment to identify numeric or alphanumeric IDs.
+ *
+ * Recognized patterns:
+ * - `/org-sil-services/35` → numeric ID (detail)
+ * - `/client-sil/IPA_TEST_123` → uppercase alphanumeric ID (detail)
+ * - `/assessment/detail/3261` → presence of "detail" in the path (detail)
+ *
+ * Excluded patterns:
+ * - `/org-sil-services/` → no ID (list)
+ * - `/org-sil-services/create` → keyword "create" (form)
+ * - `/org-sil-services/35/edit` → keyword "edit" (form)
+ *
+ * @param url - Full URL or pathname to analyze
+ * @returns true if it is a detail page
+ */
+const isDetailPageUrl = (url: string): boolean => {
+  if (!url) return false;
+
+  // Remove query params and hash
+  const pathname = url.split('?')[0].split('#')[0];
+
+  // Explicitly exclude form/wizard pages
+  const excludedKeywords = ['/edit', '/create', '/new'];
+  if (excludedKeywords.some((keyword) => pathname.includes(keyword))) {
+    return false;
+  }
+
+  // If path contains "detail", it is definitely a detail page
+  if (pathname.includes('/detail/')) {
+    return true;
+  }
+
+  // Get the last path segment
+  const segments = pathname.split('/').filter(Boolean);
+  const lastSegment = segments[segments.length - 1];
+
+  if (!lastSegment) return false;
+
+  // Check if it is a numeric ID (digits only)
+  const isNumericId = /^\d+$/.test(lastSegment);
+
+  // Check if it is an uppercase alphanumeric ID (e.g., IPA_TEST_123)
+  const isAlphanumericId = /^[A-Z0-9_]+$/.test(lastSegment);
+
+  return isNumericId || isAlphanumericId;
+};
+
+/**
+ * Configuration options for the useSmartBack hook
+ */
+type UseSmartBackOptions = {
+  /**
+   * Fallback route (full path) used when the history
+   * does not contain valid pages or the safety cap is reached.
+   *
+   * @example '/piattaformaunitaria/backoffice/client-sil'
+   */
+  fallbackRoute?: string;
+
+  /**
+   * Maximum number of back iterations in the history to avoid infinite loops.
+   * Default: 10 (sufficient for complex flows with multiple wizards)
+   */
+  maxIterations?: number;
+
+  /**
+   * Callback invoked when the back navigation is completed
+   * (either successfully or via fallback)
+   */
+  onNavigationComplete?: () => void;
+};
+
+/**
+ * Return value of the useSmartBack hook
+ */
+type UseSmartBackReturn = {
+  /**
+   * Function that performs smart back navigation
+   * automatically skipping consecutive success pages
+   */
+  handleSmartBack: () => void;
+};
+
+/**
+ * Hook to handle smart "back" navigation that automatically skips
+ * consecutive intermediate pages present in history.
+ *
+ * Smart Back v2 - Recognizes and skips:
+ * - Success pages (fromSuccess, category containing "success")
+ * - Form pages (create, edit, new)
+ * - Wizard pages (mode=add, mode=remove, mode=edit)
+ *
+ * This hook implements logic that:
+ * 1. Detects if the current page should be skipped (via state + URL analysis)
+ * 2. Executes navigate(-1) and listens to the popstate event
+ * 3. If the reached page should still be skipped, continues going back
+ * 4. Stops when it finds a valid page or reaches the safety cap
+ * 5. Navigates to fallbackRoute if configured and the history is not valid
+ *
+ * @param options - Optional hook configuration
+ * @returns Object containing handleSmartBack function
+ *
+ * @example
+ * ```typescript
+ * // In a component that renders a back button
+ * const { handleSmartBack } = useSmartBack({
+ *   fallbackRoute: '/client-sil',
+ *   maxIterations: 5,
+ *   onNavigationComplete: () => console.log('Back completed')
+ * });
+ *
+ * return (
+ *   <Button onClick={handleSmartBack}>
+ *     Back
+ *   </Button>
+ * );
+ * ```
+ */
+export const useSmartBack = (
+  options: UseSmartBackOptions = {}
+): UseSmartBackReturn => {
+  const navigate = useNavigate();
+
+  // Refs to track internal state without causing re-renders
+  const iterationCountRef = useRef(0);
+  const hasSkippedWizardOrFormRef = useRef(false);
+  const popstateHandlerRef = useRef<((event: PopStateEvent) => void) | null>(
+    null
+  );
+
+  const { fallbackRoute, maxIterations = 10, onNavigationComplete } = options;
+
+  /**
+   * Cleans up listeners and resets internal state
+   */
+  const cleanup = useCallback(() => {
+    if (popstateHandlerRef.current) {
+      window.removeEventListener('popstate', popstateHandlerRef.current);
+      popstateHandlerRef.current = null;
+    }
+    iterationCountRef.current = 0;
+    hasSkippedWizardOrFormRef.current = false;
+  }, []);
+
+  /**
+   * Navigates to the fallback route if configured
+   */
+  const navigateToFallback = useCallback(() => {
+    cleanup();
+    if (fallbackRoute) {
+      navigate(fallbackRoute, { replace: true });
+    }
+    onNavigationComplete?.();
+  }, [fallbackRoute, navigate, cleanup, onNavigationComplete]);
+
+  /**
+   * Executes smart back navigation
+   */
+  const handleSmartBack = useCallback(() => {
+    // Guard: no available history, go to fallback
+    if (!hasValidHistory()) {
+      navigateToFallback();
+      return;
+    }
+
+    // Check whether current page should be skipped
+    const currentState = getCurrentHistoryState();
+    const currentUrl = window.location.pathname + window.location.search;
+    const shouldSkipCurrent = isPageToSkip(currentState, currentUrl);
+
+    // Simple case: current page does not require skip, perform normal back
+    if (!shouldSkipCurrent) {
+      navigate(-1);
+      onNavigationComplete?.();
+      return;
+    }
+
+    // Complex case: current page must be skipped, start skip chain
+    iterationCountRef.current = 0;
+    hasSkippedWizardOrFormRef.current = false;
+
+    // Save URL and state of the current page (before go(-1))
+    const initialUrl = currentUrl;
+    const initialState = currentState;
+
+    /**
+     * Popstate handler that checks each reached page
+     * during back navigation and decides whether to continue or stop
+     */
+    const handlePopstate = () => {
+      iterationCountRef.current++;
+
+      // Safety cap reached: too many consecutive backs, go to fallback
+      if (iterationCountRef.current >= maxIterations) {
+        navigateToFallback();
+        return;
+      }
+
+      // Get URL and state of the just reached page
+      const newUrl = window.location.pathname + window.location.search;
+      const newState = getCurrentHistoryState();
+
+      // On iteration 1, we might still be on the initial page
+      // (state changes before the actual navigation)
+      // Use the initial state if the URL is still the same
+      const isStillOnInitialPage =
+        iterationCountRef.current === 1 && newUrl === initialUrl;
+      const stateToCheck = isStillOnInitialPage ? initialState : newState;
+      const shouldSkipThis = isPageToSkip(stateToCheck, newUrl);
+
+      // Check whether this page is a wizard/form
+      const isWizardOrForm =
+        newUrl.includes('/create') ||
+        newUrl.includes('/edit') ||
+        newUrl.includes('/new') ||
+        newUrl.includes('mode=add') ||
+        newUrl.includes('mode=remove') ||
+        newUrl.includes('mode=edit');
+
+      if (isWizardOrForm && shouldSkipThis) {
+        hasSkippedWizardOrFormRef.current = true;
+      }
+
+      if (shouldSkipThis) {
+        // Page still needs to be skipped, continue traversing history
+        window.history.go(-1);
+      } else if (hasSkippedWizardOrFormRef.current) {
+        // If at least one wizard/form was skipped
+        // and we are now on a "valid" page (not to be skipped),
+        // keep going back until reaching the list
+
+        // Check if we are on a Detail page
+        const isDetailPage = isDetailPageUrl(newUrl);
+
+        if (isDetailPage) {
+          // Still on a detail → continue
+          window.history.go(-1);
+        } else {
+          // Not a detail → we reached the list
+          hasSkippedWizardOrFormRef.current = false;
+          cleanup();
+          onNavigationComplete?.();
+        }
+      } else {
+        // Valid page reached (not to be skipped, no previous wizard)
+        // BUT verify if it is still a Detail after multiple edits
+        const isDetailPage = isDetailPageUrl(newUrl);
+
+        if (isDetailPage && iterationCountRef.current > 1) {
+          // Still on a detail after skipping → continue (multiple edits)
+          window.history.go(-1);
+        } else {
+          // Valid page reached
+          cleanup();
+          onNavigationComplete?.();
+        }
+      }
+    };
+
+    // Register the popstate event listener
+    popstateHandlerRef.current = handlePopstate;
+    window.addEventListener('popstate', handlePopstate);
+
+    // Perform the first step back in history
+    window.history.go(-1);
+  }, [
+    navigate,
+    navigateToFallback,
+    cleanup,
+    maxIterations,
+    onNavigationComplete
+  ]);
+
+  return {
+    handleSmartBack
+  };
+};

--- a/src/hooks/useSmartBack.ts
+++ b/src/hooks/useSmartBack.ts
@@ -55,9 +55,8 @@ const isDetailPageUrl = (url: string): boolean => {
   return isNumericId || isAlphanumericId;
 };
 
-/**
- * Configuration options for the useSmartBack hook
- */
+// Configuration options for the useSmartBack hook
+
 type UseSmartBackOptions = {
   /**
    * Fallback route (full path) used when the history
@@ -67,27 +66,20 @@ type UseSmartBackOptions = {
    */
   fallbackRoute?: string;
 
-  /**
-   * Maximum number of back iterations in the history to avoid infinite loops.
-   * Default: 10 (sufficient for complex flows with multiple wizards)
-   */
+  // Maximum number of back iterations in the history to avoid infinite loops.
+  // Default: 10 (sufficient for complex flows with multiple wizards)
+
   maxIterations?: number;
 
-  /**
-   * Callback invoked when the back navigation is completed
-   * (either successfully or via fallback)
-   */
+  // Callback invoked when the back navigation is completed
+  // (either successfully or via fallback)
   onNavigationComplete?: () => void;
 };
 
-/**
- * Return value of the useSmartBack hook
- */
+// Return value of the useSmartBack hook
 type UseSmartBackReturn = {
-  /**
-   * Function that performs smart back navigation
-   * automatically skipping consecutive success pages
-   */
+  // Function that performs smart back navigation
+  // automatically skipping consecutive success pages
   handleSmartBack: () => void;
 };
 
@@ -140,9 +132,7 @@ export const useSmartBack = (
 
   const { fallbackRoute, maxIterations = 10, onNavigationComplete } = options;
 
-  /**
-   * Cleans up listeners and resets internal state
-   */
+  // Cleans up listeners and resets internal state
   const cleanup = useCallback(() => {
     if (popstateHandlerRef.current) {
       window.removeEventListener('popstate', popstateHandlerRef.current);
@@ -152,9 +142,7 @@ export const useSmartBack = (
     hasSkippedWizardOrFormRef.current = false;
   }, []);
 
-  /**
-   * Navigates to the fallback route if configured
-   */
+  // Navigates to the fallback route if configured
   const navigateToFallback = useCallback(() => {
     cleanup();
     if (fallbackRoute) {
@@ -163,9 +151,7 @@ export const useSmartBack = (
     onNavigationComplete?.();
   }, [fallbackRoute, navigate, cleanup, onNavigationComplete]);
 
-  /**
-   * Executes smart back navigation
-   */
+  // Executes smart back navigation
   const handleSmartBack = useCallback(() => {
     // Guard: no available history, go to fallback
     if (!hasValidHistory()) {
@@ -193,10 +179,8 @@ export const useSmartBack = (
     const initialUrl = currentUrl;
     const initialState = currentState;
 
-    /**
-     * Popstate handler that checks each reached page
-     * during back navigation and decides whether to continue or stop
-     */
+    // Popstate handler that checks each reached page
+    // during back navigation and decides whether to continue or stop
     const handlePopstate = () => {
       iterationCountRef.current++;
 

--- a/src/models/Routes.ts
+++ b/src/models/Routes.ts
@@ -2,6 +2,42 @@ export type RouteHandleObject = {
   backButton?: boolean;
   backButtonText?: string;
   backButtonFunction?: () => void;
+  /**
+   * Fallback route ID for "smart back" navigation.
+   * When specified, it is used as destination if the history
+   * does not contain valid pages (e.g. only success pages).
+   *
+   * **When to use:**
+   * - Detail pages with Create/Edit → Success → Detail flows
+   * - When you want to ensure safe back navigation even without valid history
+   *
+   * **Usage examples:**
+   * - `CLIENT_SIL_DETAIL` → `backFallbackRoute: 'CLIENT_SIL_INDEX'`
+   * - `ASSESSMENT_DETAIL` → `backFallbackRoute: 'ASSESSMENT_INDEX'`
+   * - `ORG_SIL_SERVICE_DETAIL` → `backFallbackRoute: 'ORG_SIL_SERVICE_INDEX'`
+   *
+   * ```
+   */
+  backFallbackRoute?: string;
+  /**
+   * Enables "smart back" navigation that automatically skips
+   * intermediate pages (success, wizard, form) in history.
+   *
+   * **Default:** `true` (enabled by default)
+   *
+   * **When to disable (enableSmartBack: false):**
+   * - Pages with custom navigation logic
+   * - Flows that do not have intermediate pages to skip
+   * - Compatibility with legacy behavior
+   *
+   * **Smart Back recognizes and skips:**
+   * - Success pages (state.fromSuccess, state.category containing "success")
+   * - Form pages (URL with /create, /edit, /new)
+   * - Wizard pages (URL with mode=add, mode=remove, mode=edit)
+   *
+   * @default true
+   */
+  enableSmartBack?: boolean;
   hideBreadcrumbs?: boolean;
   /** this property is used in Breadcrumbs Component.
    * When it's true the breadcumb element is hidden by the breadcumbs path */

--- a/src/models/SuccessPageConfig.ts
+++ b/src/models/SuccessPageConfig.ts
@@ -16,8 +16,8 @@ export const SuccessPageConfig: SuccessOpts = {
       {
         variant: 'contained',
         size: 'large',
-        buttonLabel: 'AssessmentRegistryUpdate.success.backToStart',
-        actionID: 'ASSESSMENT_REGISTRY_SEARCH_RESULTS'
+        buttonLabel: 'AssessmentRegistryUpdate.success.goToDetail',
+        customNavigation: 'ASSESSMENT_REGISTRY_DETAIL'
       }
     ]
   },
@@ -28,8 +28,8 @@ export const SuccessPageConfig: SuccessOpts = {
       {
         variant: 'contained',
         size: 'large',
-        buttonLabel: 'AssessmentRegistryCreate.success.backToStart',
-        actionID: 'ASSESSMENT_REGISTRY_SEARCH_RESULTS'
+        buttonLabel: 'AssessmentRegistryCreate.success.goToDetail',
+        customNavigation: 'ASSESSMENT_REGISTRY_DETAIL'
       }
     ]
   },

--- a/src/routes/AssessmentRegistryCreate/AssessmentRegistryEdit.test.tsx
+++ b/src/routes/AssessmentRegistryCreate/AssessmentRegistryEdit.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen, fireEvent, waitFor } from '../../__tests__/renderers';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AssessmentRegistryEdit } from './AssessmentRegistryEdit';
+
+const {
+  mockMutateAsync,
+  mockGetAssessmentsRegistry,
+  mockUpdateAssessmentsRegistry
+} = vi.hoisted(() => ({
+  mockMutateAsync: vi.fn(),
+  mockGetAssessmentsRegistry: vi.fn(),
+  mockUpdateAssessmentsRegistry: vi.fn()
+}));
+
+vi.mock('../../api/assessments', () => ({
+  getAssessmentsRegistry: (...args: Array<unknown>) =>
+    mockGetAssessmentsRegistry(...args),
+  updateAssessmentsRegistry: (...args: Array<unknown>) =>
+    mockUpdateAssessmentsRegistry(...args)
+}));
+
+const { mockNavigate } = vi.hoisted(() => ({ mockNavigate: vi.fn() }));
+
+vi.mock('react-router', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router')>('react-router');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => ({ assessmentRegistryId: '42' })
+  };
+});
+
+vi.mock('../../routes', () => ({
+  PageRoutes: {
+    RESPONSES_SUCCESS: '/success',
+    RESPONSES_ERROR: '/error'
+  }
+}));
+
+vi.mock('../../store/GlobalStore', () => ({
+  useStore: () => ({
+    state: { organizationId: '123' }
+  }),
+  StoreProvider: ({ children }: { children: React.ReactNode }) => children
+}));
+
+vi.mock('../../components/Wizard/WizardStepButtons', () => ({
+  default: ({
+    onBack,
+    onNext,
+    nextLabel,
+    backLabel
+  }: {
+    onBack: () => void;
+    onNext: () => void;
+    nextLabel: string;
+    backLabel: string;
+  }) => (
+    <div data-testid="wizard-step-buttons">
+      <button data-testid="back-button" onClick={onBack}>
+        {backLabel}
+      </button>
+      <button data-testid="next-button" onClick={onNext}>
+        {nextLabel}
+      </button>
+    </div>
+  )
+}));
+
+describe('AssessmentRegistryEdit', () => {
+  const existingRegistry = {
+    assessmentRegistryId: 42,
+    debtPositionTypeOrgCode: 'TYPE1',
+    status: 'ACTIVE',
+    operatingYear: '2024',
+    sectionCode: 'SC01',
+    sectionDescription: 'Capitolo A',
+    officeCode: 'OFF01',
+    officeDescription: 'Ufficio 1',
+    assessmentCode: 'AC01',
+    assessmentDescription: 'Accertamento 1'
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAssessmentsRegistry.mockReturnValue({ data: existingRegistry });
+    mockUpdateAssessmentsRegistry.mockReturnValue({
+      mutateAsync: mockMutateAsync
+    });
+  });
+
+  const renderComponent = () => render(<AssessmentRegistryEdit />);
+
+  it('renders the form', () => {
+    renderComponent();
+    expect(screen.getByRole('form')).toBeInTheDocument();
+  });
+
+  it('submits and navigates to success with correct state', async () => {
+    mockMutateAsync.mockResolvedValueOnce({});
+
+    renderComponent();
+
+    const nextBtn = await screen.findByTestId('next-button');
+    fireEvent.click(nextBtn);
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organizationId: '123',
+          assessmentRegistryId: 42,
+          debtPositionTypeOrgCode: 'TYPE1',
+          operatingYear: '2024'
+        })
+      );
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('/success', {
+      replace: true,
+      state: {
+        category: 'assessment-registry-update',
+        assessmentRegistryId: 42,
+        i18nParams: { paymentObject: 'Capitolo A' }
+      }
+    });
+  });
+
+  it('navigates to error on submit failure', async () => {
+    mockMutateAsync.mockRejectedValueOnce(new Error('update failed'));
+
+    renderComponent();
+
+    const nextBtn = await screen.findByTestId('next-button');
+    fireEvent.click(nextBtn);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/error');
+    });
+  });
+});

--- a/src/routes/AssessmentRegistryCreate/AssessmentRegistryEdit.tsx
+++ b/src/routes/AssessmentRegistryCreate/AssessmentRegistryEdit.tsx
@@ -84,6 +84,7 @@ export const AssessmentRegistryEdit = () => {
         replace: true,
         state: {
           category: 'assessment-registry-update',
+          assessmentRegistryId: Number(assessmentRegistryId),
           i18nParams: {
             paymentObject: request.sectionDescription
           }

--- a/src/routes/AssessmentRegistryCreate/index.test.tsx
+++ b/src/routes/AssessmentRegistryCreate/index.test.tsx
@@ -1,0 +1,162 @@
+import { render, screen, fireEvent, waitFor } from '../../__tests__/renderers';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AssessmentRegistryCreate } from './index';
+
+const { mockMutateAsync, mockCreateAssessmentsRegistry } = vi.hoisted(() => ({
+  mockMutateAsync: vi.fn(),
+  mockCreateAssessmentsRegistry: vi.fn()
+}));
+
+vi.mock('../../api/assessments', () => ({
+  createAssessmentsRegistry: (...args: Array<unknown>) =>
+    mockCreateAssessmentsRegistry(...args)
+}));
+
+const { mockNavigate } = vi.hoisted(() => ({ mockNavigate: vi.fn() }));
+
+vi.mock('react-router', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-router')>('react-router');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate
+  };
+});
+
+vi.mock('../../routes', () => ({
+  PageRoutes: {
+    RESPONSES_SUCCESS: '/success',
+    RESPONSES_ERROR: '/error'
+  }
+}));
+
+vi.mock('../../store/GlobalStore', () => ({
+  useStore: () => ({
+    state: { organizationId: '123' }
+  }),
+  StoreProvider: ({ children }: { children: React.ReactNode }) => children
+}));
+
+vi.mock('../../components/Wizard/WizardStepButtons', () => ({
+  default: ({
+    onBack,
+    onNext,
+    nextLabel,
+    backLabel
+  }: {
+    onBack: () => void;
+    onNext: () => void;
+    nextLabel: string;
+    backLabel: string;
+  }) => (
+    <div data-testid="wizard-step-buttons">
+      <button data-testid="back-button" onClick={onBack}>
+        {backLabel}
+      </button>
+      <button data-testid="next-button" onClick={onNext}>
+        {nextLabel}
+      </button>
+    </div>
+  )
+}));
+
+const fakeData = {
+  debtPositionType: 'TYPE1',
+  status: 'ACTIVE',
+  operatingYear: { from: new Date(2024, 0, 1), to: null },
+  sectionCode: 'SC01',
+  sectionDescription: 'Capitolo A',
+  officeCode: 'OFF01',
+  officeDescription: 'Ufficio 1',
+  assessmentCode: 'AC01',
+  assessmentDescription: 'Accertamento 1'
+};
+
+vi.mock('react-hook-form', async () => {
+  const actual =
+    await vi.importActual<typeof import('react-hook-form')>('react-hook-form');
+  return {
+    ...actual,
+    useForm: () => ({
+      handleSubmit: (fn: (data: unknown) => void) => () => fn(fakeData),
+      register: vi.fn(),
+      control: {},
+      formState: { errors: {} }
+    }),
+    useFormContext: () => ({
+      control: {},
+      register: vi.fn(),
+      setValue: vi.fn(),
+      watch: vi.fn(),
+      formState: { errors: {} }
+    }),
+    FormProvider: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    )
+  };
+});
+
+vi.mock('./steps/Step1Configuration', () => ({
+  Step1Configuration: () => <div data-testid="step1" />
+}));
+
+describe('AssessmentRegistryCreate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateAssessmentsRegistry.mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false
+    });
+  });
+
+  const renderComponent = () => render(<AssessmentRegistryCreate />);
+
+  it('renders the form', () => {
+    renderComponent();
+    expect(screen.getByRole('form')).toBeInTheDocument();
+  });
+
+  it('submits and navigates to success with correct state', async () => {
+    mockMutateAsync.mockResolvedValueOnce({
+      assessmentRegistryId: 77,
+      sectionDescription: 'Capitolo A'
+    });
+
+    renderComponent();
+
+    const nextBtn = await screen.findByTestId('next-button');
+    fireEvent.click(nextBtn);
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organizationId: '123',
+          debtPositionTypeOrgCode: 'TYPE1',
+          operatingYear: '2024'
+        })
+      );
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('/success', {
+      replace: true,
+      state: {
+        category: 'assessment-registry-create',
+        assessmentRegistryId: 77,
+        i18nParams: { paymentObject: 'Capitolo A' }
+      }
+    });
+  });
+
+  it('navigates to error on submit failure', async () => {
+    mockMutateAsync.mockRejectedValueOnce(new Error('create failed'));
+
+    renderComponent();
+
+    const nextBtn = await screen.findByTestId('next-button');
+    fireEvent.click(nextBtn);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/error');
+    });
+  });
+});

--- a/src/routes/AssessmentRegistryCreate/index.tsx
+++ b/src/routes/AssessmentRegistryCreate/index.tsx
@@ -51,6 +51,7 @@ export const AssessmentRegistryCreate = () => {
         replace: true,
         state: {
           category: 'assessment-registry-create',
+          assessmentRegistryId: response.assessmentRegistryId,
           i18nParams: {
             paymentObject: response.sectionDescription
           }

--- a/src/routes/ClientSilDetail/index.tsx
+++ b/src/routes/ClientSilDetail/index.tsx
@@ -53,7 +53,6 @@ const ClientSilDetail = () => {
   }, [isError, error, navigate]);
 
   useEffect(() => {
-    console.log(data?.clientName);
     if (data && !clientItem) {
       setClientItem(data);
     }
@@ -85,9 +84,6 @@ const ClientSilDetail = () => {
     try {
       await deleteClientMutation.mutateAsync(clientId);
       utils.dialog.close();
-
-      console.log('clientName:', data?.clientName);
-
       navigate(PageRoutes.RESPONSES_SUCCESS, {
         replace: true,
         state: {

--- a/src/routes/Home/index.test.tsx
+++ b/src/routes/Home/index.test.tsx
@@ -11,13 +11,13 @@ vi.mock('../../utils', () => ({
       emit: vi.fn()
     },
     config: {
-      deployPath: '/test',
+      deployPath: '/test'
     }
   }
 }));
 vi.mock('react-router', async (importOriginal) => ({
   ...(await importOriginal()),
-  useNavigate: vi.fn(),
+  useNavigate: vi.fn()
 }));
 
 describe('Home page', () => {
@@ -29,15 +29,15 @@ describe('Home page', () => {
   };
 
   const user = {
-          userId: 'userId',
-          familyName: 'Polo',
-          name: 'Marco',
-          fiscalCode: 'XXXXXXX',
-          canManageUsers: false,
-          issuer: 'Issuer',
-          organizations: [],
-          mappedExternalUserId: 'mappedExternalUserId'
-        };
+    userId: 'userId',
+    familyName: 'Polo',
+    name: 'Marco',
+    fiscalCode: 'XXXXXXX',
+    canManageUsers: false,
+    issuer: 'Issuer',
+    organizations: [],
+    mappedExternalUserId: 'mappedExternalUserId'
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -63,7 +63,9 @@ describe('Home page', () => {
     mockSessionStorage.getItem.mockReturnValue(null);
     renderHome();
 
-    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(`${user.name} ${user.familyName}`);
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      `${user.name} ${user.familyName}`
+    );
   });
 
   it('handles pending notification when present in sessionStorage', () => {

--- a/src/routes/UtilityPages/success.tsx
+++ b/src/routes/UtilityPages/success.tsx
@@ -22,7 +22,7 @@ export const SuccessPage = () => {
     if (!pageConfig) {
       navigate(PageRoutes.HOME, { replace: true });
     }
-  }, [pageConfig]);
+  }, [pageConfig, navigate]);
 
   const buttonConfig = pageConfig?.buttonConfig?.map((btn) => {
     const handleClick = () => {
@@ -59,10 +59,18 @@ export const SuccessPage = () => {
           orgName,
           mappedExternalUserId
         });
-
+        navigate(detailPath, { replace: true, state: { fromSuccess: true } });
+      } else if (
+        btn.customNavigation === 'ASSESSMENT_REGISTRY_DETAIL' &&
+        location?.state?.assessmentRegistryId
+      ) {
+        const detailPath = generatePath(PageRoutes.ASSESSMENT_REGISTRY_DETAIL, {
+          assessmentRegistryId: location.state.assessmentRegistryId.toString()
+        });
         navigate(detailPath, { replace: true, state: { fromSuccess: true } });
       } else {
-        navigate(PageRoutes[btn.actionID || PageRoutes.HOME]);
+        const to = PageRoutes[btn.actionID || PageRoutes.HOME];
+        navigate(to);
       }
     };
 

--- a/src/routes/assessment.tsx
+++ b/src/routes/assessment.tsx
@@ -60,7 +60,8 @@ export const assessmentRoutes = [
         handle: {
           backButton: true,
           hideBreadcrumbs: false,
-          custom: true
+          custom: true,
+          backFallbackRoute: 'ASSESSMENT_INDEX'
         } as RouteHandleObject
       },
       {
@@ -96,6 +97,7 @@ export const assessmentRoutes = [
         handle: {
           backButton: true,
           backButtonText: 'commons.back',
+          backFallbackRoute: 'ASSESSMENT_REGISTRY_SEARCH_RESULTS',
           hideBreadcrumbs: true,
           sidebar: {
             visible: false

--- a/src/routes/backoffice.tsx
+++ b/src/routes/backoffice.tsx
@@ -135,6 +135,7 @@ export const backofficeRoutes = [
             handle: {
               backButton: true,
               hideBreadcrumbs: false,
+              backFallbackRoute: 'ORG_SIL_SERVICE_INDEX',
               sidebar: {
                 visible: false
               }
@@ -206,6 +207,7 @@ export const backofficeRoutes = [
             handle: {
               hideBreadcrumbs: true,
               backButton: true,
+              backFallbackRoute: 'CLIENT_SIL_INDEX',
               sidebar: {
                 visible: false
               }

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -3,8 +3,9 @@
     "accessibleTitle": "Creazione capitolo",
     "success": {
       "backToStart": "Visualizza capitoli",
+      "goToDetail": "Visualizza capitolo",
       "description": "Lo trovi nella sezione capitoli, dove puoi consultarlo in qualsiasi momento.",
-      "title": "Il Capitolo ‘{{paymentObject}}’ è stato creato!"
+      "title": "Il Capitolo '{{paymentObject}}' è stato creato!"
     },
     "title": "Crea un nuovo capitolo",
     "configuration": "Crea un nuovo capitolo",
@@ -38,8 +39,9 @@
     "accessibleTitle": "Modifica capitolo",
     "success": {
       "backToStart": "Visualizza capitoli",
+      "goToDetail": "Visualizza capitolo",
       "description": "Lo trovi nella sezione capitoli, dove puoi consultarlo in qualsiasi momento.",
-      "title": "Il Capitolo ‘{{paymentObject}}’ è stato aggiornato!"
+      "title": "Il Capitolo '{{paymentObject}}' è stato aggiornato!"
     },
     "title": "Modifica capitolo",
     "subtitle": "Gestisci i parametri del capitolo.",

--- a/src/utils/historyNavigation.test.ts
+++ b/src/utils/historyNavigation.test.ts
@@ -1,0 +1,532 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  isPageToSkip,
+  getCurrentHistoryState,
+  isFormOrWizardUrl,
+  hasValidHistory
+} from './historyNavigation';
+
+describe('historyNavigation', () => {
+  describe('isPageToSkip', () => {
+    describe('Success pages detection', () => {
+      it('returns true when state has fromSuccess flag', () => {
+        const state = { fromSuccess: true };
+        expect(isPageToSkip(state)).toBe(true);
+      });
+
+      it('returns true when category contains "success"', () => {
+        const state = { category: 'client-sil-delete-success' };
+        expect(isPageToSkip(state)).toBe(true);
+      });
+
+      it('returns true when category contains "success" anywhere', () => {
+        const state = { category: 'assessment-create-partial-success' };
+        expect(isPageToSkip(state)).toBe(true);
+      });
+
+      it('returns false when category does not contain "success"', () => {
+        const state = { category: 'some-other-category' };
+        expect(isPageToSkip(state)).toBe(false);
+      });
+    });
+
+    describe('Form/Wizard pages detection via state markers', () => {
+      it('returns true when state has fromWizard flag', () => {
+        const state = { fromWizard: true };
+        expect(isPageToSkip(state)).toBe(true);
+      });
+
+      it('returns true when state has fromForm flag', () => {
+        const state = { fromForm: true };
+        expect(isPageToSkip(state)).toBe(true);
+      });
+
+      it('returns false when fromWizard is false', () => {
+        const state = { fromWizard: false };
+        expect(isPageToSkip(state)).toBe(false);
+      });
+
+      it('returns false when fromForm is false', () => {
+        const state = { fromForm: false };
+        expect(isPageToSkip(state)).toBe(false);
+      });
+    });
+
+    describe('Form/Wizard pages detection via URL analysis', () => {
+      it('returns true for create URLs', () => {
+        expect(isPageToSkip({}, '/client-sil/create')).toBe(true);
+        expect(isPageToSkip({}, '/org-sil-services/create')).toBe(true);
+        expect(isPageToSkip({}, '/assessment/create')).toBe(true);
+      });
+
+      it('returns true for edit URLs', () => {
+        expect(isPageToSkip({}, '/client-sil/123/edit')).toBe(true);
+        expect(isPageToSkip({}, '/org-sil-services/35/edit')).toBe(true);
+        expect(isPageToSkip({}, '/organizations/123/edit')).toBe(true);
+      });
+
+      it('returns true for new URLs', () => {
+        expect(isPageToSkip({}, '/client-sil/new')).toBe(true);
+        expect(isPageToSkip({}, '/org-sil-services/new')).toBe(true);
+      });
+
+      it('returns true for wizard URLs with mode=add', () => {
+        expect(
+          isPageToSkip(
+            {},
+            '/assessment/create?mode=add&assessmentId=123&debtPositionTypeOrgCode=TEST'
+          )
+        ).toBe(true);
+      });
+
+      it('returns true for wizard URLs with mode=remove', () => {
+        expect(
+          isPageToSkip(
+            {},
+            '/assessment/create?mode=remove&assessmentId=456&debtPositionTypeOrgCode=TEST'
+          )
+        ).toBe(true);
+      });
+
+      it('returns true for wizard URLs with mode=edit', () => {
+        expect(
+          isPageToSkip({}, '/org-sil-services/create?mode=edit&id=789')
+        ).toBe(true);
+      });
+
+      it('returns false for list URLs', () => {
+        expect(isPageToSkip({}, '/client-sil')).toBe(false);
+        expect(isPageToSkip({}, '/org-sil-services')).toBe(false);
+        expect(isPageToSkip({}, '/assessment')).toBe(false);
+      });
+
+      it('returns false for detail URLs', () => {
+        expect(isPageToSkip({}, '/client-sil/123')).toBe(false);
+        expect(isPageToSkip({}, '/client-sil/IPA_TEST_123')).toBe(false);
+        expect(isPageToSkip({}, '/org-sil-services/35')).toBe(false);
+        expect(isPageToSkip({}, '/assessment/detail/3261')).toBe(false);
+      });
+    });
+
+    describe('Combined state and URL detection', () => {
+      it('prioritizes state markers over URL analysis', () => {
+        const state = { fromSuccess: true };
+        expect(isPageToSkip(state, '/client-sil')).toBe(true);
+      });
+
+      it('falls back to URL analysis when no state markers', () => {
+        expect(isPageToSkip({}, '/client-sil/create')).toBe(true);
+      });
+
+      it('works with both state and URL indicating skip', () => {
+        const state = { fromWizard: true };
+        expect(isPageToSkip(state, '/assessment/create?mode=add')).toBe(true);
+      });
+    });
+
+    describe('Edge cases', () => {
+      it('returns false when both state and URL are null/undefined', () => {
+        expect(isPageToSkip(null)).toBe(false);
+        expect(isPageToSkip(undefined)).toBe(false);
+        expect(isPageToSkip(null)).toBe(false);
+      });
+
+      it('returns false when state is not an object', () => {
+        expect(isPageToSkip('string')).toBe(false);
+        expect(isPageToSkip(123)).toBe(false);
+        expect(isPageToSkip(true)).toBe(false);
+      });
+
+      it('returns false when URL is not a string', () => {
+        expect(isPageToSkip({}, null as unknown as string)).toBe(false);
+        expect(isPageToSkip({}, 123 as unknown as string)).toBe(false);
+      });
+
+      it('handles empty state object', () => {
+        expect(isPageToSkip({})).toBe(false);
+      });
+
+      it('handles empty URL string', () => {
+        expect(isPageToSkip({}, '')).toBe(false);
+      });
+
+      it('handles URL with hash', () => {
+        expect(isPageToSkip({}, '/client-sil/create#section')).toBe(true);
+      });
+
+      it('handles URL with query params and hash', () => {
+        expect(isPageToSkip({}, '/assessment/create?mode=add#top')).toBe(true);
+      });
+
+      it('is case-insensitive for URL patterns', () => {
+        expect(isPageToSkip({}, '/CLIENT-SIL/CREATE')).toBe(true);
+        expect(isPageToSkip({}, '/org-sil-services/EDIT')).toBe(true);
+        expect(isPageToSkip({}, '/assessment/create?MODE=ADD')).toBe(true);
+      });
+    });
+  });
+
+  describe('getCurrentHistoryState', () => {
+    const originalHistory = window.history;
+
+    afterEach(() => {
+      Object.defineProperty(window, 'history', {
+        value: originalHistory,
+        writable: true,
+        configurable: true
+      });
+    });
+
+    it('returns state from window.history.state.usr', () => {
+      const mockState = { fromSuccess: true, category: 'test' };
+
+      Object.defineProperty(window, 'history', {
+        value: {
+          state: {
+            usr: mockState
+          }
+        },
+        writable: true,
+        configurable: true
+      });
+
+      expect(getCurrentHistoryState()).toEqual(mockState);
+    });
+
+    it('returns undefined when window.history.state is null', () => {
+      Object.defineProperty(window, 'history', {
+        value: {
+          state: null
+        },
+        writable: true,
+        configurable: true
+      });
+
+      expect(getCurrentHistoryState()).toBeUndefined();
+    });
+
+    it('returns undefined when window.history.state.usr is undefined', () => {
+      Object.defineProperty(window, 'history', {
+        value: {
+          state: {}
+        },
+        writable: true,
+        configurable: true
+      });
+
+      expect(getCurrentHistoryState()).toBeUndefined();
+    });
+
+    it('returns undefined on error accessing window.history', () => {
+      Object.defineProperty(window, 'history', {
+        get: () => {
+          throw new Error('Access denied');
+        },
+        configurable: true
+      });
+
+      expect(getCurrentHistoryState()).toBeUndefined();
+    });
+
+    it('handles complex nested state objects', () => {
+      const mockState = {
+        fromSuccess: true,
+        category: 'test',
+        data: {
+          nested: {
+            value: 123
+          }
+        }
+      };
+
+      Object.defineProperty(window, 'history', {
+        value: {
+          state: {
+            usr: mockState
+          }
+        },
+        writable: true,
+        configurable: true
+      });
+
+      expect(getCurrentHistoryState()).toEqual(mockState);
+    });
+  });
+
+  describe('isFormOrWizardUrl', () => {
+    describe('Form pages with path segments', () => {
+      it('returns true for URLs with /create', () => {
+        expect(isFormOrWizardUrl('/client-sil/create')).toBe(true);
+        expect(isFormOrWizardUrl('/org-sil-services/create')).toBe(true);
+        expect(isFormOrWizardUrl('/assessment/create')).toBe(true);
+      });
+
+      it('returns true for URLs with /edit', () => {
+        expect(isFormOrWizardUrl('/client-sil/123/edit')).toBe(true);
+        expect(isFormOrWizardUrl('/org-sil-services/35/edit')).toBe(true);
+      });
+
+      it('returns true for URLs with /new', () => {
+        expect(isFormOrWizardUrl('/client-sil/new')).toBe(true);
+        expect(isFormOrWizardUrl('/org-sil-services/new')).toBe(true);
+      });
+    });
+
+    describe('Wizard pages with query parameters', () => {
+      it('returns true for URLs with mode=add', () => {
+        expect(isFormOrWizardUrl('/assessment/create?mode=add')).toBe(true);
+        expect(
+          isFormOrWizardUrl('/assessment/create?mode=add&assessmentId=123')
+        ).toBe(true);
+      });
+
+      it('returns true for URLs with mode=remove', () => {
+        expect(isFormOrWizardUrl('/assessment/create?mode=remove')).toBe(true);
+        expect(
+          isFormOrWizardUrl('/assessment/create?mode=remove&assessmentId=456')
+        ).toBe(true);
+      });
+
+      it('returns true for URLs with mode=edit', () => {
+        expect(isFormOrWizardUrl('/org-sil-services/create?mode=edit')).toBe(
+          true
+        );
+        expect(
+          isFormOrWizardUrl('/org-sil-services/create?mode=edit&id=789')
+        ).toBe(true);
+      });
+    });
+
+    describe('Debt Positions exclusion', () => {
+      it('returns false for debt position URLs with /create', () => {
+        expect(isFormOrWizardUrl('/debt-position/create')).toBe(false);
+      });
+
+      it('returns false for debt position URLs with /edit', () => {
+        expect(isFormOrWizardUrl('/debt-position/123/edit')).toBe(false);
+      });
+
+      it('returns false for debt position URLs with mode params', () => {
+        expect(isFormOrWizardUrl('/debt-position/create?mode=add')).toBe(false);
+        expect(isFormOrWizardUrl('/debt-position/create?mode=edit')).toBe(
+          false
+        );
+      });
+
+      it('returns false for any debt position URL', () => {
+        expect(isFormOrWizardUrl('/debt-position')).toBe(false);
+        expect(isFormOrWizardUrl('/debt-position/123')).toBe(false);
+      });
+    });
+
+    describe('Normal pages', () => {
+      it('returns false for list URLs', () => {
+        expect(isFormOrWizardUrl('/client-sil')).toBe(false);
+        expect(isFormOrWizardUrl('/org-sil-services')).toBe(false);
+        expect(isFormOrWizardUrl('/assessment')).toBe(false);
+      });
+
+      it('returns false for detail URLs', () => {
+        expect(isFormOrWizardUrl('/client-sil/123')).toBe(false);
+        expect(isFormOrWizardUrl('/client-sil/IPA_TEST_123')).toBe(false);
+        expect(isFormOrWizardUrl('/org-sil-services/35')).toBe(false);
+        expect(isFormOrWizardUrl('/assessment/detail/3261')).toBe(false);
+      });
+
+      it('returns false for URLs with other query params', () => {
+        expect(isFormOrWizardUrl('/client-sil?page=1&size=10')).toBe(false);
+        expect(isFormOrWizardUrl('/assessment?filter=active')).toBe(false);
+      });
+    });
+
+    describe('Edge cases', () => {
+      it('returns false for null or undefined URL', () => {
+        expect(isFormOrWizardUrl(null as unknown as string)).toBe(false);
+        expect(isFormOrWizardUrl(undefined as unknown as string)).toBe(false);
+      });
+
+      it('returns false for non-string URL', () => {
+        expect(isFormOrWizardUrl(123 as unknown as string)).toBe(false);
+        expect(isFormOrWizardUrl({} as unknown as string)).toBe(false);
+      });
+
+      it('returns false for empty string', () => {
+        expect(isFormOrWizardUrl('')).toBe(false);
+      });
+
+      it('is case-insensitive', () => {
+        expect(isFormOrWizardUrl('/CLIENT-SIL/CREATE')).toBe(true);
+        expect(isFormOrWizardUrl('/org-sil-services/EDIT')).toBe(true);
+        expect(isFormOrWizardUrl('/assessment/create?MODE=ADD')).toBe(true);
+      });
+
+      it('handles URLs with hash', () => {
+        expect(isFormOrWizardUrl('/client-sil/create#section')).toBe(true);
+        expect(isFormOrWizardUrl('/client-sil/123#detail')).toBe(false);
+      });
+
+      it('handles complex query strings', () => {
+        expect(
+          isFormOrWizardUrl(
+            '/assessment/create?mode=add&id=123&name=test&filter=active'
+          )
+        ).toBe(true);
+        expect(isFormOrWizardUrl('/client-sil?page=1&size=10&sort=name')).toBe(
+          false
+        );
+      });
+    });
+  });
+
+  describe('hasValidHistory', () => {
+    const originalHistory = window.history;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+      Object.defineProperty(window, 'history', {
+        value: originalHistory,
+        writable: true,
+        configurable: true
+      });
+    });
+
+    it('returns true when history length is greater than 1', () => {
+      Object.defineProperty(window, 'history', {
+        value: {
+          length: 5
+        },
+        writable: true,
+        configurable: true
+      });
+
+      expect(hasValidHistory()).toBe(true);
+    });
+
+    it('returns true when history length is exactly 2', () => {
+      Object.defineProperty(window, 'history', {
+        value: {
+          length: 2
+        },
+        writable: true,
+        configurable: true
+      });
+
+      expect(hasValidHistory()).toBe(true);
+    });
+
+    it('returns false when history length is 1', () => {
+      Object.defineProperty(window, 'history', {
+        value: {
+          length: 1
+        },
+        writable: true,
+        configurable: true
+      });
+
+      expect(hasValidHistory()).toBe(false);
+    });
+
+    it('returns false when history length is 0', () => {
+      Object.defineProperty(window, 'history', {
+        value: {
+          length: 0
+        },
+        writable: true,
+        configurable: true
+      });
+
+      expect(hasValidHistory()).toBe(false);
+    });
+
+    it('handles very long history', () => {
+      Object.defineProperty(window, 'history', {
+        value: {
+          length: 100
+        },
+        writable: true,
+        configurable: true
+      });
+
+      expect(hasValidHistory()).toBe(true);
+    });
+  });
+
+  describe('Integration scenarios', () => {
+    describe('Client SIL flow', () => {
+      it('identifies success page after creation', () => {
+        const successState = {
+          category: 'client-sil',
+          fromSuccess: true
+        };
+        expect(isPageToSkip(successState)).toBe(true);
+      });
+
+      it('identifies create form page', () => {
+        expect(isPageToSkip({}, '/client-sil/create')).toBe(true);
+      });
+
+      it('does not skip detail page', () => {
+        expect(isPageToSkip({}, '/client-sil/IPA_TEST_123')).toBe(false);
+      });
+
+      it('does not skip list page', () => {
+        expect(isPageToSkip({}, '/client-sil')).toBe(false);
+      });
+    });
+
+    describe('Assessment flow', () => {
+      it('identifies success page after adding payments', () => {
+        const successState = {
+          category: 'assessment-add-payments',
+          fromSuccess: true
+        };
+        expect(isPageToSkip(successState)).toBe(true);
+      });
+
+      it('identifies wizard page with mode=add', () => {
+        const wizardUrl =
+          '/assessment/create?mode=add&assessmentId=123&debtPositionTypeOrgCode=TEST';
+        expect(isPageToSkip({}, wizardUrl)).toBe(true);
+      });
+
+      it('identifies wizard page with mode=remove', () => {
+        const wizardUrl =
+          '/assessment/create?mode=remove&assessmentId=456&debtPositionTypeOrgCode=TEST';
+        expect(isPageToSkip({}, wizardUrl)).toBe(true);
+      });
+
+      it('does not skip detail page', () => {
+        expect(isPageToSkip({}, '/assessment/detail/3261')).toBe(false);
+      });
+
+      it('does not skip search results page', () => {
+        expect(isPageToSkip({}, '/assessment/search-results')).toBe(false);
+      });
+    });
+
+    describe('Org SIL Service flow', () => {
+      it('identifies success page after edit', () => {
+        const successState = {
+          category: 'org-sil-service-edit',
+          fromSuccess: true
+        };
+        expect(isPageToSkip(successState)).toBe(true);
+      });
+
+      it('identifies edit form page', () => {
+        expect(isPageToSkip({}, '/org-sil-services/35/edit')).toBe(true);
+      });
+
+      it('does not skip detail page', () => {
+        expect(isPageToSkip({}, '/org-sil-services/35')).toBe(false);
+      });
+
+      it('does not skip list page', () => {
+        expect(isPageToSkip({}, '/org-sil-services')).toBe(false);
+      });
+    });
+  });
+});

--- a/src/utils/historyNavigation.ts
+++ b/src/utils/historyNavigation.ts
@@ -1,0 +1,210 @@
+/**
+ * Utility functions to manage browser history navigation
+ * intelligently, recognizing and handling intermediate pages.
+ *
+ * These functions are used to implement the "smart back" logic
+ * that allows automatically skipping consecutive intermediate pages
+ * in history during backward navigation.
+ *
+ * Pages that are skipped:
+ * - Success pages: operation confirmation pages
+ * - Form pages: create/edit pages (create, edit, new)
+ * - Wizard pages: multi-step pages with query params (mode=add/remove/edit)
+ *
+ * Smart Back v2 - Recognizes pages via:
+ * 1. Explicit state markers: fromSuccess, fromWizard, fromForm
+ * 2. URL pattern analysis: /create, /edit, /new, ?mode=add, ?mode=remove
+ */
+
+/**
+ * Checks whether a page should be skipped during back navigation.
+ *
+ * A page is skipped if it is a:
+ * - Success page: operation confirmation pages
+ * - Form page: create/edit pages (create, edit, new)
+ * - Wizard page: multi-step pages with query params (mode=add/remove/edit)
+ *
+ * Recognized via:
+ * 1. State markers: `fromSuccess`, `fromWizard`, `fromForm`, `category` containing "success"
+ * 2. URL analysis: path segments (/create, /edit, /new) and query params (mode=)
+ *
+ * @param historyState - The state from history (typically window.history.state.usr)
+ * @param url - The full URL (pathname + search) for pattern analysis (optional)
+ * @returns true if the page should be skipped during back navigation
+ *
+ * @example
+ * ```typescript
+ * // Success pages
+ * isPageToSkip({ fromSuccess: true }); // true
+ * isPageToSkip({ category: 'client-sil-delete-success' }); // true
+ *
+ * // Form/Wizard pages (state markers)
+ * isPageToSkip({ fromWizard: true }); // true
+ * isPageToSkip({ fromForm: true }); // true
+ *
+ * // Form/Wizard pages (URL analysis)
+ * isPageToSkip({}, '/client-sil/create'); // true
+ * isPageToSkip({}, '/org-sil-services/123/edit'); // true
+ * isPageToSkip({}, '/assessment/create?mode=add'); // true
+ *
+ * // Normal pages
+ * isPageToSkip({}, '/client-sil'); // false
+ * isPageToSkip({}, '/client-sil/123'); // false (detail page)
+ * ```
+ */
+export const isPageToSkip = (historyState: unknown, url?: string): boolean => {
+  // Guard: if there is neither state nor URL, nothing can be determined
+  if (
+    (!historyState || typeof historyState !== 'object') &&
+    (!url || typeof url !== 'string')
+  ) {
+    return false;
+  }
+
+  const state = historyState as Record<string, unknown> | null;
+
+  // Case 1: Success pages (state markers)
+  if (state) {
+    // Explicit success page (fromSuccess flag)
+    if (state.fromSuccess === true) {
+      return true;
+    }
+
+    // Success page via category
+    if (
+      typeof state.category === 'string' &&
+      state.category.includes('success')
+    ) {
+      return true;
+    }
+
+    // Case 2: Form/Wizard pages (explicit state markers)
+    // These markers may be set explicitly by pages
+    if (state.fromWizard === true) {
+      return true;
+    }
+
+    if (state.fromForm === true) {
+      return true;
+    }
+  }
+
+  // Case 3: Form/Wizard pages (URL analysis fallback)
+  // If there are no explicit markers, analyze the URL
+  if (url) {
+    return isFormOrWizardUrl(url);
+  }
+
+  return false;
+};
+
+/**
+ * @deprecated Use `isPageToSkip` instead. This function will be removed in a future version.
+ *
+ * Checks whether a history state represents a success page
+ * to be ignored during back navigation.
+ *
+ * @param historyState - The state from history (typically window.history.state.usr)
+ * @returns true if it is a success page to ignore during back navigation
+ */
+export const isSuccessPage = (historyState: unknown): boolean => {
+  // Backward compatibility: delegate to new function
+  return isPageToSkip(historyState);
+};
+
+/**
+ * Reads the state of the current position in history.
+ *
+ * React Router stores user state in `window.history.state.usr`.
+ * This function provides safe access to that state, handling
+ * potential access errors.
+ *
+ * @returns The current history state, or undefined if not available
+ *
+ * @example
+ * ```typescript
+ * const currentState = getCurrentHistoryState();
+ * if (isSuccessPage(currentState)) {
+ *   console.log('We are on a success page');
+ * }
+ * ```
+ */
+export const getCurrentHistoryState = (): unknown => {
+  try {
+    // React Router v6 stores state in window.history.state.usr
+    return window.history.state?.usr;
+  } catch {
+    // In case of error (e.g., window access not available), return undefined
+    return undefined;
+  }
+};
+
+/**
+ * Checks whether a URL represents a form or wizard page to be skipped
+ * during back navigation.
+ *
+ * Recognizes:
+ * - Form pages: path segments containing /create, /new, /edit
+ * - Wizard pages: query parameters with mode=add, mode=remove, mode=edit
+ *
+ * Exclusions:
+ * - Debt Positions (/debt-position) → separate custom handling
+ *
+ * @param url - The full URL (pathname + search) to analyze
+ * @returns true if it is a form/wizard page to skip
+ *
+ * ```
+ */
+export const isFormOrWizardUrl = (url: string): boolean => {
+  // Guard: null or non-string URL
+  if (!url || typeof url !== 'string') {
+    return false;
+  }
+
+  const urlLower = url.toLowerCase();
+
+  // Exclusion: Debt Positions (separate custom handling)
+  // Debt positions have custom success page logic
+  if (urlLower.includes('/debt-position')) {
+    return false;
+  }
+
+  // Pattern 1: Form pages with path segments
+  // Recognizes URLs containing /create, /new, /edit
+  // Example: /client-sil/create, /org-sil-services/new, /organizations/123/edit
+  const formPathPatterns = ['/create', '/new', '/edit'];
+
+  if (formPathPatterns.some((pattern) => urlLower.includes(pattern))) {
+    return true;
+  }
+
+  // Pattern 2: Wizard pages with query parameters
+  // Recognizes URLs with query params mode=add, mode=remove, mode=edit
+  // Example: /assessment/create?mode=add&assessmentId=123
+  const wizardQueryPatterns = ['mode=add', 'mode=remove', 'mode=edit'];
+
+  return wizardQueryPatterns.some((pattern) => urlLower.includes(pattern));
+};
+
+/**
+ * Checks whether there is sufficient history to navigate back.
+ *
+ * Ensures there is at least one previous page in history
+ * that can be navigated back to.
+ *
+ * @returns true if it is possible to navigate back, false otherwise
+ *
+ * @example
+ * ```typescript
+ * if (hasValidHistory()) {
+ *   window.history.back();
+ * } else {
+ *   console.log('No previous page available');
+ * }
+ * ```
+ */
+export const hasValidHistory = (): boolean => {
+  // window.history.length includes the current page
+  // so > 1 means there is at least one previous page
+  return window.history.length > 1;
+};


### PR DESCRIPTION
Smart Back Navigation:
- Add useSmartBack hook to intelligently skip intermediate pages (success/form/wizard)
- Add historyNavigation utils for URL pattern detection
- Update BackButton to use Smart Back by default with enableSmartBack prop
- Enable for Client SIL, Org SIL Service with backFallbackRoute configuration
- Add comprehensive test coverage (useSmartBack.test.ts, historyNavigation.test.ts)

Assessment Registry Success Flow:
- Change success CTA from "Visualizza capitoli" → "Visualizza capitolo" (singular)
- Navigate to detail page instead of list after create/edit
- Pass assessmentRegistryId in navigate state for ASSESSMENT_REGISTRY_DETAIL handler
- Add backFallbackRoute: ASSESSMENT_REGISTRY_SEARCH_RESULTS to detail route
- Add tests for create and edit flows


#### How Has This Been Tested?

-visual testing
-unit tests


#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
