### PR TITLE
feat: [P4ADEV-4224] a11y widget home

### DIFF
--- a/src/components/GenericDialog/GenericDialog.tsx
+++ b/src/components/GenericDialog/GenericDialog.tsx
@@ -19,6 +19,8 @@ export type GenericDialogProps = {
   onConfirm?: () => void;
   onClose?: () => void;
   'data-testid'?: string;
+  ariaDescribedby?: string;
+  ariaLabelledby?: string;
 };
 
 const GenericDialog = ({
@@ -29,6 +31,8 @@ const GenericDialog = ({
   cancelLabel,
   children,
   fullWidth = false,
+  ariaDescribedby,
+  ariaLabelledby,
   onConfirm,
   onClose,
   'data-testid': testId
@@ -39,8 +43,10 @@ const GenericDialog = ({
       onClose={onClose}
       fullWidth={fullWidth}
       data-testid={testId}
+      aria-describedby={ariaDescribedby}
+      aria-labelledby={ariaLabelledby || "generic-dialog-title"}
     >
-      <DialogTitle sx={{ px: 4, pt: 4 }}>{title}</DialogTitle>
+      <DialogTitle sx={{ px: 4, pt: 4 }} id="generic-dialog-title">{title}</DialogTitle>
       <DialogContent sx={{ px: 4 }}>
         {message && <DialogContentText>{message}</DialogContentText>}
         {children}

--- a/src/routes/Home/index.tsx
+++ b/src/routes/Home/index.tsx
@@ -364,14 +364,15 @@ const Home = () => {
         fullWidth={true}
         onConfirm={userProfileConfirmChange}
         onClose={userProfileCancelChange}
+        ariaDescribedby="home-choose-widget-description"
       >
-        <Typography variant="body1" mb={2}>
+        <Typography variant="body1" mb={2} id="home-choose-widget-description">
           {t('home.chooseWidget.message')}
         </Typography>
         <Box my={{ xs: 1, sm: 2 }}>
           <FormControl>
             <RadioGroup
-              aria-label={t('home.chooseWidget.title')}
+              aria-label={t('home.chooseWidget.listDescription')}
               name="chooseprofile"
               defaultValue={defaultUserProfile}
               value={radioValue}

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -1850,6 +1850,7 @@
       "title": "Scegli la tua attività principale",
       "closingText": "Potrai modificare la tua scelta in qualsiasi momento.",
       "message": "Scegli un profilo che rispecchi le tue attività quotidiane per accedere a contenuti e funzioni su misura per te.",
+      "listDescription": "Lista dei profili disponibili",
       "profiles": {
         "debtpositionsManager": {
           "title": "Gestore delle Posizioni Debitorie",


### PR DESCRIPTION
Enhance screen-reader capability when in home and with the "choose widget modal" showed

#### List of Changes
- Add aria attributes in the right place
- add more descriptive label 
- 
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
