### PR TITLE
feat: [P4ADEV-4291] Drop FLAG_IUV_VOLATILE refs

### DIFF
--- a/src/hooks/useStep3ApiOperations.test.tsx
+++ b/src/hooks/useStep3ApiOperations.test.tsx
@@ -59,7 +59,6 @@ vi.mock('../models/Step3Schema', () => ({
 
 vi.mock('../utils/paymentUtility', () => ({
   DEFAULT_VALUES: {
-    FLAG_IUV_VOLATILE: false,
     MULTI_DEBTOR: false,
     FLAG_PAGO_PA_PU_PAYMENT: true,
     PAYMENT_OPTION_INDEX: 0

--- a/src/hooks/useStep3ApiOperations.tsx
+++ b/src/hooks/useStep3ApiOperations.tsx
@@ -180,7 +180,6 @@ export const useStep3ApiOperations = (): UseStep3ApiOperationsResult => {
       status: isDraft ? DebtPositionStatus.DRAFT : DebtPositionStatus.UNPAID,
       organizationId: organizationId,
       debtPositionTypeOrgId: Number(step1Data?.debtPositionType.value || 0),
-      flagIuvVolatile: DEFAULT_VALUES.FLAG_IUV_VOLATILE,
       debtPositionOrigin: DebtPositionOrigin.ORDINARY,
       multiDebtor: DEFAULT_VALUES.MULTI_DEBTOR,
       flagPuPagoPaPayment: DEFAULT_VALUES.FLAG_PAGO_PA_PU_PAYMENT,

--- a/src/utils/paymentUtility.ts
+++ b/src/utils/paymentUtility.ts
@@ -360,7 +360,6 @@ export function formatAmountForDisplay(value: string): string {
 
 // Default values
 export const DEFAULT_VALUES = {
-  FLAG_IUV_VOLATILE: false,
   MULTI_DEBTOR: false,
   FLAG_PAGO_PA_PU_PAYMENT: true,
   PAYMENT_OPTION_INDEX: 1


### PR DESCRIPTION
After an update on BFF services, the FLAG_IUV_VOLATILE is to drop in the FE.

#### List of Changes
- Drop references in some points

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
