### PR TITLE
feat: [P4ADEV-4200] Handle 409 error with a toast for import flows

### DIFF
--- a/src/components/ImportFlowPage/ImportFlowPage.test.tsx
+++ b/src/components/ImportFlowPage/ImportFlowPage.test.tsx
@@ -180,6 +180,50 @@ describe('ImportFlow', () => {
       });
     });
 
+    it('handles 409 error by showing specific notification without navigating', async () => {
+      const mockError = {
+        response: {
+          status: 409
+        }
+      };
+
+      mockUploadMutate.mockImplementation((_file, options) => {
+        options.onError(mockError);
+      });
+
+      render(<ImportFlow />);
+
+      const file = new File(['content'], 'test1_2.zip', {
+        type: 'application/zip'
+      });
+      const dropZone = screen.getByTestId('drop-zone');
+
+      fireEvent.dragOver(dropZone);
+      fireEvent.drop(dropZone, {
+        dataTransfer: {
+          files: [file]
+        }
+      });
+
+      await vi.waitFor(() =>
+        expect(screen.getAllByText('test1_2.zip')).toBeDefined()
+      );
+
+      const successButton = screen.getByTestId('success-button');
+      fireEvent.click(successButton);
+
+      await waitFor(() => {
+        expect(mockNotifyEmit).toHaveBeenCalledWith(
+          'commons.files.alreadyExists',
+          'error'
+        );
+        expect(mockNavigate).not.toHaveBeenCalledWith(
+          PageRoutes.RESPONSES_ERROR,
+          expect.anything()
+        );
+      });
+    });
+
     it('handles network error by showing notification', async () => {
       const mockError = new Error('Network Error');
 

--- a/src/components/ImportFlowPage/ImportFlowPage.tsx
+++ b/src/components/ImportFlowPage/ImportFlowPage.tsx
@@ -60,14 +60,7 @@ const ImportFlow = () => {
           ? error.response?.status
           : undefined;
 
-        if (statusCode && statusCode > 400 && statusCode < 500) {
-          navigate(PageRoutes.RESPONSES_ERROR, {
-            state: {
-              category: config.category,
-              statusCode
-            }
-          });
-        } else if (statusCode && statusCode === 400) {
+        if (statusCode === 400) {
           navigate(PageRoutes.RESPONSES_ERROR, {
             state: {
               category: config.category,
@@ -75,6 +68,15 @@ const ImportFlow = () => {
             }
           });
           utils.notify.emit(t('commons.files.missingVersion'));
+        } else if (statusCode === 409) {
+          utils.notify.emit(t('commons.files.alreadyExists'), 'error');
+        } else if (statusCode && statusCode > 400 && statusCode < 500) {
+          navigate(PageRoutes.RESPONSES_ERROR, {
+            state: {
+              category: config.category,
+              statusCode
+            }
+          });
         } else {
           utils.notify.emit(t('commons.importFlowErrorMessage'));
         }

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -771,7 +771,8 @@
       "downloadFailed": "Errore durante il download.",
       "missingIuv": "Manca il codice IUV o l'ID della posizione debitoria",
       "missingDebtPositionId": "Manca l'ID della posizione debitoria",
-      "missingVersion": "Il nome del file deve essere versionato, contenere un Numero_Numero se previsto."
+      "missingVersion": "Il nome del file deve essere versionato, contenere un Numero_Numero se previsto.",
+      "alreadyExists": "Esiste già un file caricato con questo nome. Modifica il nome del file e riprova."
     },
     "filters": {
       "accountingDate": {


### PR DESCRIPTION
Handled the HTTP 409 error during flow import: when uploading a file with the same name as one already imported, a clear toast message is shown instead of the generic error page.
The change applies to all import flows (telematic receipts, reporting, debt positions, treasury).

#### List of Changes

Translations:
Added a new key commons.files.alreadyExists in translations.json with a UX-friendly message for file name conflicts.

Error handling logic:
Updated the handleError function in ImportFlowPage.tsx to explicitly intercept status 409, display a toast with the new message, and prevent navigation to the generic error page.

Tests:
Added a Vitest unit test to verify that a 409 scenario shows the correct toast and does not navigate to the error page.

Coverage:
Confirmed that the new handling applies to all import categories using ImportFlowPage (telematic-receipt, reporting, debt-positions, treasury).

#### How Has This Been Tested?

-visual testing
-unit tests


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
