### PR TITLE
feat: [P4ADEV-4190] save user profile preference in localStorage

### DIFF
--- a/src/hooks/useStep3ApiOperations.test.tsx
+++ b/src/hooks/useStep3ApiOperations.test.tsx
@@ -8,7 +8,7 @@ import {
   ManageDebtPositionDTO,
   DebtPositionStatus,
   DebtPositionOrigin,
-  PaymentOptionTypeEnum
+  PaymentOptionType
 } from '../../generated/data-contracts';
 import {
   Step1Data,
@@ -110,7 +110,7 @@ describe('useStep3ApiOperations', () => {
       {
         paymentOptionId: 1,
         totalAmountCents: 10000,
-        paymentOptionType: PaymentOptionTypeEnum.SINGLE_INSTALLMENT,
+        paymentOptionType: PaymentOptionType.SINGLE_INSTALLMENT,
         installments: []
       }
     ]
@@ -377,7 +377,7 @@ describe('useStep3ApiOperations', () => {
           paymentOptions: expect.arrayContaining([
             expect.objectContaining({
               totalAmountCents: 10000,
-              paymentOptionType: PaymentOptionTypeEnum.SINGLE_INSTALLMENT
+              paymentOptionType: PaymentOptionType.SINGLE_INSTALLMENT
             })
           ])
         }),
@@ -463,7 +463,7 @@ describe('useStep3ApiOperations', () => {
           status: DebtPositionStatus.DRAFT,
           paymentOptions: expect.arrayContaining([
             expect.objectContaining({
-              paymentOptionType: PaymentOptionTypeEnum.INSTALLMENTS,
+              paymentOptionType: PaymentOptionType.INSTALLMENTS,
               description:
                 'debtPositionCreateWizard.step3.paymentOption.installments'
             })

--- a/src/hooks/useStep3ApiOperations.tsx
+++ b/src/hooks/useStep3ApiOperations.tsx
@@ -8,7 +8,7 @@ import {
   ManageDebtPositionDTO,
   DebtPositionStatus,
   DebtPositionOrigin,
-  PaymentOptionTypeEnum
+  PaymentOptionType
 } from '../../generated/data-contracts';
 import { PageRoutes } from '../routes';
 import {
@@ -193,8 +193,8 @@ export const useStep3ApiOperations = (): UseStep3ApiOperationsResult => {
             ? t('debtPositionCreateWizard.step3.paymentOption.installments')
             : t('debtPositionCreateWizard.step3.paymentOption.single'),
           paymentOptionType: isInstallment
-            ? PaymentOptionTypeEnum.INSTALLMENTS
-            : PaymentOptionTypeEnum.SINGLE_INSTALLMENT,
+            ? PaymentOptionType.INSTALLMENTS
+            : PaymentOptionType.SINGLE_INSTALLMENT,
           paymentOptionIndex: DEFAULT_VALUES.PAYMENT_OPTION_INDEX,
           installments: isInstallment
             ? formattedData.installments?.map((installment) =>

--- a/src/hooks/useStep3FormHandlers.test.tsx
+++ b/src/hooks/useStep3FormHandlers.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { useStep3FormHandlers } from './useStep3FormHandlers';
 import { Step3FormValues } from '../models/Step3Schema';
 import { DebtPositionTypeEnum } from '../models/DebtPositionType';
-import { PaymentOptionTypeEnum } from '../../generated/data-contracts';
+import { PaymentOptionType } from '../../generated/data-contracts';
 import { triggerValidationForAllBeneficiaries } from '../utils/paymentUtility';
 import type { Beneficiary } from '../models/paymentTypes';
 
@@ -249,7 +249,7 @@ describe('useStep3FormHandlers', () => {
         onChange: vi.fn()
       };
       const mockEvent = {
-        target: { value: PaymentOptionTypeEnum.SINGLE_INSTALLMENT }
+        target: { value: PaymentOptionType.SINGLE_INSTALLMENT }
       } as React.ChangeEvent<HTMLInputElement>;
 
       act(() => {

--- a/src/hooks/useStep3FormHandlers.tsx
+++ b/src/hooks/useStep3FormHandlers.tsx
@@ -7,7 +7,7 @@ import {
 } from 'react-hook-form';
 import { Step3FormValues } from '../models/Step3Schema';
 import { DebtPositionTypeEnum } from '../models/DebtPositionType';
-import { PaymentOptionTypeEnum } from '../../generated/data-contracts';
+import { PaymentOptionType } from '../../generated/data-contracts';
 import type { PaymentOption, Beneficiary } from '../models/paymentTypes';
 import { BeneficiaryFieldRef } from '../routes/DebtPositionCreateWizard/components/Beneficiary/BeneficiaryField';
 import { triggerValidationForAllBeneficiaries } from '../utils/paymentUtility';
@@ -167,7 +167,7 @@ export const useStep3FormHandlers = (
           installments: []
         });
         break;
-      case PaymentOptionTypeEnum.SINGLE_INSTALLMENT:
+      case PaymentOptionType.SINGLE_INSTALLMENT:
         if (paymentOption === DebtPositionTypeEnum.INSTALLMENTS) {
           reset({
             ...initialData,

--- a/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizard.test.tsx
+++ b/src/routes/DebtPositionCreateWizard/DebtPositionCreateWizard.test.tsx
@@ -9,7 +9,7 @@ import utils from '../../utils';
 import {
   DebtPositionDetailDTO,
   PersonEntityType,
-  PaymentOptionTypeEnum,
+  PaymentOptionType,
   DebtPositionStatus
 } from '../../../generated/data-contracts';
 import { PageRoutes } from '..';
@@ -157,7 +157,7 @@ const mockDebtPositionDetail: DebtPositionDetailDTO = {
   },
   paymentOptions: [
     {
-      paymentOptionType: PaymentOptionTypeEnum.SINGLE_INSTALLMENT,
+      paymentOptionType: PaymentOptionType.SINGLE_INSTALLMENT,
       totalAmountCents: 10000,
       installments: [
         {
@@ -214,7 +214,7 @@ const mockInstallmentDebtPositionDetail: DebtPositionDetailDTO = {
   },
   paymentOptions: [
     {
-      paymentOptionType: PaymentOptionTypeEnum.INSTALLMENTS,
+      paymentOptionType: PaymentOptionType.INSTALLMENTS,
       totalAmountCents: 30000,
       installments: [
         {
@@ -576,7 +576,7 @@ describe('DebtPositionCreateWizard', () => {
         },
         paymentOptions: [
           {
-            paymentOptionType: PaymentOptionTypeEnum.INSTALLMENTS,
+            paymentOptionType: PaymentOptionType.INSTALLMENTS,
             totalAmountCents: 5000,
             installments: [
               {
@@ -629,7 +629,7 @@ describe('DebtPositionCreateWizard', () => {
         },
         paymentOptions: [
           {
-            paymentOptionType: PaymentOptionTypeEnum.INSTALLMENTS,
+            paymentOptionType: PaymentOptionType.INSTALLMENTS,
             totalAmountCents: 15000,
             installments: [
               {

--- a/src/routes/DebtPositionDetail/DebtPositionDetail.test.tsx
+++ b/src/routes/DebtPositionDetail/DebtPositionDetail.test.tsx
@@ -14,7 +14,7 @@ import { DebtPositionDetailDTO } from '../../../generated/apiClient';
 import { UseQueryResult } from '@tanstack/react-query';
 import {
   InstallmentStatus,
-  PaymentOptionTypeEnum,
+  PaymentOptionType,
   PaymentOptionStatus,
   DebtPositionStatus,
   DebtPositionOrigin
@@ -31,7 +31,7 @@ mockDebtPositionDetail.paymentOptions = [
     debtPositionId: 10,
     totalAmountCents: 5400,
     status: PaymentOptionStatus.REPORTED,
-    paymentOptionType: PaymentOptionTypeEnum.SINGLE_INSTALLMENT,
+    paymentOptionType: PaymentOptionType.SINGLE_INSTALLMENT,
     paymentOptionIndex: 1,
     installments: [
       {
@@ -50,7 +50,7 @@ mockDebtPositionDetail.paymentOptions = [
     debtPositionId: 10,
     totalAmountCents: 5400,
     status: PaymentOptionStatus.REPORTED,
-    paymentOptionType: PaymentOptionTypeEnum.INSTALLMENTS,
+    paymentOptionType: PaymentOptionType.INSTALLMENTS,
     paymentOptionIndex: 2,
     installments: [
       {
@@ -69,7 +69,7 @@ mockDebtPositionDetail.paymentOptions = [
     debtPositionId: 10,
     totalAmountCents: 5400,
     status: PaymentOptionStatus.REPORTED,
-    paymentOptionType: PaymentOptionTypeEnum.DOWN_PAYMENT,
+    paymentOptionType: PaymentOptionType.DOWN_PAYMENT,
     paymentOptionIndex: 3,
     installments: [
       {
@@ -731,7 +731,7 @@ describe('DebtPositionDetail Component', () => {
         debtPositionId: 10,
         totalAmountCents: 1000,
         status: PaymentOptionStatus.REPORTED,
-        paymentOptionType: PaymentOptionTypeEnum.SINGLE_INSTALLMENT,
+        paymentOptionType: PaymentOptionType.SINGLE_INSTALLMENT,
         paymentOptionIndex: 1,
         installments: []
       }

--- a/src/routes/DebtPositionDetail/DebtPositionDetail.tsx
+++ b/src/routes/DebtPositionDetail/DebtPositionDetail.tsx
@@ -28,7 +28,7 @@ import { format, parseISO } from 'date-fns';
 import {
   PaymentOptionDTO,
   InstallmentDTO,
-  PaymentOptionTypeEnum,
+  PaymentOptionType,
   PaymentOptionStatus,
   DebtPositionStatus,
   InstallmentStatus,
@@ -456,9 +456,9 @@ const DebtPositionDetail = () => {
   };
 
   const priorityType = [
-    PaymentOptionTypeEnum.SINGLE_INSTALLMENT,
-    PaymentOptionTypeEnum.DOWN_PAYMENT,
-    PaymentOptionTypeEnum.INSTALLMENTS
+    PaymentOptionType.SINGLE_INSTALLMENT,
+    PaymentOptionType.DOWN_PAYMENT,
+    PaymentOptionType.INSTALLMENTS
   ];
 
   const paymentOptionsDisplayData = (debtPositionDetail?.paymentOptions ?? [])

--- a/src/routes/Home/index.tsx
+++ b/src/routes/Home/index.tsx
@@ -42,6 +42,8 @@ import {
   normalizeFiscalCodeOrPIVA,
   normalizeCompact
 } from '../../utils/fieldValidation';
+import { saveUserProfilePreference } from '../../utils/userPreferences';
+import type { UserProfilePreference } from '../../utils/userPreferences';
 
 const Home = () => {
   const { t } = useTranslation();
@@ -151,14 +153,25 @@ const Home = () => {
     setSearchValue(''); // Reset search input when switching tabs
   };
 
+  const persistUserProfilePreference = (
+    preference: UserProfilePreference
+  ): void => {
+    if (!userInfo?.mappedExternalUserId) {
+      return;
+    }
+    saveUserProfilePreference(userInfo.mappedExternalUserId, preference);
+  };
+
   const userProfileConfirmChange = () => {
     const tabsPerProfile = tabsAvailableForProfile(radioValue as USER_PROFILES);
     setProfileSelected(radioValue as USER_PROFILES);
     setCurrentTab(tabsPerProfile[0].id);
     setDialogOpen(false);
+    persistUserProfilePreference(radioValue as USER_PROFILES);
   };
 
   const userProfileCancelChange = () => {
+    persistUserProfilePreference(radioValue as USER_PROFILES);
     setRadioValue(profileSelected);
     setDialogOpen(false);
   };

--- a/src/utils/__tests__/userPreferences.test.ts
+++ b/src/utils/__tests__/userPreferences.test.ts
@@ -69,7 +69,7 @@ describe('userPreferences', () => {
       const result = saveUserProfilePreference(validUserId, validPreference);
 
       expect(result).toBe(true);
-      expect(localStorage.getItem(`userProfilePreference_${validUserId}`)).toBe(
+      expect(localStorage.getItem(`userProfilePreference:${validUserId}`)).toBe(
         validPreference
       );
     });
@@ -87,7 +87,7 @@ describe('userPreferences', () => {
         const result = saveUserProfilePreference(userId, pref);
 
         expect(result).toBe(true);
-        expect(localStorage.getItem(`userProfilePreference_${userId}`)).toBe(
+        expect(localStorage.getItem(`userProfilePreference:${userId}`)).toBe(
           pref
         );
       }
@@ -95,14 +95,14 @@ describe('userPreferences', () => {
 
     it('overwrites an existing preference', () => {
       saveUserProfilePreference(validUserId, USER_PROFILES.DP);
-      expect(localStorage.getItem(`userProfilePreference_${validUserId}`)).toBe(
+      expect(localStorage.getItem(`userProfilePreference:${validUserId}`)).toBe(
         USER_PROFILES.DP
       );
 
       const result = saveUserProfilePreference(validUserId, USER_PROFILES.TM);
 
       expect(result).toBe(true);
-      expect(localStorage.getItem(`userProfilePreference_${validUserId}`)).toBe(
+      expect(localStorage.getItem(`userProfilePreference:${validUserId}`)).toBe(
         USER_PROFILES.TM
       );
     });
@@ -113,7 +113,7 @@ describe('userPreferences', () => {
 
         expect(result).toBe(false);
         expect(console.error).toHaveBeenCalled();
-        expect(localStorage.getItem('userProfilePreference_')).toBeNull();
+        expect(localStorage.getItem('userProfilePreference:')).toBeNull();
       });
 
       it('returns false if mappedExternalUserId is null', () => {
@@ -155,7 +155,7 @@ describe('userPreferences', () => {
         expect(result).toBe(false);
         expect(console.error).toHaveBeenCalled();
         expect(
-          localStorage.getItem(`userProfilePreference_${validUserId}`)
+          localStorage.getItem(`userProfilePreference:${validUserId}`)
         ).toBeNull();
       });
 
@@ -188,7 +188,7 @@ describe('userPreferences', () => {
         expect(result).toBe(false);
         expect(console.error).toHaveBeenCalled();
         expect(
-          localStorage.getItem(`userProfilePreference_${validUserId}`)
+          localStorage.getItem(`userProfilePreference:${validUserId}`)
         ).toBeNull();
       });
     });
@@ -227,7 +227,7 @@ describe('userPreferences', () => {
 
     it('retrieves a saved preference correctly', () => {
       const preference = USER_PROFILES.DP;
-      localStorage.setItem(`userProfilePreference_${validUserId}`, preference);
+      localStorage.setItem(`userProfilePreference:${validUserId}`, preference);
 
       const result = getUserProfilePreference(validUserId);
 
@@ -244,7 +244,7 @@ describe('userPreferences', () => {
       for (let index = 0; index < preferences.length; index += 1) {
         const pref = preferences[index];
         const userId = `user-${index}`;
-        localStorage.setItem(`userProfilePreference_${userId}`, pref);
+        localStorage.setItem(`userProfilePreference:${userId}`, pref);
 
         const result = getUserProfilePreference(userId);
         expect(result).toBe(pref);
@@ -260,7 +260,7 @@ describe('userPreferences', () => {
     it('removes and returns null if saved value is invalid', () => {
       const invalidValue = 'invalidPreference';
       localStorage.setItem(
-        `userProfilePreference_${validUserId}`,
+        `userProfilePreference:${validUserId}`,
         invalidValue
       );
 
@@ -269,7 +269,7 @@ describe('userPreferences', () => {
       expect(result).toBeNull();
       expect(console.warn).toHaveBeenCalled();
       expect(
-        localStorage.getItem(`userProfilePreference_${validUserId}`)
+        localStorage.getItem(`userProfilePreference:${validUserId}`)
       ).toBeNull();
     });
 
@@ -325,10 +325,10 @@ describe('userPreferences', () => {
 
     it('removes an existing preference correctly', () => {
       localStorage.setItem(
-        `userProfilePreference_${validUserId}`,
+        `userProfilePreference:${validUserId}`,
         validPreference
       );
-      expect(localStorage.getItem(`userProfilePreference_${validUserId}`)).toBe(
+      expect(localStorage.getItem(`userProfilePreference:${validUserId}`)).toBe(
         validPreference
       );
 
@@ -336,7 +336,7 @@ describe('userPreferences', () => {
 
       expect(result).toBe(true);
       expect(
-        localStorage.getItem(`userProfilePreference_${validUserId}`)
+        localStorage.getItem(`userProfilePreference:${validUserId}`)
       ).toBeNull();
     });
 
@@ -345,7 +345,7 @@ describe('userPreferences', () => {
 
       expect(result).toBe(true);
       expect(
-        localStorage.getItem(`userProfilePreference_${validUserId}`)
+        localStorage.getItem(`userProfilePreference:${validUserId}`)
       ).toBeNull();
     });
 

--- a/src/utils/__tests__/userPreferences.test.ts
+++ b/src/utils/__tests__/userPreferences.test.ts
@@ -1,0 +1,447 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  saveUserProfilePreference,
+  getUserProfilePreference,
+  removeUserProfilePreference
+} from '../userPreferences';
+import { USER_PROFILES } from '../../routes/Home/models';
+
+describe('userPreferences', () => {
+  const localStorageMock = (() => {
+    let store: Record<string, string> = {};
+
+    function getItem(key: string) {
+      return store[key] || null;
+    }
+
+    function setItem(key: string, value: string) {
+      store[key] = value.toString();
+    }
+
+    function removeItem(key: string) {
+      Reflect.deleteProperty(store, key);
+    }
+
+    function clear() {
+      store = {};
+    }
+
+    return {
+      getItem,
+      setItem,
+      removeItem,
+      clear
+    };
+  })();
+
+  function quotaExceededThrower(): never {
+    throw new Error('QuotaExceededError');
+  }
+
+  function storageDisabledThrower(): never {
+    throw new Error('Storage disabled');
+  }
+
+  function genericStorageErrorThrower(): never {
+    throw new Error('Storage error');
+  }
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'localStorage', {
+      value: localStorageMock,
+      writable: true
+    });
+    localStorageMock.clear();
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    localStorageMock.clear();
+    vi.restoreAllMocks();
+  });
+
+  describe('saveUserProfilePreference', () => {
+    const validUserId = 'user-123';
+    const validPreference = USER_PROFILES.DP;
+
+    it('saves a valid preference correctly', () => {
+      const result = saveUserProfilePreference(validUserId, validPreference);
+
+      expect(result).toBe(true);
+      expect(localStorage.getItem(`userProfilePreference_${validUserId}`)).toBe(
+        validPreference
+      );
+    });
+
+    it('saves all valid preferences correctly', () => {
+      const preferences = [
+        USER_PROFILES.DP,
+        USER_PROFILES.TM,
+        USER_PROFILES.OM
+      ];
+
+      for (let index = 0; index < preferences.length; index += 1) {
+        const pref = preferences[index];
+        const userId = `user-${index}`;
+        const result = saveUserProfilePreference(userId, pref);
+
+        expect(result).toBe(true);
+        expect(localStorage.getItem(`userProfilePreference_${userId}`)).toBe(
+          pref
+        );
+      }
+    });
+
+    it('overwrites an existing preference', () => {
+      saveUserProfilePreference(validUserId, USER_PROFILES.DP);
+      expect(localStorage.getItem(`userProfilePreference_${validUserId}`)).toBe(
+        USER_PROFILES.DP
+      );
+
+      const result = saveUserProfilePreference(validUserId, USER_PROFILES.TM);
+
+      expect(result).toBe(true);
+      expect(localStorage.getItem(`userProfilePreference_${validUserId}`)).toBe(
+        USER_PROFILES.TM
+      );
+    });
+
+    describe('input validation', () => {
+      it('returns false if mappedExternalUserId is empty', () => {
+        const result = saveUserProfilePreference('', validPreference);
+
+        expect(result).toBe(false);
+        expect(console.error).toHaveBeenCalled();
+        expect(localStorage.getItem('userProfilePreference_')).toBeNull();
+      });
+
+      it('returns false if mappedExternalUserId is null', () => {
+        const result = saveUserProfilePreference(
+          null as unknown as string,
+          validPreference
+        );
+
+        expect(result).toBe(false);
+        expect(console.error).toHaveBeenCalled();
+      });
+
+      it('returns false if mappedExternalUserId is undefined', () => {
+        const result = saveUserProfilePreference(
+          undefined as unknown as string,
+          validPreference
+        );
+
+        expect(result).toBe(false);
+        expect(console.error).toHaveBeenCalled();
+      });
+
+      it('returns false if mappedExternalUserId is not a string', () => {
+        const result = saveUserProfilePreference(
+          123 as unknown as string,
+          validPreference
+        );
+
+        expect(result).toBe(false);
+        expect(console.error).toHaveBeenCalled();
+      });
+
+      it('returns false if preference is empty', () => {
+        const result = saveUserProfilePreference(
+          validUserId,
+          '' as USER_PROFILES
+        );
+
+        expect(result).toBe(false);
+        expect(console.error).toHaveBeenCalled();
+        expect(
+          localStorage.getItem(`userProfilePreference_${validUserId}`)
+        ).toBeNull();
+      });
+
+      it('returns false if preference is null', () => {
+        const result = saveUserProfilePreference(
+          validUserId,
+          null as unknown as USER_PROFILES
+        );
+
+        expect(result).toBe(false);
+        expect(console.error).toHaveBeenCalled();
+      });
+
+      it('returns false if preference is undefined', () => {
+        const result = saveUserProfilePreference(
+          validUserId,
+          undefined as unknown as USER_PROFILES
+        );
+
+        expect(result).toBe(false);
+        expect(console.error).toHaveBeenCalled();
+      });
+
+      it('returns false if preference is not a valid USER_PROFILES value', () => {
+        const result = saveUserProfilePreference(
+          validUserId,
+          'invalidPreference' as USER_PROFILES
+        );
+
+        expect(result).toBe(false);
+        expect(console.error).toHaveBeenCalled();
+        expect(
+          localStorage.getItem(`userProfilePreference_${validUserId}`)
+        ).toBeNull();
+      });
+    });
+
+    describe('error handling', () => {
+      it('handles errors correctly during save (quota exceeded)', () => {
+        const setItemSpy = vi
+          .spyOn(localStorage, 'setItem')
+          .mockImplementation(quotaExceededThrower);
+
+        const result = saveUserProfilePreference(validUserId, validPreference);
+
+        expect(result).toBe(false);
+        expect(console.error).toHaveBeenCalled();
+
+        setItemSpy.mockRestore();
+      });
+
+      it('handles generic errors correctly during save', () => {
+        const setItemSpy = vi
+          .spyOn(localStorage, 'setItem')
+          .mockImplementation(storageDisabledThrower);
+
+        const result = saveUserProfilePreference(validUserId, validPreference);
+
+        expect(result).toBe(false);
+        expect(console.error).toHaveBeenCalled();
+
+        setItemSpy.mockRestore();
+      });
+    });
+  });
+
+  describe('getUserProfilePreference', () => {
+    const validUserId = 'user-123';
+
+    it('retrieves a saved preference correctly', () => {
+      const preference = USER_PROFILES.DP;
+      localStorage.setItem(`userProfilePreference_${validUserId}`, preference);
+
+      const result = getUserProfilePreference(validUserId);
+
+      expect(result).toBe(preference);
+    });
+
+    it('retrieves all valid preferences correctly', () => {
+      const preferences = [
+        USER_PROFILES.DP,
+        USER_PROFILES.TM,
+        USER_PROFILES.OM
+      ];
+
+      for (let index = 0; index < preferences.length; index += 1) {
+        const pref = preferences[index];
+        const userId = `user-${index}`;
+        localStorage.setItem(`userProfilePreference_${userId}`, pref);
+
+        const result = getUserProfilePreference(userId);
+        expect(result).toBe(pref);
+      }
+    });
+
+    it('returns null if preference does not exist', () => {
+      const result = getUserProfilePreference(validUserId);
+
+      expect(result).toBeNull();
+    });
+
+    it('removes and returns null if saved value is invalid', () => {
+      const invalidValue = 'invalidPreference';
+      localStorage.setItem(
+        `userProfilePreference_${validUserId}`,
+        invalidValue
+      );
+
+      const result = getUserProfilePreference(validUserId);
+
+      expect(result).toBeNull();
+      expect(console.warn).toHaveBeenCalled();
+      expect(
+        localStorage.getItem(`userProfilePreference_${validUserId}`)
+      ).toBeNull();
+    });
+
+    describe('input validation', () => {
+      it('returns null if mappedExternalUserId is empty', () => {
+        const result = getUserProfilePreference('');
+
+        expect(result).toBeNull();
+        expect(console.error).toHaveBeenCalled();
+      });
+
+      it('returns null if mappedExternalUserId is null', () => {
+        const result = getUserProfilePreference(null as unknown as string);
+
+        expect(result).toBeNull();
+        expect(console.error).toHaveBeenCalled();
+      });
+
+      it('returns null if mappedExternalUserId is undefined', () => {
+        const result = getUserProfilePreference(undefined as unknown as string);
+
+        expect(result).toBeNull();
+        expect(console.error).toHaveBeenCalled();
+      });
+
+      it('returns null if mappedExternalUserId is not a string', () => {
+        const result = getUserProfilePreference(123 as unknown as string);
+
+        expect(result).toBeNull();
+        expect(console.error).toHaveBeenCalled();
+      });
+    });
+
+    describe('error handling', () => {
+      it('handles errors correctly during retrieval', () => {
+        const getItemSpy = vi
+          .spyOn(localStorage, 'getItem')
+          .mockImplementation(genericStorageErrorThrower);
+
+        const result = getUserProfilePreference(validUserId);
+
+        expect(result).toBeNull();
+        expect(console.error).toHaveBeenCalled();
+
+        getItemSpy.mockRestore();
+      });
+    });
+  });
+
+  describe('removeUserProfilePreference', () => {
+    const validUserId = 'user-123';
+    const validPreference = USER_PROFILES.DP;
+
+    it('removes an existing preference correctly', () => {
+      localStorage.setItem(
+        `userProfilePreference_${validUserId}`,
+        validPreference
+      );
+      expect(localStorage.getItem(`userProfilePreference_${validUserId}`)).toBe(
+        validPreference
+      );
+
+      const result = removeUserProfilePreference(validUserId);
+
+      expect(result).toBe(true);
+      expect(
+        localStorage.getItem(`userProfilePreference_${validUserId}`)
+      ).toBeNull();
+    });
+
+    it('returns true even if preference does not exist', () => {
+      const result = removeUserProfilePreference(validUserId);
+
+      expect(result).toBe(true);
+      expect(
+        localStorage.getItem(`userProfilePreference_${validUserId}`)
+      ).toBeNull();
+    });
+
+    describe('input validation', () => {
+      it('returns false if mappedExternalUserId is empty', () => {
+        const result = removeUserProfilePreference('');
+
+        expect(result).toBe(false);
+        expect(console.error).toHaveBeenCalled();
+      });
+
+      it('returns false if mappedExternalUserId is null', () => {
+        const result = removeUserProfilePreference(null as unknown as string);
+
+        expect(result).toBe(false);
+        expect(console.error).toHaveBeenCalled();
+      });
+
+      it('returns false if mappedExternalUserId is undefined', () => {
+        const result = removeUserProfilePreference(
+          undefined as unknown as string
+        );
+
+        expect(result).toBe(false);
+        expect(console.error).toHaveBeenCalled();
+      });
+
+      it('returns false if mappedExternalUserId is not a string', () => {
+        const result = removeUserProfilePreference(123 as unknown as string);
+
+        expect(result).toBe(false);
+        expect(console.error).toHaveBeenCalled();
+      });
+    });
+
+    describe('error handling', () => {
+      it('handles errors correctly during removal', () => {
+        const removeItemSpy = vi
+          .spyOn(localStorage, 'removeItem')
+          .mockImplementation(genericStorageErrorThrower);
+
+        const result = removeUserProfilePreference(validUserId);
+
+        expect(result).toBe(false);
+        expect(console.error).toHaveBeenCalled();
+
+        removeItemSpy.mockRestore();
+      });
+    });
+  });
+
+  describe('function integration', () => {
+    const validUserId = 'user-integration-test';
+
+    it('saves, retrieves and removes a preference correctly', () => {
+      const preference = USER_PROFILES.OM;
+
+      const saveResult = saveUserProfilePreference(validUserId, preference);
+      expect(saveResult).toBe(true);
+
+      const getResult = getUserProfilePreference(validUserId);
+      expect(getResult).toBe(preference);
+
+      const removeResult = removeUserProfilePreference(validUserId);
+      expect(removeResult).toBe(true);
+
+      const getAfterRemove = getUserProfilePreference(validUserId);
+      expect(getAfterRemove).toBeNull();
+    });
+
+    it('handles multiple users with different preferences correctly', () => {
+      const users = [
+        { id: 'user-1', pref: USER_PROFILES.DP },
+        { id: 'user-2', pref: USER_PROFILES.TM },
+        { id: 'user-3', pref: USER_PROFILES.OM }
+      ];
+
+      for (const { id, pref } of users) {
+        const result = saveUserProfilePreference(id, pref);
+        expect(result).toBe(true);
+      }
+
+      for (const { id, pref } of users) {
+        const result = getUserProfilePreference(id);
+        expect(result).toBe(pref);
+      }
+
+      for (const { id } of users) {
+        const result = removeUserProfilePreference(id);
+        expect(result).toBe(true);
+      }
+
+      for (const { id } of users) {
+        const result = getUserProfilePreference(id);
+        expect(result).toBeNull();
+      }
+    });
+  });
+});

--- a/src/utils/userPreferences.ts
+++ b/src/utils/userPreferences.ts
@@ -1,0 +1,176 @@
+/**
+ * Utility to manage user preferences in localStorage
+ *
+ * This utility manages the saving and retrieval of user preferences
+ * associated with the user's mappedExternalUserId.
+ * Preferences are saved in localStorage with a unique key
+ * based on the user's mappedExternalUserId.
+ */
+
+import { USER_PROFILES } from '../routes/Home/models';
+
+/**
+ * Type for the user profile preference
+ * Rappresenta uno dei valori validi dell'enum USER_PROFILES
+ */
+export type UserProfilePreference = USER_PROFILES;
+
+/**
+ * Base key used to build the localStorage key
+ * Final format: `userProfilePreference_${mappedExternalUserId}`
+ */
+const STORAGE_KEY_PREFIX = 'userProfilePreference_';
+
+/**
+ * Builds the localStorage key for a specific user
+ *
+ * @param mappedExternalUserId - The external mapped userId
+ * @returns The complete key for the localStorage
+ */
+const buildStorageKey = (mappedExternalUserId: string): string => {
+  return `${STORAGE_KEY_PREFIX}${mappedExternalUserId}`;
+};
+
+/**
+ * Saves the user profile preference in localStorage
+ *
+ * The preference is saved associated with the user's mappedExternalUserId.
+ * In case of error during saving, the error is logged
+ * but no exception is thrown to not interrupt the application flow.
+ *
+ * @param mappedExternalUserId - The external mapped userId (required)
+ * @param preference - The user profile preference selected by the user
+ * @returns true if the saving was completed successfully, false otherwise
+ *
+ * @example
+ * ```typescript
+ * saveUserProfilePreference('user-123', USER_PROFILES.DP);
+ * ```
+ */
+export const saveUserProfilePreference = (
+  mappedExternalUserId: string,
+  preference: UserProfilePreference
+): boolean => {
+  if (!mappedExternalUserId || typeof mappedExternalUserId !== 'string') {
+    console.error(
+      'saveUserProfilePreference: mappedExternalUserId must be a non-empty string'
+    );
+    return false;
+  }
+
+  if (!preference || !Object.values(USER_PROFILES).includes(preference)) {
+    console.error(
+      'saveUserProfilePreference: preference must be a valid value of USER_PROFILES'
+    );
+    return false;
+  }
+
+  try {
+    const storageKey = buildStorageKey(mappedExternalUserId);
+    localStorage.setItem(storageKey, preference);
+    return true;
+  } catch (error) {
+    // Common error handling (quota exceeded, storage disabled, etc.)
+    console.error(
+      'Error during saving the user profile preference in localStorage:',
+      error
+    );
+    return false;
+  }
+};
+
+/**
+ * Retrieves the user profile preference from localStorage
+ *
+ * @param mappedExternalUserId - The external mapped userId
+ * @returns The saved preference or null if not present or in case of error
+ *
+ * @example
+ * ```typescript
+ * const preference = getUserProfilePreference('user-123');
+ * if (preference) {
+ *   console.log('Preference found:', preference);
+ * }
+ * ```
+ */
+export const getUserProfilePreference = (
+  mappedExternalUserId: string
+): UserProfilePreference | null => {
+  if (!mappedExternalUserId || typeof mappedExternalUserId !== 'string') {
+    console.error(
+      'getUserProfilePreference: mappedExternalUserId must be a non-empty string'
+    );
+    return null;
+  }
+
+  try {
+    const storageKey = buildStorageKey(mappedExternalUserId);
+    const storedValue = localStorage.getItem(storageKey);
+
+    if (!storedValue) {
+      return null;
+    }
+
+    // Validation that the retrieved value is a valid value of USER_PROFILES
+    if (
+      Object.values(USER_PROFILES).includes(
+        storedValue as UserProfilePreference
+      )
+    ) {
+      return storedValue as UserProfilePreference;
+    }
+
+    // If the value is not valid, log a warning and remove the corrupted value
+    console.warn(
+      `Invalid value found in localStorage for the key ${storageKey}: ${storedValue}. The value will be removed.`
+    );
+    localStorage.removeItem(storageKey);
+    return null;
+  } catch (error) {
+    console.error(
+      'Error during retrieval of the user profile preference from localStorage:',
+      error
+    );
+    return null;
+  }
+};
+
+/**
+ * Removes the user profile preference from localStorage
+ *
+ * @param mappedExternalUserId - The external mapped userId
+ * @returns true if the removal was completed successfully, false otherwise
+ *
+ * @example
+ * ```typescript
+ * removeUserProfilePreference('user-123');
+ * ```
+ */
+export const removeUserProfilePreference = (
+  mappedExternalUserId: string
+): boolean => {
+  if (!mappedExternalUserId || typeof mappedExternalUserId !== 'string') {
+    console.error(
+      'removeUserProfilePreference: mappedExternalUserId must be a non-empty string'
+    );
+    return false;
+  }
+
+  try {
+    const storageKey = buildStorageKey(mappedExternalUserId);
+    localStorage.removeItem(storageKey);
+    return true;
+  } catch (error) {
+    console.error(
+      'Error during removal of the user profile preference from localStorage:',
+      error
+    );
+    return false;
+  }
+};
+
+export default {
+  saveUserProfilePreference,
+  getUserProfilePreference,
+  removeUserProfilePreference
+};

--- a/src/utils/userPreferences.ts
+++ b/src/utils/userPreferences.ts
@@ -17,9 +17,9 @@ export type UserProfilePreference = USER_PROFILES;
 
 /**
  * Base key used to build the localStorage key
- * Final format: `userProfilePreference_${mappedExternalUserId}`
+ * Final format: `userProfilePreference:${mappedExternalUserId}`
  */
-const STORAGE_KEY_PREFIX = 'userProfilePreference_';
+const STORAGE_KEY_PREFIX = 'userProfilePreference:';
 
 /**
  * Builds the localStorage key for a specific user


### PR DESCRIPTION
 Implement user profile preference persistence in localStorage

- Add userPreferences utility to manage user profile preferences in localStorage
  - Implement saveUserProfilePreference to persist user selection
  - Implement getUserProfilePreference to retrieve saved preference
  - Implement removeUserProfilePreference for cleanup
  - Associate preferences with mappedExternalUserId from userInfo

- Integrate preference saving in Home component
  - Save preference on "Continue" button click in profile selection dialog
  - Save preference on "Close" button click to persist user choice
  - Add persistUserProfilePreference helper function to avoid code duplication

- Add unit tests for userPreferences utility

The preference is saved with key format: userProfilePreference_{mappedExternalUserId}


#### How Has This Been Tested?

-visual testing
-unit tests


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
