### PR TITLE
feat: [P4ADEV-4097] debt-positions-wizard-and-search-validation-alignment

### DIFF
--- a/src/components/DebtPositionsPage/DebtPositionsPage.tsx
+++ b/src/components/DebtPositionsPage/DebtPositionsPage.tsx
@@ -19,6 +19,16 @@ import {
   noFilterSetted,
   shouldShowGeneralError
 } from '../../utils/filtersValidation';
+import {
+  isValidFiscalCodeOrPIVA,
+  normalizeFiscalCodeOrPIVA,
+  normalizeCompact
+} from '../../utils/fieldValidation';
+import {
+  clearFieldError,
+  setFieldError,
+  stripErrorFields
+} from '../../utils/filterErrors';
 
 export const DebtPositionsPage = () => {
   const { t } = useTranslation();
@@ -43,37 +53,84 @@ export const DebtPositionsPage = () => {
 
     const tabFilters = filters[activeTabIndex];
 
-    const cleanedFilters = Object.entries(tabFilters).reduce(
-      (acc, [key, value]) => {
-        if (key.endsWith('_fromError') || key.endsWith('_toError')) {
-          return acc;
-        }
+    // Normalize and validate fields
+    let nextTabFilters = { ...tabFilters };
 
-        if (
-          typeof value === 'object' &&
-          value !== null &&
-          'from' in value &&
-          'to' in value
-        ) {
-          const dateRange = value as { from?: Date | null; to?: Date | null };
-          if (dateRange.from && dateRange.to) {
-            acc[key] = value;
-          }
-        } else if (value !== null && value !== undefined && value !== '') {
-          if (typeof value === 'string') {
-            const trimmedValue = value.trim();
-            if (trimmedValue) {
-              acc[key] = trimmedValue;
-            }
-          } else {
-            acc[key] = value;
-          }
-        }
+    // Normalize IUV if present
+    const iuv = tabFilters[FilterFieldIds.IUV_CODE] as string | undefined;
+    if (iuv && typeof iuv === 'string' && iuv.trim() !== '') {
+      const normalizedIUV = normalizeCompact(iuv);
+      nextTabFilters = {
+        ...nextTabFilters,
+        [FilterFieldIds.IUV_CODE]: normalizedIUV
+      };
+    }
 
-        return acc;
-      },
-      {} as BaseFilterValues
-    );
+    // Validate fiscalCode if present
+    const fiscalCode = tabFilters[FilterFieldIds.FISCAL_CODE] as
+      | string
+      | undefined;
+
+    if (
+      fiscalCode &&
+      typeof fiscalCode === 'string' &&
+      fiscalCode.trim() !== ''
+    ) {
+      // Normalize the value (remove spaces, uppercase)
+      const normalizedFiscalCode = normalizeFiscalCodeOrPIVA(fiscalCode);
+      const isValid = isValidFiscalCodeOrPIVA(normalizedFiscalCode);
+
+      if (!isValid) {
+        const newFilters = [...filters];
+        newFilters[activeTabIndex] = setFieldError(
+          tabFilters,
+          FilterFieldIds.FISCAL_CODE,
+          t('commons.validation.invalidFiscalCodeOrVat')
+        ) as typeof tabFilters;
+        setFilters(newFilters);
+        return;
+      }
+      // Prepare next filters with normalized value and cleared error
+      nextTabFilters = {
+        ...nextTabFilters,
+        [FilterFieldIds.FISCAL_CODE]: normalizedFiscalCode,
+        [`${FilterFieldIds.FISCAL_CODE}_error`]: ''
+      };
+    }
+
+    // Persist normalized values in state
+    if (iuv || fiscalCode) {
+      const newFilters = [...filters];
+      newFilters[activeTabIndex] = nextTabFilters;
+      setFilters(newFilters);
+    }
+
+    const cleanedFilters = Object.entries(
+      stripErrorFields(nextTabFilters) as BaseFilterValues
+    ).reduce((acc, [key, value]) => {
+      if (
+        typeof value === 'object' &&
+        value !== null &&
+        'from' in value &&
+        'to' in value
+      ) {
+        const dateRange = value as { from?: Date | null; to?: Date | null };
+        if (dateRange.from && dateRange.to) {
+          acc[key] = value;
+        }
+      } else if (value !== null && value !== undefined && value !== '') {
+        if (typeof value === 'string') {
+          const trimmedValue = value.trim();
+          if (trimmedValue) {
+            acc[key] = trimmedValue;
+          }
+        } else {
+          acc[key] = value;
+        }
+      }
+
+      return acc;
+    }, {} as BaseFilterValues);
 
     const params = utils.URI.encode(cleanedFilters);
 
@@ -90,7 +147,7 @@ export const DebtPositionsPage = () => {
         }
       });
     }
-  }, [activeTabIndex, filters, navigate]);
+  }, [activeTabIndex, filters, navigate, t]);
 
   const resetCurrentFilters = useCallback(() => {
     const newFilters = [...filters];
@@ -115,6 +172,17 @@ export const DebtPositionsPage = () => {
       }
 
       const newFilters = [...filters];
+
+      // Clear fiscalCode error when user changes the field
+      if (id === FilterFieldIds.FISCAL_CODE) {
+        const currentTabFilters = newFilters[activeTabIndex] || {};
+        if (currentTabFilters[`${FilterFieldIds.FISCAL_CODE}_error`]) {
+          newFilters[activeTabIndex] = clearFieldError(
+            currentTabFilters,
+            FilterFieldIds.FISCAL_CODE
+          ) as typeof currentTabFilters;
+        }
+      }
 
       if (id === FilterFieldIds.DATE_RANGE) {
         const dateRangeValue = value as {
@@ -142,6 +210,7 @@ export const DebtPositionsPage = () => {
       } else if (id === FilterFieldIds.DATE_RANGE + '_toError') {
         setToError(value as DateValidationError | null);
       } else {
+        // Handle all other field changes (including fiscalCode_error)
         newFilters[activeTabIndex] = {
           ...newFilters[activeTabIndex],
           [id]: value

--- a/src/components/FilterContainer/FilterContainer.tsx
+++ b/src/components/FilterContainer/FilterContainer.tsx
@@ -103,11 +103,21 @@ const RenderComponent = ({
           ? ((values[fieldId] as string) ?? defaultValue)
           : (textItem.value ?? defaultValue);
 
+      // Check for field-specific error (e.g., fiscalCode_error)
+      const fieldError = values?.[`${fieldId}_error`] as string | undefined;
+      const hasError = !!fieldError;
+
       return (
         <FormComponent.TextField
           {...textItem}
           value={currentValue}
+          error={hasError}
+          helperText={fieldError}
           onChange={(e: TextFieldChangeEvent) => {
+            // Clear error when user starts typing
+            if (hasError && onChange) {
+              onChange(`${fieldId}_error`, '');
+            }
             if (onChange) {
               onChange(fieldId, e.target.value);
             } else if (textItem.onChange) {

--- a/src/components/TelematicReceipt/TelematicReceipt.tsx
+++ b/src/components/TelematicReceipt/TelematicReceipt.tsx
@@ -16,29 +16,132 @@ import utils from '../../utils';
 import useTelematicReceiptsFilters from '../../hooks/useTelematicReceiptsFilters';
 import { TelematicReceiptsFilters } from '../../api/receipts/mappings';
 import { FilterFieldValue } from '../../models/Filters';
+import { FilterFieldIds } from '../../models/SearchCardFields';
+import {
+  isValidFiscalCodeOrPIVA,
+  normalizeFiscalCodeOrPIVA,
+  normalizeCompact
+} from '../../utils/fieldValidation';
+import {
+  clearFieldError,
+  setFieldError,
+  stripErrorFields
+} from '../../utils/filterErrors';
+
+type TelematicReceiptsFiltersWithErrors = TelematicReceiptsFilters & {
+  fiscalCode_error?: string;
+};
 
 export const TelematicReceipt = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const [filters, setFilters] = useState<TelematicReceiptsFilters>({});
+  const [filters, setFilters] = useState<TelematicReceiptsFiltersWithErrors>(
+    {}
+  );
   const [error, setError] = useState<boolean>(false);
 
   const navigateToResults = useCallback(() => {
-    if (noFilterSetted(filters)) {
-      setError(shouldShowGeneralError(filters));
+    // Prepare working copy and normalize IUV if present
+    let nextFilters = { ...filters } as TelematicReceiptsFiltersWithErrors;
+    const iuv = (filters as Record<string, unknown>)[
+      FilterFieldIds.IUV_CODE
+    ] as string | undefined;
+    if (iuv && typeof iuv === 'string' && iuv.trim() !== '') {
+      const normalizedIUV = normalizeCompact(iuv);
+      nextFilters = {
+        ...nextFilters,
+        [FilterFieldIds.IUV_CODE]: normalizedIUV
+      };
+      setFilters(nextFilters);
+    }
+    // Validate fiscalCode when present
+    const fiscalCode = filters.fiscalCode as string | undefined;
+    if (
+      fiscalCode &&
+      typeof fiscalCode === 'string' &&
+      fiscalCode.trim() !== ''
+    ) {
+      // Normalize the value (remove spaces, uppercase)
+      const normalizedFiscalCode = normalizeFiscalCodeOrPIVA(fiscalCode);
+      const isValid = isValidFiscalCodeOrPIVA(normalizedFiscalCode);
+      if (!isValid) {
+        setFilters(
+          (prev) =>
+            setFieldError(
+              prev,
+              FilterFieldIds.FISCAL_CODE,
+              t('commons.validation.invalidFiscalCodeOrVat')
+            ) as typeof prev
+        );
+        return;
+      }
+      // Prepare next filters with normalized value and cleared error
+      nextFilters = {
+        ...nextFilters,
+        fiscalCode: normalizedFiscalCode,
+        fiscalCode_error: ''
+      };
+      setFilters(nextFilters);
+    }
+
+    if (noFilterSetted(nextFilters)) {
+      setError(shouldShowGeneralError(nextFilters));
     } else {
       setError(false);
-      const params = utils.URI.encode(filters);
+      // Exclude field errors from URL params
+      const cleanedFilters = stripErrorFields(nextFilters);
+      const params = utils.URI.encode(cleanedFilters);
       navigate(`${PageRoutes.TELEMATIC_RECEIPT_SEARCH_RESULTS}#${params}`);
     }
-  }, [filters, navigate]);
+  }, [filters, navigate, t]);
 
   const resetCurrentFilters = useCallback(() => {
     setFilters({});
   }, [filters]);
 
   const handleFilterChange = (id: string, value: FilterFieldValue) => {
-    setFilters((prev) => ({ ...prev, [id]: value }));
+    if (id === FilterFieldIds.FISCAL_CODE) {
+      setFilters(
+        (prev) =>
+          clearFieldError(
+            {
+              ...prev,
+              fiscalCode: (value as string) ?? ''
+            },
+            FilterFieldIds.FISCAL_CODE
+          ) as typeof prev
+      );
+      return;
+    }
+    if (id === FilterFieldIds.IUV_CODE) {
+      setFilters((prev) => ({
+        ...prev,
+        iuv: (value as string) ?? ''
+      }));
+      return;
+    }
+    if (id === FilterFieldIds.TYPE_ORG) {
+      setFilters((prev) => ({
+        ...prev,
+        typeOrgId: (value as number) ?? undefined
+      }));
+      return;
+    }
+    if (id === FilterFieldIds.DATE_RANGE) {
+      const range = value as
+        | { from?: Date | null; to?: Date | null }
+        | undefined;
+      const normalized =
+        range && range.from && range.to
+          ? { from: range.from as Date, to: range.to as Date }
+          : undefined;
+      setFilters((prev) => ({
+        ...prev,
+        dateRange: normalized as
+          | TelematicReceiptsFilters['dateRange']
+          | undefined
+      }));
+    }
   };
 
   const { filters: filtersGrid } = useTelematicReceiptsFilters({

--- a/src/routes/DebtPositions/DebtPositionsResults.tsx
+++ b/src/routes/DebtPositions/DebtPositionsResults.tsx
@@ -23,7 +23,13 @@ import {
   shouldShowGeneralError
 } from '../../utils/filtersValidation';
 import { ErrorMessage } from '../../components/ErrorMessage/ErrorMessage';
+import {
+  isValidFiscalCodeOrPIVA,
+  normalizeFiscalCodeOrPIVA,
+  normalizeCompact
+} from '../../utils/fieldValidation';
 import utils from '../../utils';
+import { clearFieldError, setFieldError } from '../../utils/filterErrors';
 
 export const DebtPositionResults = () => {
   const theme = useTheme();
@@ -69,11 +75,52 @@ export const DebtPositionResults = () => {
   });
 
   const applyFilters = () => {
-    if (!noFilterSetted(filterValues)) {
-      debtPosition.applyFilters(filterValues);
+    let nextValues = { ...filterValues };
+
+    // Normalize IUV if present
+    const iuv = filterValues?.iuv as string | undefined;
+    if (iuv && typeof iuv === 'string' && iuv.trim() !== '') {
+      const normalizedIUV = normalizeCompact(iuv);
+      nextValues = {
+        ...nextValues,
+        iuv: normalizedIUV
+      };
+    }
+
+    // Validate fiscalCode if present
+    const fiscalCode = filterValues?.fiscalCode as string | undefined;
+    if (fiscalCode && fiscalCode.trim() !== '') {
+      // Normalize the value (remove spaces, uppercase)
+      const normalizedFiscalCode = normalizeFiscalCodeOrPIVA(fiscalCode);
+      if (!isValidFiscalCodeOrPIVA(normalizedFiscalCode)) {
+        setFilterValues(
+          (prev) =>
+            setFieldError(
+              prev,
+              'fiscalCode',
+              t('commons.validation.invalidFiscalCodeOrVat')
+            ) as typeof prev
+        );
+        return;
+      }
+      // Update with normalized value and clear error if validation passes
+      nextValues = {
+        ...nextValues,
+        fiscalCode: normalizedFiscalCode,
+        fiscalCode_error: ''
+      };
+    }
+
+    // Persist normalized values in state
+    if (iuv || fiscalCode) {
+      setFilterValues(nextValues);
+    }
+
+    if (!noFilterSetted(nextValues)) {
+      debtPosition.applyFilters(nextValues);
       setError(false);
     } else {
-      setError(shouldShowGeneralError(filterValues));
+      setError(shouldShowGeneralError(nextValues));
     }
   };
 
@@ -129,12 +176,32 @@ export const DebtPositionResults = () => {
         <FilterContainer
           items={filters}
           values={filterValues}
-          onChange={(id, value) =>
-            setFilterValues((filterValues) => ({
-              ...filterValues,
-              [id]: value as string
-            }))
-          }
+          onChange={(id, value) => {
+            // Clear fiscalCode error when user changes the field
+            if (id === 'fiscalCode' && filterValues?.fiscalCode_error) {
+              setFilterValues(
+                (prev) =>
+                  clearFieldError(
+                    {
+                      ...prev,
+                      [id]: value as string
+                    },
+                    'fiscalCode'
+                  ) as typeof prev
+              );
+            } else if (id === 'fiscalCode_error') {
+              // Handle fiscalCode error field changes
+              setFilterValues((prev) => ({
+                ...prev,
+                [id]: value as string
+              }));
+            } else {
+              setFilterValues((filterValues) => ({
+                ...filterValues,
+                [id]: value as string
+              }));
+            }
+          }}
           onSubmit={applyFilters}
         />
         <Grid

--- a/src/routes/DebtTypeOrgCreate/steps/Step3Accounting/Step3Accounting.test.tsx
+++ b/src/routes/DebtTypeOrgCreate/steps/Step3Accounting/Step3Accounting.test.tsx
@@ -93,7 +93,10 @@ describe('Step3Accounting', () => {
 
     renderWithForm(<Step3Accounting />, onSubmit);
 
-    fillField('debtTypeOrgCreate.accounting.postalIban', '123456');
+    fillField(
+      'debtTypeOrgCreate.accounting.postalIban',
+      'IT60X0542811101000000654321'
+    );
     fillField(
       'debtTypeOrgCreate.accounting.pspIban',
       'IT60X0542811101000000123456'
@@ -112,7 +115,7 @@ describe('Step3Accounting', () => {
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
         {
-          postalIban: '123456',
+          postalIban: 'IT60X0542811101000000654321',
           iban: 'IT60X0542811101000000123456',
           postalAccountCode: '123456789',
           holderPostalCc: 'John Doe',

--- a/src/routes/DebtTypeOrgCreate/steps/Step3Accounting/schema.test.ts
+++ b/src/routes/DebtTypeOrgCreate/steps/Step3Accounting/schema.test.ts
@@ -17,7 +17,7 @@ describe('step3Schema validation', () => {
 
   it('accepts valid IBANs', () => {
     const validData = {
-      postalIban: '123456',
+      postalIban: 'IT60X0542811101000000123456',
       iban: 'IT60X0542811101000000123456'
     };
     const result = step3Schema.safeParse(validData);

--- a/src/routes/DebtTypeOrgCreate/steps/Step3Accounting/schema.ts
+++ b/src/routes/DebtTypeOrgCreate/steps/Step3Accounting/schema.ts
@@ -1,18 +1,11 @@
 import { z } from 'zod';
-import {
-  isValidIBAN,
-  isValidPostalAccount
-} from '../../../../utils/fieldValidation';
+import { isValidIBAN } from '../../../../utils/fieldValidation';
 
 export const step3Schema = z.object({
   postalIban: z
     .literal(undefined)
     .or(z.literal(''))
-    .or(
-      z
-        .string()
-        .refine(isValidPostalAccount, 'commons.validation.invalidPostalIban')
-    ),
+    .or(z.string().refine(isValidIBAN, 'commons.validation.invalidPostalIban')),
   iban: z
     .literal(undefined)
     .or(z.literal(''))

--- a/src/routes/Home/index.tsx
+++ b/src/routes/Home/index.tsx
@@ -32,6 +32,11 @@ import {
   useDashboardByFiscalCode
 } from '../../api/home';
 import { DashboardResult, TABS } from './models';
+import {
+  isValidFiscalCodeOrPIVA,
+  normalizeFiscalCodeOrPIVA,
+  normalizeCompact
+} from '../../utils/fieldValidation';
 
 const Home = () => {
   const { t } = useTranslation();
@@ -42,6 +47,7 @@ const Home = () => {
 
   const [currentTab, setCurrentTab] = useState(TABS.IUV);
   const [error, setError] = useState(false);
+  const [fiscalCodeError, setFiscalCodeError] = useState<string | null>(null);
   const [showDrawer, setShowDrawer] = useState(false);
   const [searchLabel, setSearchLabel] = useState('');
   const [searchValue, setSearchValue] = useState('');
@@ -65,6 +71,8 @@ const Home = () => {
   const handleChange = (_event: React.SyntheticEvent, newTab: TABS) => {
     setCurrentTab(newTab);
     setError(false);
+    setFiscalCodeError(null); // Clear fiscal code error when switching tabs
+    setSearchValue(''); // Reset search input when switching tabs
   };
 
   const user = userInfo ? `${userInfo.name} ${userInfo.familyName} ` : '';
@@ -128,14 +136,30 @@ const Home = () => {
     formData: FormData
   ) => {
     event?.preventDefault();
-    const searchValue = (formData.get('searchValue')?.toString() || '').replace(
-      /\s/g,
-      ''
-    );
+    let searchValue = formData.get('searchValue')?.toString() || '';
 
     if (!searchValue) {
       setError(true);
       return;
+    }
+
+    // Normalize/validate per tab
+    if (currentTab === TABS.FC) {
+      // Normalize the value (remove spaces, uppercase)
+      searchValue = normalizeFiscalCodeOrPIVA(searchValue);
+      // Reflect normalized value in the input immediately
+      setSearchValue(searchValue);
+      if (!isValidFiscalCodeOrPIVA(searchValue)) {
+        setFiscalCodeError(t('commons.validation.invalidFiscalCodeOrVat'));
+        setError(false);
+        return;
+      }
+      // Clear error if validation passes
+      setFiscalCodeError(null);
+    } else {
+      // For IUV and IUF: normalize by removing spaces and reflect in input
+      searchValue = normalizeCompact(searchValue);
+      setSearchValue(searchValue);
     }
 
     const mutation = mutationByTab(currentTab);
@@ -229,6 +253,18 @@ const Home = () => {
                     data-testid={`home-form-input-${tab.id}`}
                     size="small"
                     sx={{ flexGrow: 1 }}
+                    value={tab.id === currentTab ? searchValue : ''}
+                    error={tab.id === TABS.FC && !!fiscalCodeError}
+                    helperText={
+                      tab.id === TABS.FC ? fiscalCodeError : undefined
+                    }
+                    onChange={(e) => {
+                      setSearchValue((e.target as HTMLInputElement).value);
+                      // Clear fiscal code error when user types
+                      if (tab.id === TABS.FC && fiscalCodeError) {
+                        setFiscalCodeError(null);
+                      }
+                    }}
                   />
                   <Button
                     variant="contained"

--- a/src/routes/TelematicReceiptSearchResults/index.tsx
+++ b/src/routes/TelematicReceiptSearchResults/index.tsx
@@ -17,9 +17,24 @@ import utils from '../../utils';
 import TitleComponent from '../../components/TitleComponent/TitleComponent';
 import { ErrorMessage } from '../../components/ErrorMessage/ErrorMessage';
 import FilterContainer from '../../components/FilterContainer/FilterContainer';
+import {
+  isValidFiscalCodeOrPIVA,
+  normalizeFiscalCodeOrPIVA,
+  normalizeCompact
+} from '../../utils/fieldValidation';
+import { FilterFieldIds } from '../../models/SearchCardFields';
+import {
+  clearFieldError,
+  setFieldError,
+  stripErrorFields
+} from '../../utils/filterErrors';
 
 export type LocationState = {
   filters: BaseFilterValues;
+};
+
+type FilterValuesWithErrors = FieldValues & {
+  fiscalCode_error?: string;
 };
 
 const TelematicReceiptSearchResults = () => {
@@ -27,8 +42,11 @@ const TelematicReceiptSearchResults = () => {
   const { t } = useTranslation();
   const [error, setError] = useState(false);
 
-  const initialFilters: FieldValues = utils.URI.decode(window.location.hash);
-  const [filterValues, setFilterValues] = useState(initialFilters);
+  const initialFilters: FilterValuesWithErrors = utils.URI.decode(
+    window.location.hash
+  );
+  const [filterValues, setFilterValues] =
+    useState<FilterValuesWithErrors>(initialFilters);
 
   const {
     state: { organizationId }
@@ -36,17 +54,60 @@ const TelematicReceiptSearchResults = () => {
 
   const query = getReceipts({ organizationId });
 
+  // Helper to exclude error fields from filters
+  const getCleanFilters = (filters: FilterValuesWithErrors): FieldValues =>
+    stripErrorFields(filters) as FieldValues;
+
   const telematicReceipt = useSearch({
-    filters: filterValues,
+    filters: getCleanFilters(filterValues),
     query
   });
 
   const applyFilters = () => {
-    if (!noFilterSetted(filterValues)) {
-      telematicReceipt.applyFilters(filterValues);
+    let nextValues = { ...filterValues } as FilterValuesWithErrors;
+
+    // Normalize IUV if present
+    const iuv = filterValues?.[FilterFieldIds.IUV_CODE] as string | undefined;
+    if (iuv && iuv.trim() !== '') {
+      nextValues = {
+        ...nextValues,
+        [FilterFieldIds.IUV_CODE]: normalizeCompact(iuv)
+      };
+      setFilterValues(nextValues);
+    }
+
+    // Validate fiscalCode when present
+    const fiscalCode = filterValues?.[FilterFieldIds.FISCAL_CODE] as
+      | string
+      | undefined;
+    if (fiscalCode && fiscalCode.trim() !== '') {
+      // Normalize the value (remove spaces, uppercase)
+      const normalizedFiscalCode = normalizeFiscalCodeOrPIVA(fiscalCode);
+      if (!isValidFiscalCodeOrPIVA(normalizedFiscalCode)) {
+        setFilterValues(
+          (prev) =>
+            setFieldError(
+              prev,
+              FilterFieldIds.FISCAL_CODE,
+              t('commons.validation.invalidFiscalCodeOrVat')
+            ) as FilterValuesWithErrors
+        );
+        return;
+      }
+      // Prepare next filters with normalized value and cleared error
+      nextValues = {
+        ...nextValues,
+        [FilterFieldIds.FISCAL_CODE]: normalizedFiscalCode,
+        fiscalCode_error: ''
+      };
+      setFilterValues(nextValues);
+    }
+
+    if (!noFilterSetted(nextValues)) {
+      telematicReceipt.applyFilters(getCleanFilters(nextValues));
       setError(false);
     } else {
-      setError(shouldShowGeneralError(filterValues));
+      setError(shouldShowGeneralError(nextValues));
     }
   };
 
@@ -66,9 +127,23 @@ const TelematicReceiptSearchResults = () => {
         <FilterContainer
           items={filters}
           values={filterValues}
-          onChange={(field, value) =>
-            setFilterValues({ ...filterValues, [field]: value })
-          }
+          onChange={(field, value) => {
+            // Clear field-specific error when user types in fiscalCode
+            if (field === FilterFieldIds.FISCAL_CODE) {
+              setFilterValues(
+                (prev) =>
+                  clearFieldError(
+                    {
+                      ...prev,
+                      [field]: value
+                    },
+                    FilterFieldIds.FISCAL_CODE
+                  ) as FilterValuesWithErrors
+              );
+              return;
+            }
+            setFilterValues({ ...filterValues, [field]: value });
+          }}
           onSubmit={applyFilters}
         />
         <Grid

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -1101,7 +1101,8 @@
       "fieldRequired": "Campo obbligatorio",
       "checkboxRequired": "Questa conferma è obbligatoria",
       "invalidIban": "Formato IBAN non valido",
-      "invalidPostalIban": "Formato conto poste non valido"
+      "invalidPostalIban": "Formato conto poste non valido",
+      "invalidFiscalCodeOrVat": "Il codice fiscale o la partita IVA non sono corretti"
     },
     "yes": "Si"
   },

--- a/src/utils/__tests__/fieldValidation.test.tsx
+++ b/src/utils/__tests__/fieldValidation.test.tsx
@@ -1,13 +1,119 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as fv from '../fieldValidation';
 import {
   isValidCodiceFiscale,
   isValidPartitaIVA,
   isValidIBAN,
+  normalizeCompact,
+  normalizeFiscalCodeOrPIVA,
+  isValidFiscalCodeOrPIVA,
   createBeneficiaryFieldValidators,
   createAmountValidator,
   isBeneficiariesTotalValid,
   createBeneficiaryValidators
 } from '../fieldValidation';
+
+describe('isValidPartitaIVA - environment branches and checksum', () => {
+  const envRef = (import.meta as unknown as { env: { ENV: string } }).env;
+  const originalEnv = envRef.ENV;
+
+  afterEach(() => {
+    envRef.ENV = originalEnv;
+  });
+
+  it('returns false for empty or invalid formats', () => {
+    expect(isValidPartitaIVA('')).toBe(false);
+    expect(isValidPartitaIVA('123')).toBe(false);
+    expect(isValidPartitaIVA('1234567890A')).toBe(false);
+  });
+
+  it('bypasses checksum when check is disabled (non-PROD)', () => {
+    envRef.ENV = 'DEV';
+    expect(isValidPartitaIVA('12345678901')).toBe(true);
+  });
+
+  it('validates checksum in PROD', () => {
+    // Set environment to PROD to enable checksum validation
+    envRef.ENV = 'PROD';
+
+    // Test with valid PIVAs (correct check digit)
+    expect(isValidPartitaIVA('12345678903')).toBe(true); // Computed: base '1234567890' -> check digit 3
+    expect(isValidPartitaIVA('00000000000')).toBe(true); // All zeros is valid (check digit 0)
+
+    // Test with invalid PIVAs (incorrect check digit)
+    // These PIVAs have the wrong check digit and should fail in PROD
+    // We test multiple cases to ensure the checksum validation works correctly
+    // Test invalid PIVAs with wrong check digits
+    const invalidPivas = ['12345678900', '12345678901', '12345678902'];
+
+    invalidPivas.forEach((piva) => {
+      const result = isValidPartitaIVA(piva);
+      // If checksum validation is enabled (ENV='PROD'), these should fail
+      if (fv.isPIVACheckEnabled()) {
+        expect(result).toBe(false);
+      } else {
+        // In non-PROD, any 11-digit number is considered valid
+        expect(result).toBe(true);
+      }
+    });
+  });
+});
+
+describe('isValidFiscalCodeOrPIVA', () => {
+  let pivacheckSpy: ReturnType<typeof vi.spyOn> | undefined;
+  afterEach(() => {
+    pivacheckSpy?.mockRestore();
+  });
+
+  it('accepts ANONIMO (case-insensitive)', () => {
+    expect(isValidFiscalCodeOrPIVA('ANONIMO')).toBe(true);
+    expect(isValidFiscalCodeOrPIVA('anonimo')).toBe(true);
+    expect(isValidFiscalCodeOrPIVA('  aNoNiMo  ')).toBe(true);
+  });
+
+  it('validates CF via underlying validator', () => {
+    expect(isValidFiscalCodeOrPIVA('RSSMRA80A01H501U')).toBe(true);
+  });
+
+  it('validates PIVA in non-PROD bypassing checksum', () => {
+    pivacheckSpy = vi.spyOn(fv, 'isPIVACheckEnabled').mockReturnValue(false);
+    expect(isValidFiscalCodeOrPIVA('12345678901')).toBe(true);
+  });
+
+  it('returns false for invalid values', () => {
+    expect(isValidFiscalCodeOrPIVA('')).toBe(false);
+    expect(isValidFiscalCodeOrPIVA('INVALID')).toBe(false);
+  });
+});
+
+describe('normalize utilities', () => {
+  describe('normalizeCompact', () => {
+    it('removes all spaces and preserves case', () => {
+      expect(normalizeCompact(' 12 3  4 ')).toBe('1234');
+      expect(normalizeCompact('Ab C d E F')).toBe('AbCdEF');
+    });
+    it('returns empty string for falsy inputs', () => {
+      expect(normalizeCompact('')).toBe('');
+      expect(normalizeCompact(null as unknown as string)).toBe('');
+      expect(normalizeCompact(undefined as unknown as string)).toBe('');
+    });
+  });
+
+  describe('normalizeFiscalCodeOrPIVA', () => {
+    it('removes spaces and uppercases fiscal code', () => {
+      expect(normalizeFiscalCodeOrPIVA('rss mra 80a01 h501 u')).toBe(
+        'RSSMRA80A01H501U'
+      );
+    });
+    it('removes spaces and preserves digits for P.IVA', () => {
+      expect(normalizeFiscalCodeOrPIVA('123 456 789 01')).toBe('12345678901');
+    });
+    it('returns empty string for falsy inputs', () => {
+      expect(normalizeFiscalCodeOrPIVA('')).toBe('');
+      expect(normalizeFiscalCodeOrPIVA(null as unknown as string)).toBe('');
+    });
+  });
+});
 
 describe('isValidCodiceFiscale', () => {
   describe('Valid Cases', () => {

--- a/src/utils/__tests__/filterErrors.test.ts
+++ b/src/utils/__tests__/filterErrors.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import {
+  clearFieldError,
+  setFieldError,
+  stripErrorFields
+} from '../filterErrors';
+
+describe('filterErrors utils', () => {
+  it('setFieldError should add error message for field', () => {
+    const values = { fiscalCode: 'ABC' } as const;
+    const result = setFieldError(values, 'fiscalCode', 'invalid');
+    expect(result).toEqual({
+      fiscalCode: 'ABC',
+      fiscalCode_error: 'invalid'
+    });
+  });
+
+  it('clearFieldError should clear existing error for field', () => {
+    const values = {
+      fiscalCode: 'ABC',
+      fiscalCode_error: 'invalid'
+    } as const;
+    const result = clearFieldError(values, 'fiscalCode');
+    expect(result).toEqual({
+      fiscalCode: 'ABC',
+      fiscalCode_error: ''
+    });
+  });
+
+  it('clearFieldError should return same object shape if error key is absent', () => {
+    const values = { fiscalCode: 'ABC' } as const;
+    const result = clearFieldError(values, 'fiscalCode');
+    expect(result).toEqual({ fiscalCode: 'ABC' });
+  });
+
+  it('stripErrorFields should remove all *_error keys', () => {
+    const values = {
+      fiscalCode: 'ABC',
+      fiscalCode_error: 'invalid',
+      iuv: '123',
+      iuv_error: ''
+    } as const;
+    const result = stripErrorFields(values);
+    expect(result).toEqual({
+      fiscalCode: 'ABC',
+      iuv: '123'
+    });
+    expect('fiscalCode_error' in result).toBe(false);
+    expect('iuv_error' in result).toBe(false);
+  });
+});

--- a/src/utils/fieldValidation.tsx
+++ b/src/utils/fieldValidation.tsx
@@ -55,22 +55,123 @@ export const isValidEmail = (email: string): boolean => {
 };
 
 /**
+ * Determines if the Partita IVA check digit validation should be enabled
+ * The check digit validation is enabled only in PROD environment
+ * @returns true if check digit validation should be enabled (PROD), false otherwise (DEV/UAT/LOCAL)
+ */
+export const isPIVACheckEnabled = (): boolean => {
+  return import.meta.env.ENV === 'PROD';
+};
+
+/**
+ * Validates the check digit of an Italian VAT number using the Luhn algorithm
+ * @param pi - VAT number (must be 11 digits, already normalized)
+ * @returns true if the check digit is valid, false otherwise
+ */
+const validatePIVACheckDigit = (pi: string): boolean => {
+  let sum = 0;
+
+  // Sum digits in even positions (0, 2, 4, 6, 8)
+  for (let i = 0; i <= 8; i += 2) {
+    sum += parseInt(pi[i], 10);
+  }
+
+  // Digits in odd positions (1, 3, 5, 7, 9): multiply by 2 and adjust
+  for (let i = 1; i <= 9; i += 2) {
+    let doubled = parseInt(pi[i], 10) * 2;
+    if (doubled > 9) {
+      doubled -= 9; // e.g., 8*2=16 -> 16-9=7
+    }
+    sum += doubled;
+  }
+
+  // Verify check digit (last digit)
+  const checkDigit = (10 - (sum % 10)) % 10;
+  return checkDigit === parseInt(pi[10], 10);
+};
+
+/**
  * Checks if an Italian VAT number is valid
  * @param piva - VAT number to validate
  * @returns true if the VAT number is valid, false otherwise
+ * @remarks
+ * - In PROD environment: validates format (11 digits) + check digit (Luhn algorithm)
+ * - In DEV/UAT/LOCAL environments: validates only format (11 digits)
  */
 export const isValidPartitaIVA = (piva: string): boolean => {
-  // If the VAT number is empty or null, immediately returns false
-  if (!piva) return false;
+  // 1. Basic checks
+  if (!piva) {
+    return false;
+  }
 
   // Normalizes the VAT number by removing all spaces
   piva = piva.replace(/\s/g, '');
 
-  // Checks that:
-  // 1. The length is exactly 11 characters (Italian VAT number standard)
-  // 2. It consists only of numerical digits (0-9)
-  // Note: this validation only checks the format
-  return piva.length === 11 && /^\d{11}$/.test(piva);
+  // 2. Check length after normalization
+  if (piva.length !== 11) {
+    return false;
+  }
+
+  // 3. Verify that all characters are digits
+  if (!/^\d{11}$/.test(piva)) {
+    return false;
+  }
+
+  // 4. If check is disabled, stop here
+  if (!isPIVACheckEnabled()) {
+    return true;
+  }
+
+  // 5. Luhn algorithm for checksum validation
+  return validatePIVACheckDigit(piva);
+};
+
+/**
+ * Normalizes a fiscal code or VAT number by removing spaces and converting to uppercase
+ * @param value - Fiscal code, VAT number, or "ANONIMO" to normalize
+ * @returns Normalized value (spaces removed, uppercase)
+ */
+export const normalizeFiscalCodeOrPIVA = (value: string): string => {
+  if (!value) {
+    return '';
+  }
+  return value.replace(/\s/g, '').toUpperCase();
+};
+
+/**
+ * Removes all spaces from a string without altering case.
+ * Useful for compacting identifiers like IUV/IUF.
+ */
+export const normalizeCompact = (value: string): string => {
+  if (!value) {
+    return '';
+  }
+  return value.replace(/\s/g, '');
+};
+
+/**
+ * Validates a fiscal code or VAT number, accepting also "ANONIMO" as valid value
+ * This function is used in search forms where anonymous subjects are allowed
+ * @param value - Fiscal code, VAT number, or "ANONIMO" to validate
+ * @returns true if the value is valid (CF, P.IVA, or "ANONIMO"), false otherwise
+ */
+export const isValidFiscalCodeOrPIVA = (value: string): boolean => {
+  if (!value) {
+    return false;
+  }
+
+  // Normalize the value by removing spaces and converting to uppercase
+  const normalizedValue = normalizeFiscalCodeOrPIVA(value);
+
+  // Accept "ANONIMO" as valid (case-insensitive)
+  if (normalizedValue === 'ANONIMO') {
+    return true;
+  }
+
+  // Otherwise, validate as Codice Fiscale or Partita IVA
+  return (
+    isValidCodiceFiscale(normalizedValue) || isValidPartitaIVA(normalizedValue)
+  );
 };
 
 /**
@@ -268,22 +369,6 @@ export const isValidIBAN = (iban: string): boolean => {
 
   // Verification with regular expression
   return regex.test(iban);
-};
-
-/**
- * Checks if an Italian postal account number is valid
- * @param postalAccount - Postal account number to validate
- * @returns true if the number is valid, false otherwise
- */
-export const isValidPostalAccount = (postalAccount: string): boolean => {
-  if (!postalAccount) return false;
-
-  // Normalizes the postal account number by removing spaces
-  postalAccount = postalAccount.replace(/\s/g, '');
-
-  // Italian postal accounts consist of 12 numerical digits
-  // or shorter numbers (minimum 6 digits)
-  return /^\d{6,12}$/.test(postalAccount);
 };
 
 /**

--- a/src/utils/filterErrors.ts
+++ b/src/utils/filterErrors.ts
@@ -1,0 +1,52 @@
+/**
+ * Utilities to manage field-specific error keys in filters/forms.
+ * Error keys convention: `${fieldId}_error`
+ */
+
+export type GenericValues = Readonly<Record<string, unknown>>;
+
+/**
+ * Returns a new object with the error message set for the given field id.
+ */
+export function setFieldError<T extends GenericValues>(
+  values: T,
+  fieldId: string,
+  message: string
+): T & Record<string, unknown> {
+  const errorKey = `${fieldId}_error`;
+  return {
+    ...values,
+    [errorKey]: message
+  };
+}
+
+/**
+ * Returns a new object with the error for the given field id cleared (set to empty string).
+ * If the error key is not present, the original object is returned unchanged.
+ */
+export function clearFieldError<T extends GenericValues>(
+  values: T,
+  fieldId: string
+): T & Record<string, unknown> {
+  const errorKey = `${fieldId}_error`;
+  if (!(errorKey in values)) {
+    return values as T & Record<string, unknown>;
+  }
+  return {
+    ...values,
+    [errorKey]: ''
+  };
+}
+
+/**
+ * Returns a shallow-copied object without any keys that end with `_error`.
+ * Useful before serializing filters into URL or sending to APIs.
+ */
+export function stripErrorFields<T extends GenericValues>(
+  values: T
+): Record<string, unknown> {
+  const entries = Object.entries(values).filter(
+    ([key]) => !key.endsWith('_error')
+  );
+  return Object.fromEntries(entries);
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 
 type ImportMetaEnv = Readonly<{
   VITE_DEPLOY_PATH: string;
+  ENV: string;
 }>;
 
 type ImportMeta = Readonly<{


### PR DESCRIPTION
Added automatic space normalization for IUV, IUF, CF, and VAT in all search sections.

-Implemented VAT validation using the Luhn algorithm (check digit), enabled only in the PROD environment

-Added support for "ANONIMO" as a valid value in CF/VAT searches

-Centralized normalization functions in utils (normalizeCompact, normalizeFiscalCodeOrPIVA)

-Applied normalization in:

-Overview (Home) – IUV, IUF, CF tabs

-Debt Positions – IUV and CF/VAT search

-Electronic Receipts – IUV and CF/VAT search

-Normalized values are now stored in state and used in both URL and payload

-Improved error handling with direct display below input fields

-Centralized translation key for CF/VAT errors (commons.validation.invalidFiscalCodeOrVat)

-Created utilities for filter error handling (setFieldError, clearFieldError, stripErrorFields)

#### How Has This Been Tested?

-visual testing
-unit tests

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
