### PR TITLE
feat: [P4ADEV-4253] imported due flow expose cta and fetch file

### DIFF
--- a/src/api/ingestionFlowFiles/index.ts
+++ b/src/api/ingestionFlowFiles/index.ts
@@ -91,3 +91,42 @@ export const getIngestionFlowFileError = (organizationId: number) =>
       return { data: response.data, fileName };
     }
   });
+
+/** returns a mutation to get the ingestion flow IUV file blob */
+export const getIngestionFlowFileIuv = (organizationId: number) =>
+  useMutation({
+    mutationKey: ['getIngestionFlowFileIuv', organizationId],
+    mutationFn: async (ingestionFlowFileId: number) => {
+      const response = await utils.fileshareClient.organization.downloadIuvFile(
+        organizationId,
+        ingestionFlowFileId,
+        { format: 'blob' }
+      );
+
+      const contentDisposition = response.headers['content-disposition'] || '';
+      const fileName =
+        extractFilename(contentDisposition) || `iuv-${ingestionFlowFileId}`;
+
+      return { data: response.data, fileName };
+    }
+  });
+
+/** returns a mutation to get the ingestion flow notice file blob (ZIP with PDF avvisi) */
+export const getIngestionFlowFileNotice = (organizationId: number) =>
+  useMutation({
+    mutationKey: ['getIngestionFlowFileNotice', organizationId],
+    mutationFn: async (ingestionFlowFileId: number) => {
+      const response = await utils.fileshareClient.organization.downloadNotice(
+        organizationId,
+        ingestionFlowFileId,
+        { format: 'blob' }
+      );
+
+      const contentDisposition = response.headers['content-disposition'] || '';
+      const fileName =
+        extractFilename(contentDisposition) ||
+        `notice-${ingestionFlowFileId}.zip`;
+
+      return { data: response.data, fileName };
+    }
+  });

--- a/src/api/ingestionFlowFiles/ingestionFlowFiles.test.ts
+++ b/src/api/ingestionFlowFiles/ingestionFlowFiles.test.ts
@@ -3,6 +3,8 @@ import { act, renderHook } from '../../__tests__/renderers';
 import {
   getIngestionFlowFiles,
   getIngestionFlowFile,
+  getIngestionFlowFileIuv,
+  getIngestionFlowFileNotice,
   uploadIngestionFlowFile
 } from './';
 import {
@@ -24,7 +26,9 @@ vi.mock('../../utils', () => ({
     fileshareClient: {
       organization: {
         uploadIngestionFlowFile: vi.fn(),
-        downloadIngestionFlowFile: vi.fn()
+        downloadIngestionFlowFile: vi.fn(),
+        downloadIuvFile: vi.fn(),
+        downloadNotice: vi.fn()
       }
     },
     formatters: {
@@ -49,6 +53,14 @@ const mockUploadIngestionFlowFile = vi.mocked(
 
 const mockDownloadIngestionFlowFile = vi.mocked(
   utils.fileshareClient.organization.downloadIngestionFlowFile
+);
+
+const mockDownloadIuvFile = vi.mocked(
+  utils.fileshareClient.organization.downloadIuvFile
+);
+
+const mockDownloadNotice = vi.mocked(
+  utils.fileshareClient.organization.downloadNotice
 );
 
 const mockExtractFilename = vi.mocked(formatters.extractFilename);
@@ -223,5 +235,168 @@ describe('getIngestionFlowFile', () => {
     });
 
     expect(mockExtractFilename).toHaveBeenCalledWith('');
+  });
+});
+
+describe('getIngestionFlowFileIuv', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExtractFilename.mockImplementation((header) => {
+      if (header.includes('iuv-file.csv')) {
+        return 'iuv-file.csv';
+      }
+      return null;
+    });
+  });
+
+  it('returns blob and filename from response with content-disposition header', async () => {
+    const mockFileData = new Blob(['iuv data'], { type: 'text/plain' });
+    const mockFileName = 'iuv-file.csv';
+
+    mockDownloadIuvFile.mockResolvedValueOnce({
+      data: mockFileData,
+      headers: {
+        'content-disposition': `attachment; filename="${mockFileName}"`
+      }
+    } as unknown as AxiosResponse);
+
+    const { result } = renderHook(() => getIngestionFlowFileIuv(123));
+
+    await act(async () => {
+      const response = await result.current.mutateAsync(789);
+      expect(response).toEqual({ data: mockFileData, fileName: mockFileName });
+    });
+
+    expect(mockDownloadIuvFile).toHaveBeenCalledWith(123, 789, {
+      format: 'blob'
+    });
+
+    expect(mockExtractFilename).toHaveBeenCalledWith(
+      `attachment; filename="${mockFileName}"`
+    );
+  });
+
+  it('uses default filename when content-disposition header is missing', async () => {
+    const mockFileData = new Blob(['iuv data'], { type: 'text/plain' });
+
+    mockDownloadIuvFile.mockResolvedValueOnce({
+      data: mockFileData,
+      headers: {}
+    } as unknown as AxiosResponse);
+
+    mockExtractFilename.mockReturnValueOnce(null);
+    const { result } = renderHook(() => getIngestionFlowFileIuv(123));
+
+    await act(async () => {
+      const response = await result.current.mutateAsync(789);
+      expect(response).toEqual({ data: mockFileData, fileName: 'iuv-789' });
+    });
+
+    expect(mockDownloadIuvFile).toHaveBeenCalledWith(123, 789, {
+      format: 'blob'
+    });
+
+    expect(mockExtractFilename).toHaveBeenCalledWith('');
+  });
+
+  it('handles download error', async () => {
+    const mockError = new Error('Download failed');
+
+    mockDownloadIuvFile.mockRejectedValueOnce(mockError);
+
+    const { result } = renderHook(() => getIngestionFlowFileIuv(123));
+
+    await act(async () => {
+      await result.current.mutateAsync(789).catch((error) => {
+        expect(error).toBe(mockError);
+      });
+    });
+
+    expect(mockDownloadIuvFile).toHaveBeenCalledWith(123, 789, {
+      format: 'blob'
+    });
+  });
+});
+
+describe('getIngestionFlowFileNotice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExtractFilename.mockImplementation((header) => {
+      if (header.includes('notice-file.zip')) {
+        return 'notice-file.zip';
+      }
+      return null;
+    });
+  });
+
+  it('returns blob and filename from response with content-disposition header', async () => {
+    const mockFileData = new Blob(['notice data'], { type: 'application/zip' });
+    const mockFileName = 'notice-file.zip';
+
+    mockDownloadNotice.mockResolvedValueOnce({
+      data: mockFileData,
+      headers: {
+        'content-disposition': `attachment; filename="${mockFileName}"`
+      }
+    } as unknown as AxiosResponse);
+
+    const { result } = renderHook(() => getIngestionFlowFileNotice(123));
+
+    await act(async () => {
+      const response = await result.current.mutateAsync(101);
+      expect(response).toEqual({ data: mockFileData, fileName: mockFileName });
+    });
+
+    expect(mockDownloadNotice).toHaveBeenCalledWith(123, 101, {
+      format: 'blob'
+    });
+
+    expect(mockExtractFilename).toHaveBeenCalledWith(
+      `attachment; filename="${mockFileName}"`
+    );
+  });
+
+  it('uses default filename when content-disposition header is missing', async () => {
+    const mockFileData = new Blob(['notice data'], { type: 'application/zip' });
+
+    mockDownloadNotice.mockResolvedValueOnce({
+      data: mockFileData,
+      headers: {}
+    } as unknown as AxiosResponse);
+
+    mockExtractFilename.mockReturnValueOnce(null);
+    const { result } = renderHook(() => getIngestionFlowFileNotice(123));
+
+    await act(async () => {
+      const response = await result.current.mutateAsync(101);
+      expect(response).toEqual({
+        data: mockFileData,
+        fileName: 'notice-101.zip'
+      });
+    });
+
+    expect(mockDownloadNotice).toHaveBeenCalledWith(123, 101, {
+      format: 'blob'
+    });
+
+    expect(mockExtractFilename).toHaveBeenCalledWith('');
+  });
+
+  it('handles download error', async () => {
+    const mockError = new Error('Download failed');
+
+    mockDownloadNotice.mockRejectedValueOnce(mockError);
+
+    const { result } = renderHook(() => getIngestionFlowFileNotice(123));
+
+    await act(async () => {
+      await result.current.mutateAsync(101).catch((error) => {
+        expect(error).toBe(mockError);
+      });
+    });
+
+    expect(mockDownloadNotice).toHaveBeenCalledWith(123, 101, {
+      format: 'blob'
+    });
   });
 });

--- a/src/components/ImportFlowOverview/ImportFlowOverview.test.tsx
+++ b/src/components/ImportFlowOverview/ImportFlowOverview.test.tsx
@@ -4,7 +4,9 @@ import { useNavigate, generatePath, useSearchParams } from 'react-router';
 import {
   getIngestionFlowFiles,
   getIngestionFlowFile,
-  getIngestionFlowFileError
+  getIngestionFlowFileError,
+  getIngestionFlowFileIuv,
+  getIngestionFlowFileNotice
 } from '../../api/ingestionFlowFiles';
 import { setOrganizationId } from '../../store/OrganizationIdStore';
 import { PageRoutes } from '../../routes';
@@ -43,6 +45,8 @@ vi.mock('../../api/ingestionFlowFiles', () => ({
   getIngestionFlowFiles: vi.fn().mockReturnValue({ data: { content: [] } }),
   getIngestionFlowFileError: vi.fn(),
   getIngestionFlowFile: vi.fn(),
+  getIngestionFlowFileIuv: vi.fn(),
+  getIngestionFlowFileNotice: vi.fn(),
   IngestionFlowFileType: {
     RECEIPT: 'RECEIPT',
     RECEIPT_PAGOPA: 'RECEIPT_PAGOPA',
@@ -220,7 +224,6 @@ vi.mock('../../hooks/useSearch', () => ({
         number: 0
       },
       isPending: false,
-      isLoading: false,
       error: null,
       isError: false,
       mutateAsync: mockMutateAsync
@@ -246,11 +249,31 @@ const getIngestionFlowFileErrorMock = {
   })
 };
 
+const getIngestionFlowFileIuvMock = {
+  mutateAsync: mockDownloadMutateAsync.mockResolvedValue({
+    data: new Blob(['iuv file content']),
+    fileName: 'iuv-file.csv'
+  })
+};
+
+const getIngestionFlowFileNoticeMock = {
+  mutateAsync: mockDownloadMutateAsync.mockResolvedValue({
+    data: new Blob(['notice file content']),
+    fileName: 'notice-file.zip'
+  })
+};
+
 (getIngestionFlowFile as Mock).mockImplementation(
   () => getIngestionFlowFileMock
 );
 (getIngestionFlowFileError as Mock).mockImplementation(
   () => getIngestionFlowFileErrorMock
+);
+(getIngestionFlowFileIuv as Mock).mockImplementation(
+  () => getIngestionFlowFileIuvMock
+);
+(getIngestionFlowFileNotice as Mock).mockImplementation(
+  () => getIngestionFlowFileNoticeMock
 );
 
 describe('ImportFlowOverview Component', () => {

--- a/src/components/ImportFlowOverview/ImportFlowOverview.tsx
+++ b/src/components/ImportFlowOverview/ImportFlowOverview.tsx
@@ -21,6 +21,8 @@ import {
 import {
   getIngestionFlowFile,
   getIngestionFlowFileError,
+  getIngestionFlowFileIuv,
+  getIngestionFlowFileNotice,
   getIngestionFlowFiles
 } from '../../api/ingestionFlowFiles';
 import {
@@ -90,6 +92,12 @@ const ImportFlowOverview = ({
 
   const getIngestionFlowFileMutation = getIngestionFlowFile(organizationId);
 
+  const getIngestionFlowFileIuvMutation =
+    getIngestionFlowFileIuv(organizationId);
+
+  const getIngestionFlowFileNoticeMutation =
+    getIngestionFlowFileNotice(organizationId);
+
   const handleDownloadFile = async (ingestionFlowFileId: number) => {
     try {
       const { data, fileName } =
@@ -114,6 +122,30 @@ const ImportFlowOverview = ({
     }
   };
 
+  const handleDownloadIuvFile = async (ingestionFlowFileId: number) => {
+    try {
+      const { data, fileName } =
+        await getIngestionFlowFileIuvMutation.mutateAsync(ingestionFlowFileId);
+      downloadBlob(data, fileName);
+    } catch (error) {
+      console.error(error);
+      utils.notify.emit(t('FileUploaderFlowImport.error.errorFlowFile'));
+    }
+  };
+
+  const handleDownloadNoticeFile = async (ingestionFlowFileId: number) => {
+    try {
+      const { data, fileName } =
+        await getIngestionFlowFileNoticeMutation.mutateAsync(
+          ingestionFlowFileId
+        );
+      downloadBlob(data, fileName);
+    } catch (error) {
+      console.error(error);
+      utils.notify.emit(t('FileUploaderFlowImport.error.errorFlowFile'));
+    }
+  };
+
   const handleImportFlow = () => {
     navigate(
       generatePath(PageRoutes.IMPORT_FLOWS, {
@@ -122,8 +154,47 @@ const ImportFlowOverview = ({
     );
   };
 
+  /**
+   * Checks if the export CTAs (IUV and ZIP avvisi) should be shown.
+   * The CTAs are available only for DP_INSTALLMENTS flows and are shown if:
+   * - The status is COMPLETED (ELABORATO), or
+   * - The status is WARNING (ELABORATO CON ERRORI) and the correctly imported rows count is greater than 0
+   *
+   * @param status - The status of the import flow
+   * @param correctlyImportedRows - The number of correctly imported rows (optional)
+   * @returns true if the CTAs should be shown, false otherwise
+   */
+  const shouldShowExportCTAs = (
+    status: string,
+    correctlyImportedRows?: number
+  ): boolean => {
+    // The CTAs are available only for DP_INSTALLMENTS flows
+    const isDebtPositionsFlow = ingestionFlowFileTypes.includes(
+      IngestionFlowFileTypeEnum.DP_INSTALLMENTS
+    );
+
+    if (!isDebtPositionsFlow) {
+      return false;
+    }
+
+    if (status === 'COMPLETED') {
+      return true;
+    }
+
+    if (status === 'WARNING') {
+      return (correctlyImportedRows ?? 0) > 0;
+    }
+
+    return false;
+  };
+
   const renderActionCell = (params: GridRenderCellParams) => {
-    const { ingestionFlowFileId, status, discardFileName } = params.row;
+    const {
+      ingestionFlowFileId,
+      status,
+      discardFileName,
+      correctlyImportedRows
+    } = params.row;
 
     if (MENU_STATES.includes(status)) {
       const menuItems = [
@@ -143,6 +214,21 @@ const ImportFlowOverview = ({
           icon: <DownloadIcon fontSize="small" color="primary" />,
           label: t('commons.files.importedResult'),
           action: () => handleDownloadFileError(ingestionFlowFileId)
+        });
+      }
+
+      // Add the export CTAs (IUV and ZIP avvisi) if the conditions are met
+      if (shouldShowExportCTAs(status, correctlyImportedRows)) {
+        menuItems.push({
+          icon: <DownloadIcon fontSize="small" color="primary" />,
+          label: t('commons.files.importedIuv'),
+          action: () => handleDownloadIuvFile(ingestionFlowFileId)
+        });
+
+        menuItems.push({
+          icon: <DownloadIcon fontSize="small" color="primary" />,
+          label: t('commons.files.importedNotice'),
+          action: () => handleDownloadNoticeFile(ingestionFlowFileId)
         });
       }
 

--- a/src/routes/DebtPositionsImportOverview/index.test.tsx
+++ b/src/routes/DebtPositionsImportOverview/index.test.tsx
@@ -38,6 +38,14 @@ vi.mock('../../api/ingestionFlowFiles', () => ({
   getIngestionFlowFileError: vi.fn(() => ({
     mutate: vi.fn(),
     mutateAsync: vi.fn()
+  })),
+  getIngestionFlowFileIuv: vi.fn(() => ({
+    mutate: vi.fn(),
+    mutateAsync: vi.fn()
+  })),
+  getIngestionFlowFileNotice: vi.fn(() => ({
+    mutate: vi.fn(),
+    mutateAsync: vi.fn()
   }))
 }));
 

--- a/src/routes/TreasuryImportFlowOverview/index.test.tsx
+++ b/src/routes/TreasuryImportFlowOverview/index.test.tsx
@@ -36,6 +36,12 @@ vi.mock('../../api/ingestionFlowFiles', () => ({
   getIngestionFlowFileError: vi.fn(() => ({
     mutateAsync: vi.fn()
   })),
+  getIngestionFlowFileIuv: vi.fn(() => ({
+    mutateAsync: vi.fn()
+  })),
+  getIngestionFlowFileNotice: vi.fn(() => ({
+    mutateAsync: vi.fn()
+  })),
   uploadIngestionFlowFile: vi.fn(() => ({
     mutateAsync: vi.fn()
   }))

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -760,6 +760,8 @@
       "file": "File",
       "imported": "File importato",
       "importedResult": "Esito dell'importazione",
+      "importedIuv": "Esportazione IUV caricati",
+      "importedNotice": "Esportazione ZIP file con avvisi PDF",
       "notvalid": "Il file non è valido",
       "remove": "Rimuovi file",
       "size": "Dimensione File",


### PR DESCRIPTION
Added debt-position export CTAs with fileshare downloads.

Implemented the conditional IUV/PDF export actions for imported debt-position flows and wired them to the fileshare APIs, ensuring the CTAs appear only when the backend actually provides those artifacts.

Main changes:
-Added getIngestionFlowFileIuv and getIngestionFlowFileNotice mutations, including new translation keys and download handlers.
-Updated ImportFlowOverview to inject the mutations, gate the new CTAs on status/flow-type (COMPLETED or WARNING with correctlyImportedRows > 0, only for DP_INSTALLMENTS), and hook the handlers into the action menu
-Improved action-menu render logic so the menu remains consistent for all eligible states


#### How Has This Been Tested?

-visual testing
-unit tests


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
