### PR TITLE
feat: [P4ADEV-4105] Set focus on main when navigate

### DIFF
--- a/src/components/RouteChangeAnnouncement/index.tsx
+++ b/src/components/RouteChangeAnnouncement/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router';
 
@@ -6,13 +6,24 @@ export const RouteChangeAnnouncement = () => {
   const location = useLocation();
   const { t } = useTranslation();
   const [message, setMessage] = useState('');
+  const isInitialMount = useRef(true);
 
   const updateMessage = () => {
     const page = document?.title.replace(/ - .+$/, ''); // Remove trailing app name
-    const newMessage = t('a11y.navigation.announcement', {
-      page
-    });
-    setMessage(newMessage);
+    const mainContent = document.getElementById('main-content');
+
+    // This IF is useful to set the focus only on route changes, not on the initial mount
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+    } else {
+      if (mainContent) {
+        mainContent.focus();
+      }
+      const newMessage = t('a11y.navigation.announcement', {
+        page
+      });
+      setMessage(newMessage);
+    }
   };
 
   useEffect(() => {

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -122,7 +122,7 @@ export function Layout() {
               xs={mainColumnWidth}
               paddingX={sidePadding}
               id="main-content"
-              tabIndex={0}
+              tabIndex={-1}
             >
               <Stack
                 direction="row"

--- a/src/style.css
+++ b/src/style.css
@@ -14,3 +14,7 @@
   left: 1rem;
   top: 1rem;
 }
+
+#main-content:focus {
+  outline: none;
+}


### PR DESCRIPTION
This PR adds a "listner" on the location API to intercept page change to set the focus on the main content (a11y feat)

#### List of Changes
- set a listner and an exception if is the first mount
- set a style none to the focus

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
