### PR TITLE
fix: [P4ADEV-4122] debt position detail breadcrumb show description

### DIFF
--- a/src/components/DebtPositionsInstallmentDetail/DebtPositionsInstallmentDetail.tsx
+++ b/src/components/DebtPositionsInstallmentDetail/DebtPositionsInstallmentDetail.tsx
@@ -32,6 +32,9 @@ export const DebtPositionsInstallmentDetail = () => {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [timelineOpen, setTimelineOpen] = useState(false);
   const [openDeleteDialog, setOpenDeleteDialog] = useState(false);
+  const [remittanceInformation, setRemittanceInformation] = useState<
+    string | undefined
+  >(undefined);
 
   const organizationId = Number(state[STATE.ORGANIZATION_ID]);
   const installmentId = Number(id);
@@ -209,7 +212,7 @@ export const DebtPositionsInstallmentDetail = () => {
           pathname: generatePath(PageRoutes.DEBT_POSITION_DETAIL, {
             id: installment.debtPositionId
           }),
-          label: installment.debtPositionTypeOrgDescription || '',
+          label: installment.debtPositionDescription || '-',
           id: 'branch'
         },
         {
@@ -254,7 +257,7 @@ export const DebtPositionsInstallmentDetail = () => {
           <DetailContainer
             sections={[
               {
-                description: installment?.debtPositionDescription,
+                description: remittanceInformation || '-',
                 data: installmentDetailData.summaryData,
                 inline: true,
                 footerLink: {
@@ -312,6 +315,7 @@ export const DebtPositionsInstallmentDetail = () => {
         title={t('debtPositionInstallmentDetail.drawer.title')}
         installmentId={installmentId}
         organizationId={organizationId}
+        onRemittanceInformationChange={setRemittanceInformation}
       />
 
       <Timeline.Drawer

--- a/src/components/DebtPositionsInstallmentDetail/InstallmentDetailDrawer.tsx
+++ b/src/components/DebtPositionsInstallmentDetail/InstallmentDetailDrawer.tsx
@@ -1,5 +1,6 @@
 import { List, Stack, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import { useEffect } from 'react';
 import { getTransfers } from '../../api/transfers';
 import { moneyFormat } from '../../utils/formatters';
 import { TransferDTO } from '../../../generated/data-contracts';
@@ -8,11 +9,72 @@ import { Drawer, DrawerProps } from '../Drawer';
 export type InstallmentDetailDrawerProps = DrawerProps & {
   organizationId: number;
   installmentId: number;
+  onRemittanceInformationChange?: (
+    remittanceInformation: string | undefined
+  ) => void;
+};
+
+type TransferDetailsProps = {
+  transfer: TransferDTO;
+};
+
+const TransferDetails = ({
+  transfer
+}: TransferDetailsProps): JSX.Element | null => {
+  // TODO: handle missing value
+  if (
+    !transfer?.amountCents ||
+    !transfer?.category ||
+    !transfer?.orgFiscalCode
+  ) {
+    return null;
+  }
+
+  return (
+    <List>
+      <Drawer.Field
+        id="name"
+        label=""
+        variant="overline"
+        value={transfer?.orgName ? transfer.orgName.toUpperCase() : ' - '}
+      />
+      <Drawer.Field
+        id="importo"
+        label="importo"
+        variant="sidenav"
+        value={moneyFormat(transfer.amountCents)}
+      />
+      <Drawer.Field
+        id="remittanceInformation"
+        label="Causale"
+        variant="sidenav"
+        value={transfer?.remittanceInformation ?? ' _ '}
+      />
+      <Drawer.Field
+        id="fiscalCode"
+        label="Codice fiscale"
+        value={transfer.orgFiscalCode}
+      />
+      <Drawer.Field id="iban" label="IBAN" value={transfer?.iban ?? ' _ '} />
+      <Drawer.Field
+        id="postalCode"
+        label="Conto Corrente Postale"
+        value={transfer?.postalIban ?? ' _ '}
+      />
+      <Drawer.Field
+        id="taxCode"
+        label="Codice Tassonomico"
+        variant="sidenav"
+        value={transfer.category}
+      />
+    </List>
+  );
 };
 
 export const InstallmentDetailDrawer = ({
   organizationId,
   installmentId,
+  onRemittanceInformationChange,
   ...drawerProps
 }: InstallmentDetailDrawerProps) => {
   const { t } = useTranslation();
@@ -22,60 +84,13 @@ export const InstallmentDetailDrawer = ({
     installmentId
   );
 
-  const Details = ({
-    transfer
-  }: {
-    transfer: TransferDTO;
-  }): JSX.Element | null => {
-    // TODO: handle missing value
-    if (
-      !transfer?.amountCents ||
-      !transfer?.category ||
-      !transfer?.orgFiscalCode
-    ) {
-      return null;
-    }
+  useEffect(() => {
+    if (onRemittanceInformationChange && isSuccess && transfers?.length) {
+      const remittanceInformation = transfers[0]?.remittanceInformation;
 
-    return (
-      <List key={transfer.transferId}>
-        <Drawer.Field
-          id="name"
-          label=""
-          variant="overline"
-          value={transfer?.orgName ? transfer.orgName.toUpperCase() : ' - '}
-        />
-        <Drawer.Field
-          id="importo"
-          label="importo"
-          variant="sidenav"
-          value={moneyFormat(transfer.amountCents)}
-        />
-        <Drawer.Field
-          id="remittanceInformation"
-          label="Causale"
-          variant="sidenav"
-          value={transfer?.remittanceInformation ?? ' _ '}
-        />
-        <Drawer.Field
-          id="fiscalCode"
-          label="Codice fiscale"
-          value={transfer.orgFiscalCode}
-        />
-        <Drawer.Field id="iban" label="IBAN" value={transfer?.iban ?? ' _ '} />
-        <Drawer.Field
-          id="postalCode"
-          label="Conto Corrente Postale"
-          value={transfer?.postalIban ?? ' _ '}
-        />
-        <Drawer.Field
-          id="taxCode"
-          label="Codice Tassonomico"
-          variant="sidenav"
-          value={transfer.category}
-        />
-      </List>
-    );
-  };
+      onRemittanceInformationChange(remittanceInformation);
+    }
+  }, [transfers, isSuccess, onRemittanceInformationChange]);
 
   const TransfersDetails = () => {
     if (!isSuccess || !transfers?.length) return null;
@@ -83,7 +98,7 @@ export const InstallmentDetailDrawer = ({
     return (
       <>
         {transfers.map((transfer) => (
-          <Details
+          <TransferDetails
             key={transfer.transferId}
             transfer={transfer as unknown as TransferDTO}
           />

--- a/src/components/TelematicReceipt/TelematicReceipt.tsx
+++ b/src/components/TelematicReceipt/TelematicReceipt.tsx
@@ -127,19 +127,12 @@ export const TelematicReceipt = () => {
       }));
       return;
     }
+
     if (id === FilterFieldIds.DATE_RANGE) {
-      const range = value as
-        | { from?: Date | null; to?: Date | null }
-        | undefined;
-      const normalized =
-        range && range.from && range.to
-          ? { from: range.from as Date, to: range.to as Date }
-          : undefined;
+      const range = value as { from?: Date | null; to?: Date | null };
       setFilters((prev) => ({
         ...prev,
-        dateRange: normalized as
-          | TelematicReceiptsFilters['dateRange']
-          | undefined
+        dateRange: range as TelematicReceiptsFilters['dateRange'] | undefined
       }));
     }
   };

--- a/src/routes/DebtPositionDetail/DebtPositionDetail.tsx
+++ b/src/routes/DebtPositionDetail/DebtPositionDetail.tsx
@@ -360,12 +360,12 @@ const DebtPositionDetail = () => {
           pathname: generatePath(PageRoutes.DEBT_POSITION_DETAIL, {
             id: debtPositionDetail.paymentOptions[0].debtPositionId
           }),
-          label: debtPositionDetail.debtPositionTypeOrgDescription || '',
+          label: debtPositionDetail.description || '-',
           id: 'branch'
         }
       ]);
     }
-  }, [debtPositionDetail?.paymentOptions]);
+  }, [debtPositionDetail?.paymentOptions, debtPositionDetail?.description]);
 
   const getStatusChipProps = (
     status: string


### PR DESCRIPTION
- Replaced the static title with remittanceInformation in the DetailContainer description within the notice detail page

- Updated the breadcrumb in the notice detail to display debtPositionDescription instead of debtPositionTypeOrgDescription

- Updated the breadcrumb in the debt position detail to display description instead of debtPositionTypeOrgDescription

- Added a "-" fallback when descriptions are not available

- Implemented passing remittanceInformation from the drawer to the parent component via callback to avoid duplicating the API call

- Refactoring: extracted TransferDetails as a separate component with typed props to resolve ESLint warnings

These changes improve UI consistency by showing the correct descriptions instead of due types in both the breadcrumbs and the notice detail description.

#### How Has This Been Tested?

-visual testing
-unit tests


#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
