### PR TITLE
fix: [P4ADEV-4092] debt positions edit loader

### DIFF
--- a/src/components/Loader/Loader.test.tsx
+++ b/src/components/Loader/Loader.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '../../__tests__/renderers';
+import Loader from './Loader';
+
+describe('Loader', () => {
+  it('renders default loader with title, subtitle and default message', () => {
+    render(
+      <Loader title="Titolo" subtitle="Sottotitolo" data-testid="test-loader" />
+    );
+
+    expect(screen.getByText('Titolo')).toBeInTheDocument();
+    expect(screen.getByText('Sottotitolo')).toBeInTheDocument();
+    expect(screen.getByText('commons.loading')).toBeInTheDocument();
+    const container = screen.getByTestId('test-loader');
+    expect(container).toHaveAttribute('role', 'status');
+    expect(container).toHaveAttribute('aria-busy');
+  });
+
+  it('renders custom message when messageKey is provided', () => {
+    render(
+      <Loader
+        title="A"
+        subtitle="B"
+        messageKey="debtPositionCreateWizard.loadingDebtPosition"
+        data-testid="custom-loader"
+      />
+    );
+
+    expect(
+      screen.getByText('debtPositionCreateWizard.loadingDebtPosition')
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -1,0 +1,43 @@
+import { CircularProgress, Stack, Typography } from '@mui/material';
+import { PropsWithChildren } from 'react';
+import { useTranslation } from 'react-i18next';
+import WizardStepWrapper from '../Wizard/WizardStepWrapper';
+
+type WizardStepLoaderProps = {
+  title?: string;
+  subtitle?: string;
+  messageKey?: string;
+  minHeight?: number;
+  'data-testid'?: string;
+};
+
+function WizardStepLoader({
+  title,
+  subtitle,
+  messageKey = 'commons.loading',
+  minHeight = 200,
+  'data-testid': dataTestId = 'wizard-step-loader'
+}: PropsWithChildren<WizardStepLoaderProps>) {
+  const { t } = useTranslation();
+
+  return (
+    <WizardStepWrapper title={title} subtitle={subtitle}>
+      <Stack
+        alignItems="center"
+        justifyContent="center"
+        minHeight={minHeight}
+        gap={2}
+        aria-busy
+        role="status"
+        data-testid={dataTestId}
+      >
+        <CircularProgress aria-hidden />
+        <Typography variant="body2" aria-live="polite">
+          {t(messageKey)}
+        </Typography>
+      </Stack>
+    </WizardStepWrapper>
+  );
+}
+
+export default WizardStepLoader;

--- a/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizard.test.tsx
+++ b/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizard.test.tsx
@@ -365,6 +365,20 @@ describe('DebtPositionCreateWizard', () => {
       });
     });
 
+    it('shows loader while fetching and hides step1 form', () => {
+      (debtPositions.getDebtPositionDetail as Mock).mockReturnValue({
+        data: null,
+        error: null,
+        isLoading: true,
+        isFetching: true
+      });
+
+      render(<DebtPositionCreateWizard />);
+
+      expect(screen.getByTestId('step1-loading')).toBeInTheDocument();
+      expect(screen.queryByTestId('step1-next')).not.toBeInTheDocument();
+    });
+
     it('renders in editing mode with correct titles and data', async () => {
       render(<DebtPositionCreateWizard />);
 

--- a/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizard.tsx
+++ b/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizard.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useLocation } from 'react-router';
 import Step1GeneralConfiguration from './components/Step/Step1GeneralConfiguration';
+import Step1Loading from './components/Step/Step1Loading';
 import Step2AddDebtor from './components/Step/Step2AddDebtor';
 import Step3 from './components/Step/Step3';
 import { StepperContainer } from '../../components/Stepper';
@@ -120,8 +121,12 @@ const DebtPositionCreateWizard = () => {
   const isEditing = location.state?.isEditing === true;
   const debtPositionId = location.state?.debtPositionId;
 
-  const { data: debtPositionDetail, error } =
-    debtPositions.getDebtPositionDetail(organizationId, debtPositionId || 0);
+  const debtPositionDetailQuery = debtPositions.getDebtPositionDetail(
+    organizationId,
+    debtPositionId || 0
+  );
+  const { data: debtPositionDetail, error } = debtPositionDetailQuery;
+  const { isLoading, isFetching } = debtPositionDetailQuery;
 
   useEffect(() => {
     if (isEditing && !debtPositionId) {
@@ -362,21 +367,24 @@ const DebtPositionCreateWizard = () => {
       steps={[
         {
           label: t('debtPositionCreateWizard.wizardStepper.step1'),
-          content: (
-            <Step1GeneralConfiguration
-              key="step1"
-              data={formData.step1}
-              setData={(data) => {
-                setFormData((prev) => ({ ...prev, step1: data }));
-              }}
-              onNext={() => setStep(1)}
-              onBack={() => navigate(PageRoutes.DEBT_POSITIONS_INDEX)}
-              isEditing={isEditing}
-              debtPositionTypeOrgCode={
-                debtPositionDetail?.debtPositionTypeOrgCode
-              }
-            />
-          )
+          content:
+            isEditing && (isLoading || isFetching) ? (
+              <Step1Loading key="step1-loading" />
+            ) : (
+              <Step1GeneralConfiguration
+                key="step1"
+                data={formData.step1}
+                setData={(data) => {
+                  setFormData((prev) => ({ ...prev, step1: data }));
+                }}
+                onNext={() => setStep(1)}
+                onBack={() => navigate(PageRoutes.DEBT_POSITIONS_INDEX)}
+                isEditing={isEditing}
+                debtPositionTypeOrgCode={
+                  debtPositionDetail?.debtPositionTypeOrgCode
+                }
+              />
+            )
         },
         {
           label: t('debtPositionCreateWizard.wizardStepper.step2'),

--- a/src/routes/DebtPositionCreateWizard/components/Step/Step1Loading.test.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step/Step1Loading.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '../../../../__tests__/renderers';
+import Step1Loading from './Step1Loading';
+
+describe('Step1Loading', () => {
+  it('renders Loader with step1 titles and specific loading message key', () => {
+    render(<Step1Loading />);
+
+    // Title and subtitle are translation keys in tests
+    expect(
+      screen.getByText('debtPositionCreateWizard.generalConfiguration.title')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('debtPositionCreateWizard.generalConfiguration.subtitle')
+    ).toBeInTheDocument();
+
+    // Specific message key for debt position loading
+    expect(
+      screen.getByText('debtPositionCreateWizard.loadingDebtPosition')
+    ).toBeInTheDocument();
+
+    // Loader test id
+    expect(screen.getByTestId('step1-loading')).toBeInTheDocument();
+  });
+});

--- a/src/routes/DebtPositionCreateWizard/components/Step/Step1Loading.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step/Step1Loading.tsx
@@ -1,0 +1,17 @@
+import Loader from '../../../../components/Loader/Loader';
+import { useTranslation } from 'react-i18next';
+
+function Step1Loading() {
+  const { t } = useTranslation();
+
+  return (
+    <Loader
+      title={t('debtPositionCreateWizard.generalConfiguration.title')}
+      subtitle={t('debtPositionCreateWizard.generalConfiguration.subtitle')}
+      messageKey="debtPositionCreateWizard.loadingDebtPosition"
+      data-testid="step1-loading"
+    />
+  );
+}
+
+export default Step1Loading;

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -889,7 +889,7 @@
     "iun": "Identificativo univoco notifica",
     "iur": "IUR",
     "iuv": "IUV",
-    "loading": "caricamento",
+    "loading": "Caricamento...",
     "lastUpdate": "Ultimo aggiornamento",
     "macroarea": "Macroarea",
     "mandatoryDueDate": "Data di Scadenza Obbligatoria",
@@ -1138,6 +1138,7 @@
       "subtitle": "Scegli tipo di dovuto su cui creare il nuovo dovuto e assegnarle un nome per il successivo tracciamento.",
       "title": "Configurazione generale"
     },
+    "loadingDebtPosition": "Caricamento posizione debitoria",
     "step1": {
       "debtPositionType": {
         "label": "Tipo di dovuto",


### PR DESCRIPTION
This PR introduces a generic loader and integrates it into Step 1 of the Debt Position wizard.
The loader is displayed only when editing an existing debt position in Step 1.

This ensures that if the debt position contains many installments (up to 12), the user will see the loader while the installments are being loaded.


#### How Has This Been Tested?

-visual testing
-unit tests


#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
