### PR TITLE
feat: [P4ADEV-3997] Courtesy for superAdmin

### DIFF
--- a/src/routes/CourtesyPage/CourtesyPage.test.tsx
+++ b/src/routes/CourtesyPage/CourtesyPage.test.tsx
@@ -4,6 +4,9 @@ import utils from '../../utils';
 import { CourtesyPage } from '.';
 import { operatorRoleState } from '../../store/OperatorRoleStore';
 import { OperatorRole } from '../../../generated/data-contracts';
+import { useNavigate } from 'react-router';
+import { STATE } from '../../store/types';
+import { PageRoutes } from '..';
 
 // Mock icons as simple placeholders
 vi.mock('../../assets/icons/abacus', () => ({
@@ -12,12 +15,30 @@ vi.mock('../../assets/icons/abacus', () => ({
 vi.mock('../../assets/icons/waiting', () => ({
   WaitingIcon: () => <svg data-testid="waiting-icon"></svg>
 }));
+vi.mock('react-router', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    useNavigate: vi.fn()
+  };
+});
+vi.mock('../../store/GlobalStore', () => ({
+  useStore: vi.fn(() => ({
+    state: {
+      [STATE.ORGANIZATION_ID]: 123
+    }
+  })),
+  StoreProvider: ({ children }: React.PropsWithChildren<object>) => children
+}));
 
 describe('CourtesyPage component', () => {
+  const mockNavigate = vi.fn();
+
   beforeEach(() => {
     // @ts-expect-error Mock window.location.replace safely for each test
     delete window.location;
     window.location = { replace: vi.fn() } as unknown as string & Location;
+    vi.mocked(useNavigate).mockReturnValue(mockNavigate);
   });
 
   it('renders with AbacusIcon and admin translations by default', () => {
@@ -60,5 +81,19 @@ describe('CourtesyPage component', () => {
     fireEvent.click(button);
 
     expect(window.location.replace).toHaveBeenCalledWith(utils.config.loginUrl);
+  });
+
+  it('renders a specific cta button for ROLE_SUPERADMIN', () => {
+    operatorRoleState.value = OperatorRole.ROLE_SUPERADMIN;
+    render(<CourtesyPage />);
+
+    const button = screen.getByRole('button', { name: 'commons.configure' });
+    expect(button).toBeInTheDocument();
+
+    fireEvent.click(button);
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      PageRoutes.ORGANIZATIONS_EDIT.replace(':organizationId', '123')
+    );
   });
 });

--- a/src/routes/CourtesyPage/CourtesyPage.test.tsx
+++ b/src/routes/CourtesyPage/CourtesyPage.test.tsx
@@ -31,6 +31,19 @@ vi.mock('../../store/GlobalStore', () => ({
   StoreProvider: ({ children }: React.PropsWithChildren<object>) => children
 }));
 
+vi.mock('../../../generated/data-contracts', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../../generated/data-contracts')>();
+
+  return {
+    ...actual,
+    OperatorRole: {
+      ...actual.OperatorRole,
+      ROLE_SUPERADMIN: 'ROLE_SUPERADMIN'
+    }
+  };
+});
+
 describe('CourtesyPage component', () => {
   const mockNavigate = vi.fn();
 
@@ -84,7 +97,8 @@ describe('CourtesyPage component', () => {
   });
 
   it('renders a specific cta button for ROLE_SUPERADMIN', () => {
-    operatorRoleState.value = OperatorRole.ROLE_SUPERADMIN;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    operatorRoleState.value = (OperatorRole as any).ROLE_SUPERADMIN;
     render(<CourtesyPage />);
 
     const button = screen.getByRole('button', { name: 'commons.configure' });

--- a/src/routes/CourtesyPage/index.tsx
+++ b/src/routes/CourtesyPage/index.tsx
@@ -1,12 +1,18 @@
 import { useTranslation } from 'react-i18next';
 import { AbacusIcon } from '../../assets/icons/abacus';
-import ResponsePage from '../../components/ResponsePage/ResponsePage';
+import ResponsePage, {
+  ButtonConfig
+} from '../../components/ResponsePage/ResponsePage';
 import Stack from '@mui/material/Stack';
 import { useTheme } from '@mui/material/styles';
 import utils from '../../utils';
 import { operatorComputedRole } from '../../store/OperatorRoleStore';
 import { ExtendedOperatoRole } from '../../models/OperatorRole';
 import { WaitingIcon } from '../../assets/icons/waiting';
+import { generatePath, useNavigate } from 'react-router';
+import { PageRoutes } from '..';
+import { useStore } from '../../store/GlobalStore';
+import { STATE } from '../../store/types';
 
 const OperatorIcon = ({
   operatorRole
@@ -21,12 +27,41 @@ const OperatorIcon = ({
 
 export const CourtesyPage = () => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { state } = useStore();
   const { spacing } = useTheme();
   const operatorRole = operatorComputedRole.value;
+  const ctaButton: Array<ButtonConfig> = [];
 
   const toHome = () => {
     window.location.replace(utils.config.loginUrl);
   };
+
+  const toEdit = () => {
+    navigate(
+      generatePath(PageRoutes.ORGANIZATIONS_EDIT, {
+        organizationId: state[STATE.ORGANIZATION_ID]
+      })
+    );
+  };
+
+  if (operatorRole === ExtendedOperatoRole.ROLE_SUPERADMIN) {
+    ctaButton.push({
+      variant: 'contained',
+      size: 'large',
+      buttonLabel: t('commons.configure'),
+      actionID: 'edit',
+      onButtonClick: toEdit
+    });
+  } else {
+    ctaButton.push({
+      variant: 'contained',
+      size: 'large',
+      buttonLabel: t('commons.backToHome'),
+      actionID: 'back',
+      onButtonClick: toHome
+    });
+  }
 
   return (
     <Stack maxWidth={spacing(45)} margin="auto">
@@ -34,15 +69,7 @@ export const CourtesyPage = () => {
         icon={<OperatorIcon operatorRole={operatorRole} />}
         title={t(`DraftCourtesyPage.${operatorRole}.title`)}
         description={t(`DraftCourtesyPage.${operatorRole}.description`)}
-        buttonConfig={[
-          {
-            variant: 'contained',
-            size: 'large',
-            buttonLabel: t('commons.backToHome'),
-            actionID: 'back',
-            onButtonClick: toHome
-          }
-        ]}
+        buttonConfig={[...ctaButton]}
       />
     </Stack>
   );

--- a/src/routes/Home/index.test.tsx
+++ b/src/routes/Home/index.test.tsx
@@ -11,13 +11,13 @@ vi.mock('../../utils', () => ({
       emit: vi.fn()
     },
     config: {
-      deployPath: '/test',
+      deployPath: '/test'
     }
   }
 }));
 vi.mock('react-router', async (importOriginal) => ({
   ...(await importOriginal()),
-  useNavigate: vi.fn(),
+  useNavigate: vi.fn()
 }));
 
 describe('Home page', () => {
@@ -29,15 +29,15 @@ describe('Home page', () => {
   };
 
   const user = {
-          userId: 'userId',
-          familyName: 'Polo',
-          name: 'Marco',
-          fiscalCode: 'XXXXXXX',
-          canManageUsers: false,
-          issuer: 'Issuer',
-          organizations: [],
-          mappedExternalUserId: 'mappedExternalUserId'
-        };
+    userId: 'userId',
+    familyName: 'Polo',
+    name: 'Marco',
+    fiscalCode: 'XXXXXXX',
+    canManageUsers: false,
+    issuer: 'Issuer',
+    organizations: [],
+    mappedExternalUserId: 'mappedExternalUserId'
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -63,7 +63,9 @@ describe('Home page', () => {
     mockSessionStorage.getItem.mockReturnValue(null);
     renderHome();
 
-    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(`${user.name} ${user.familyName}`);
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      `${user.name} ${user.familyName}`
+    );
   });
 
   it('handles pending notification when present in sessionStorage', () => {

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -667,6 +667,7 @@
     "404": "404: risorsa non disponibile",
     "affiliateNew": "Associa nuovo",
     "affiliate": "Associa",
+    "configure": "Configura",
     "confirm": "Conferma",
     "id": "id",
     "role": "Ruolo",


### PR DESCRIPTION
This PR modify the cta button for the CourtesyPage in case of draft Org.
When a superadmin is connected and choose an org in draft status, the FE will show the courtesypage with a "configure button" instead a simply "go to home".

#### List of Changes
- add Configure btn to the courtesy page
- modify and add unit tests


#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
