### PR TITLE
feat: [P4ADEV-4156] Manage save in draft & enable on org Edit

### DIFF
--- a/src/routes/Organizations/OrganizationEditWizard/OrganizationEditWizard.tsx
+++ b/src/routes/Organizations/OrganizationEditWizard/OrganizationEditWizard.tsx
@@ -8,7 +8,10 @@ import {
   getOrganizationDetail,
   updateOrganization
 } from '../../../api/organizations';
-import { OrganizationDetailDTO } from '../../../../generated/data-contracts';
+import {
+  OrganizationDetailDTO,
+  OrganizationStatus
+} from '../../../../generated/data-contracts';
 import {
   OrganizationEditFormData,
   LANGUAGE_OPTIONS
@@ -320,7 +323,8 @@ const OrganizationEditWizard = () => {
 
   // Submit handler for final step
   const handleFinalSubmit = async (
-    step2Values?: OrganizationEditFormData['step2']
+    step2Values?: OrganizationEditFormData['step2'],
+    enableOrg?: boolean
   ) => {
     if (!organizationDetailDataRef.current) {
       console.error('Original organization data not available');
@@ -339,12 +343,38 @@ const OrganizationEditWizard = () => {
         organizationDetailDataRef.current
       );
 
+      const mandatoryFieldsFilled =
+        payload.iban && payload.orgLogo && payload.segregationCode;
+
+      if (enableOrg) {
+        if (mandatoryFieldsFilled) {
+          payload.status = OrganizationStatus.ACTIVE;
+        } else {
+          console.error('Missed required fields to activate');
+        }
+      }
+
       await update.mutateAsync({
         organizationId: getOrganizationId,
         organizationData: payload
       });
 
-      utils.notify.emit(t('organizationEditWizard.successMessage'), 'success');
+      if (payload.status === OrganizationStatus.DRAFT && !enableOrg) {
+        utils.notify.emit(
+          t('organizationEditWizard.successDraftMessage'),
+          'success'
+        );
+      } else if (payload.status === OrganizationStatus.DRAFT && enableOrg) {
+        utils.notify.emit(
+          t('organizationEditWizard.successMessageNotEnable'),
+          'warning'
+        );
+      } else {
+        utils.notify.emit(
+          t('organizationEditWizard.successMessage'),
+          'success'
+        );
+      }
 
       navigate(
         generatePath(PageRoutes.ORGANIZATIONS_DETAIL, {

--- a/src/routes/Organizations/OrganizationEditWizard/components/Step/Step2EntityConfiguration.test.tsx
+++ b/src/routes/Organizations/OrganizationEditWizard/components/Step/Step2EntityConfiguration.test.tsx
@@ -313,16 +313,7 @@ describe('Step2EntityConfiguration', () => {
       fireEvent.click(nextButton);
 
       await waitFor(() => {
-        expect(mockOnNext).toHaveBeenCalledWith(
-          expect.objectContaining({
-            iban: expect.objectContaining({
-              value: 'IT60X0542811101000000123456'
-            }),
-            segregationCode: expect.objectContaining({
-              value: '01'
-            })
-          })
-        );
+        expect(mockOnNext).toHaveBeenCalledOnce();
       });
     });
 

--- a/src/routes/Organizations/OrganizationEditWizard/components/Step/Step2EntityConfiguration.tsx
+++ b/src/routes/Organizations/OrganizationEditWizard/components/Step/Step2EntityConfiguration.tsx
@@ -16,7 +16,7 @@ import { PagoPAIntegrationSection } from './sections/PagoPAIntegrationSection';
 type Props = {
   data: OrganizationEditStep2Data;
   setData: (data: OrganizationEditStep2Data) => void;
-  onNext: (data?: OrganizationEditStep2Data) => void;
+  onNext: (data?: OrganizationEditStep2Data, enableOrg?: boolean) => void;
   onBack: () => void;
 };
 
@@ -147,14 +147,14 @@ const Step2EntityConfiguration = ({ data, setData, onNext, onBack }: Props) => {
   // Watch the flagNotifyIo switch to show/hide IO API Key field
   const watchFlagNotifyIo = watch('flagNotifyIo');
 
-  const onSubmit = (values: Step2FormValues) => {
+  const onSubmit = (values: Step2FormValues, enableOrg?: boolean) => {
     const step2Data = formValuesToFieldData(values, data);
     setData(step2Data);
-    onNext(step2Data);
+    onNext(step2Data, enableOrg);
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form>
       <Grid item xs={12} sx={{ mt: 4 }}>
         <Box
           borderRadius={2}
@@ -222,12 +222,25 @@ const Step2EntityConfiguration = ({ data, setData, onNext, onBack }: Props) => {
         </Box>
       </Grid>
 
+      {/* Buttons: when in draft, a user can save in draft or save&enable
+          when in active can only edit */}
       <WizardStepButtons
         onBack={onBack}
-        onNext={handleSubmit(onSubmit)}
+        onNext={handleSubmit((step2Data) =>
+          onSubmit(
+            step2Data,
+            data.organizationStatus === 'DRAFT' ? true : false
+          )
+        )}
         disableNext={false}
-        nextLabel="organizationEditWizard.saveChanges"
+        nextLabel={
+          data.organizationStatus === 'DRAFT'
+            ? 'organizationEditWizard.enableOrg'
+            : 'organizationEditWizard.saveChanges'
+        }
         backLabel="commons.back"
+        showSaveDraft={data.organizationStatus === 'DRAFT' ? true : false}
+        onSaveDraft={handleSubmit((step2Data) => onSubmit(step2Data, false))}
       />
     </form>
   );

--- a/src/routes/Organizations/components/OrganizationDetailAlert.tsx
+++ b/src/routes/Organizations/components/OrganizationDetailAlert.tsx
@@ -26,10 +26,14 @@ export const OrganizationDetailAlert: React.FC<
     };
 
   useEffect(() => {
+    // create an error bucket if a mandatory key missing in data or exists with an empty value
     const missingKeys = (
       Object.keys(mandatoryFields) as Array<keyof OrganizationDetailDTO>
     )
-      .filter((key) => !(key in organizationDetailData))
+      .filter((key) => {
+        const value = organizationDetailData[key];
+        return !(key in organizationDetailData) || value === '';
+      })
       .map((key) => mandatoryFields[key] ?? key);
     setEmptyFieldsString(missingKeys.join(', '));
   }, [organizationDetailData]);

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -2019,8 +2019,12 @@
     "title": "Modifica il tuo ente",
     "description": "Aggiorna le informazioni e configurazioni del tuo ente.",
     "saveChanges": "Salva modifiche",
+    "enableOrg": "Abilita ente",
+    "errorEnablingOrg": "Non è stato possibile abilitare l'ente perché non sono stati compilati i campi obbligatori",
     "errorLoadingData": "Errore nel caricamento dei dati dell'ente",
+    "successDraftMessage": "Modifiche salvate con successo in stato bozza",
     "successMessage": "Modifiche salvate con successo",
+    "successMessageNotEnable": "Modifiche salvate con successo, ma non abilitato",
     "step1": {
       "title": "Anagrafica ente",
       "label": "Anagrafica ente",


### PR DESCRIPTION
This PR ships a little refact of the org eidt buttons.
When in Draft it's possible to save only or save & enable Org, when in Active can only save.

#### List of Changes
- mod buttons of the org edit
- set different alerts in various cases
- mod tests

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
