### PR TITLE
feat: [P4ADEV-4286] debt position review debtor fields

### DIFF
--- a/src/hooks/useStep2Form.test.tsx
+++ b/src/hooks/useStep2Form.test.tsx
@@ -6,7 +6,6 @@ import { SubjectType } from '../utils/fieldValidation';
 import { TFunction } from 'i18next';
 import { z } from 'zod';
 
-// Mock react-i18next
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) => key
@@ -329,7 +328,7 @@ describe('useStep2Form', () => {
 
       await waitFor(() => {
         expect(result.current.errors.taxCode?.value?.message).toBe(
-          'debtPositionCreateWizard.step2.vat.required'
+          'debtPositionCreateWizard.step2.taxCodeBusiness.required'
         );
       });
     });

--- a/src/hooks/useStep2Form.tsx
+++ b/src/hooks/useStep2Form.tsx
@@ -115,10 +115,13 @@ export const useStep2Form = ({
     message: string,
     subjectType?: string
   ): string => {
-    // Customize taxCode errors for BUSINESS type (VAT instead of Tax Code)
+    // Customize taxCode errors for BUSINESS type (CF/P.IVA label)
     if (fieldName === 'taxCode' && subjectType === SubjectType.BUSINESS) {
       if (message === t('debtPositionCreateWizard.step2.taxCode.required')) {
-        return t('debtPositionCreateWizard.step2.vat.required');
+        return t('debtPositionCreateWizard.step2.taxCodeBusiness.required');
+      }
+      if (message === t('debtPositionCreateWizard.step2.taxCode.invalid')) {
+        return t('debtPositionCreateWizard.step2.taxCodeBusiness.invalid');
       }
     }
 

--- a/src/models/Step2AddDebtorSchema.ts
+++ b/src/models/Step2AddDebtorSchema.ts
@@ -58,31 +58,17 @@ export const createNestedStep2AddDebtorSchema = (t: TFunction) => {
       })
   );
 
-  const addressSchema = createFieldSchema(
-    z.string().nonempty(t('debtPositionCreateWizard.step2.address.required'))
-  );
+  const addressSchema = createFieldSchema(z.string());
 
-  const civicNumberSchema = createFieldSchema(
-    z
-      .string()
-      .nonempty(t('debtPositionCreateWizard.step2.civicNumber.required'))
-  );
+  const civicNumberSchema = createFieldSchema(z.string());
 
-  const zipCodeSchema = createFieldSchema(
-    z.string().nonempty(t('debtPositionCreateWizard.step2.zipCode.required'))
-  );
+  const zipCodeSchema = createFieldSchema(z.string());
 
-  const countrySchema = createFieldSchema(
-    z.string().nonempty(t('debtPositionCreateWizard.step2.country.required'))
-  );
+  const countrySchema = createFieldSchema(z.string());
 
-  const provinceSchema = createFieldSchema(
-    z.string().nonempty(t('debtPositionCreateWizard.step2.province.required'))
-  );
+  const provinceSchema = createFieldSchema(z.string());
 
-  const citySchema = createFieldSchema(
-    z.string().nonempty(t('debtPositionCreateWizard.step2.city.required'))
-  );
+  const citySchema = createFieldSchema(z.string());
 
   // Base schema for the entire object
   const schema = z.object({
@@ -110,12 +96,13 @@ export const createNestedStep2AddDebtorSchema = (t: TFunction) => {
       return taxCode != null && taxCode.trim().length > 0;
     },
     {
+      // Message will be customized in resolver based on subject type
       message: t('debtPositionCreateWizard.step2.taxCode.required'),
       path: ['taxCode', 'value']
     }
   );
 
-  // Validation for individuals
+  // Validation for individuals: only Codice Fiscale is allowed
   const individualSchema = taxCodeRequiredSchema.refine(
     (data) => {
       if (data.subjectType.value !== SubjectType.INDIVIDUAL) return true;
@@ -128,7 +115,7 @@ export const createNestedStep2AddDebtorSchema = (t: TFunction) => {
       // Skip validation if taxCode is undefined or empty (already handled by taxCodeRequiredSchema)
       if (!taxCode || taxCode.trim().length === 0) return true;
 
-      return isValidCodiceFiscale(taxCode) || isValidPartitaIVA(taxCode);
+      return isValidCodiceFiscale(taxCode);
     },
     {
       message: t('debtPositionCreateWizard.step2.taxCode.invalid'),
@@ -136,7 +123,7 @@ export const createNestedStep2AddDebtorSchema = (t: TFunction) => {
     }
   );
 
-  // Validation for businesses
+  // Validation for businesses: accept both CF and P.IVA, share same invalid message
   const businessSchema = individualSchema.refine(
     (data) => {
       if (data.subjectType.value !== SubjectType.BUSINESS) return true;
@@ -149,10 +136,10 @@ export const createNestedStep2AddDebtorSchema = (t: TFunction) => {
       // Skip validation if taxCode is undefined or empty (already handled by taxCodeRequiredSchema)
       if (!taxCode || taxCode.trim().length === 0) return true;
 
-      return isValidPartitaIVA(taxCode);
+      return isValidCodiceFiscale(taxCode) || isValidPartitaIVA(taxCode);
     },
     {
-      message: t('debtPositionCreateWizard.step2.taxCode.invalidVAT'),
+      message: t('debtPositionCreateWizard.step2.taxCodeBusiness.invalid'),
       path: ['taxCode', 'value']
     }
   );
@@ -184,18 +171,19 @@ export const createNestedStep2AddDebtorSchema = (t: TFunction) => {
     }
   );
 
-  // Validation for zipCode (only for Italy must be 5 digits)
+  // Validation for zipCode (only for Italy must be 5 digits; optional field)
   return fullNameValidationSchema.refine(
     (data) => {
       const zipCode = data.zipCode.value;
       const country = data.country.value;
 
+      const trimmed = (zipCode || '').trim();
+      // Field is now optional: skip validation when empty
+      if (trimmed.length === 0) {
+        return true;
+      }
+
       if (country === 'IT' || !country) {
-        const trimmed = (zipCode || '').trim();
-        if (trimmed.length === 0) {
-          // Let the base required validation handle emptiness
-          return true;
-        }
         return /^\d{5}$/.test(trimmed);
       }
 

--- a/src/routes/DebtPositionCreateWizard/components/Step/Step2AddDebtor.test.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step/Step2AddDebtor.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import Step2AddDebtor from './Step2AddDebtor';
 import { Step2Data } from '../../../../models/DebtPositionType';
 
@@ -105,6 +105,100 @@ describe('Step2AddDebtor', () => {
     }) as HTMLInputElement;
     fireEvent.change(zipCodeInput, { target: { value: '20100' } });
     expect(zipCodeInput.value).toBe('20100');
+  });
+
+  it('does not accept Partita IVA for INDIVIDUAL', async () => {
+    const onNext = vi.fn();
+
+    render(
+      <Step2AddDebtor data={defaultData} setData={() => null} onNext={onNext} />
+    );
+
+    // Select INDIVIDUAL
+    const subjectTypeSelect = screen.getByRole('combobox', {
+      name: 'debtPositionCreateWizard.step2.subjectType.label'
+    }) as HTMLSelectElement;
+    fireEvent.mouseDown(subjectTypeSelect);
+    const individualOption = await screen.findByText(
+      'debtPositionCreateWizard.step2.subjectType.options.fisica'
+    );
+    fireEvent.click(individualOption);
+
+    const taxCodeInput = screen.getByRole('textbox', {
+      name: 'debtPositionCreateWizard.step2.taxCode.label'
+    }) as HTMLInputElement;
+    fireEvent.change(taxCodeInput, { target: { value: '12345678901' } }); // P.IVA format
+
+    const fullNameInput = screen.getByRole('textbox', {
+      name: 'debtPositionCreateWizard.step2.fullName.label'
+    }) as HTMLInputElement;
+    fireEvent.change(fullNameInput, { target: { value: 'Mario Rossi' } });
+
+    const continueButton = screen.getByRole('button', {
+      name: 'commons.continue'
+    });
+    fireEvent.click(continueButton);
+
+    await waitFor(() => expect(onNext).not.toHaveBeenCalled());
+  });
+
+  it('accepts CF or P.IVA for BUSINESS', async () => {
+    const onNext = vi.fn();
+
+    render(
+      <Step2AddDebtor data={defaultData} setData={() => null} onNext={onNext} />
+    );
+
+    // Select BUSINESS
+    const subjectTypeSelect = screen.getByRole('combobox', {
+      name: 'debtPositionCreateWizard.step2.subjectType.label'
+    }) as HTMLSelectElement;
+    fireEvent.mouseDown(subjectTypeSelect);
+    const businessOption = await screen.findByText(
+      'debtPositionCreateWizard.step2.subjectType.options.giuridica'
+    );
+    fireEvent.click(businessOption);
+
+    // Fill required fields with a valid P.IVA format (11 digits)
+    const taxCodeInput = screen.getByRole('textbox', {
+      name: 'debtPositionCreateWizard.step2.taxCodeBusiness.label'
+    }) as HTMLInputElement;
+    fireEvent.change(taxCodeInput, { target: { value: '12345678901' } });
+
+    const fullNameInput = screen.getByRole('textbox', {
+      name: 'debtPositionCreateWizard.step2.companyName.label'
+    }) as HTMLInputElement;
+    fireEvent.change(fullNameInput, { target: { value: 'ACME SPA' } });
+
+    const continueButton = screen.getByRole('button', {
+      name: 'commons.continue'
+    });
+    fireEvent.click(continueButton);
+
+    await waitFor(() => expect(onNext).toHaveBeenCalledTimes(1));
+  });
+
+  it('renders address-related fields as optional', () => {
+    const setData = vi.fn();
+    const onNext = vi.fn();
+
+    render(
+      <Step2AddDebtor data={defaultData} setData={setData} onNext={onNext} />
+    );
+
+    const addressInput = screen.getByTestId('address-field');
+    const civicNumberInput = screen.getByTestId('civic-number-field');
+    const zipCodeInput = screen.getByTestId('zip-code-field');
+    const countrySelect = screen.getByTestId('country-field');
+    const provinceSelect = screen.getByTestId('province-field');
+    const cityInput = screen.getByTestId('city-field');
+
+    expect(addressInput).not.toHaveAttribute('required');
+    expect(civicNumberInput).not.toHaveAttribute('required');
+    expect(zipCodeInput).not.toHaveAttribute('required');
+    expect(countrySelect).not.toHaveAttribute('required');
+    expect(provinceSelect).not.toHaveAttribute('required');
+    expect(cityInput).not.toHaveAttribute('required');
   });
 
   it('allows selecting country and province', async () => {

--- a/src/routes/DebtPositionCreateWizard/components/Step/Step2AddDebtor.tsx
+++ b/src/routes/DebtPositionCreateWizard/components/Step/Step2AddDebtor.tsx
@@ -136,13 +136,13 @@ const Step2AddDebtor = ({
 
   const getTaxCodeLabel = () => {
     return subjectTypeValue === SubjectType.BUSINESS
-      ? t('debtPositionCreateWizard.step2.vat.label')
+      ? t('debtPositionCreateWizard.step2.taxCodeBusiness.label')
       : t('debtPositionCreateWizard.step2.taxCode.label');
   };
 
   const getTaxCodePlaceholder = () => {
     return subjectTypeValue === SubjectType.BUSINESS
-      ? t('debtPositionCreateWizard.step2.vat.placeholder')
+      ? t('debtPositionCreateWizard.step2.taxCodeBusiness.placeholder')
       : t('debtPositionCreateWizard.step2.taxCode.placeholder');
   };
 
@@ -358,7 +358,6 @@ const Step2AddDebtor = ({
                 name="address"
                 control={control}
                 label={t('debtPositionCreateWizard.step2.address.label')}
-                required
                 disabled={isFieldDisabled('personal')}
                 isSubmitted={isSubmitted}
                 errors={errors}
@@ -374,7 +373,6 @@ const Step2AddDebtor = ({
                 name="civicNumber"
                 control={control}
                 label={t('debtPositionCreateWizard.step2.civicNumber.label')}
-                required
                 disabled={isFieldDisabled('personal')}
                 isSubmitted={isSubmitted}
                 errors={errors}
@@ -390,7 +388,6 @@ const Step2AddDebtor = ({
                 name="zipCode"
                 control={control}
                 label={t('debtPositionCreateWizard.step2.zipCode.label')}
-                required
                 disabled={isFieldDisabled('personal')}
                 isSubmitted={isSubmitted}
                 errors={errors}
@@ -416,7 +413,6 @@ const Step2AddDebtor = ({
                     label={t('debtPositionCreateWizard.step2.country.label')}
                     select
                     fullWidth
-                    required
                     disabled={isFieldDisabled('personal')}
                     error={isSubmitted && !!errors.country?.value}
                     helperText={isSubmitted && errors.country?.value?.message}
@@ -452,7 +448,6 @@ const Step2AddDebtor = ({
                     label={t('debtPositionCreateWizard.step2.province.label')}
                     select
                     fullWidth
-                    required
                     disabled={isFieldDisabled('personal')}
                     error={isSubmitted && !!errors.province?.value}
                     helperText={isSubmitted && errors.province?.value?.message}
@@ -481,7 +476,6 @@ const Step2AddDebtor = ({
                 name="city"
                 control={control}
                 label={t('debtPositionCreateWizard.step2.city.label')}
-                required
                 disabled={isFieldDisabled('personal')}
                 isSubmitted={isSubmitted}
                 errors={errors}

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -1162,24 +1162,20 @@
     },
     "step2": {
       "address": {
-        "label": "Indirizzo",
-        "required": "Il campo indirizzo è obbligatorio"
+        "label": "Indirizzo"
       },
       "city": {
-        "label": "Località",
-        "required": "Il campo località è obbligatorio"
+        "label": "Località"
       },
       "civicNumber": {
-        "label": "Civico",
-        "required": "Il campo civico è obbligatorio"
+        "label": "Civico"
       },
       "companyName": {
         "label": "Ragione sociale",
         "required": "Il campo ragione sociale è obbligatorio"
       },
       "country": {
-        "label": "Nazione",
-        "required": "Il campo nazione è obbligatorio"
+        "label": "Nazione"
       },
       "fiscalData": "DATI FISCALI",
       "fullName": {
@@ -1189,8 +1185,7 @@
       },
       "personalData": "DATI PERSONALI",
       "province": {
-        "label": "Provincia",
-        "required": "Il campo provincia è obbligatorio"
+        "label": "Provincia"
       },
       "subjectType": {
         "label": "Tipo di soggetto",
@@ -1211,6 +1206,12 @@
         "placeholder": "Inserisci il codice fiscale (16 caratteri)",
         "required": "Il campo codice fiscale è obbligatorio"
       },
+      "taxCodeBusiness": {
+        "label": "Codice fiscale / P. IVA",
+        "placeholder": "Inserisci il Codice fiscale (16 caratteri) o la Partita IVA (11 cifre)",
+        "required": "Il campo Codice fiscale / P. IVA è obbligatorio",
+        "invalid": "Verifica che il Codice fiscale o la Partita IVA siano corretti"
+      },
       "title": "Debitore",
       "vat": {
         "invalid": "Verifica che la Partita IVA sia corretta",
@@ -1221,8 +1222,7 @@
       "zipCode": {
         "error": "Verifica che il CAP sia corretto. Deve contenere 5 cifre",
         "invalid": "Verifica che il CAP sia corretto. Deve contenere 5 cifre",
-        "label": "CAP",
-        "required": "Il campo CAP è obbligatorio"
+        "label": "CAP"
       }
     },
     "step3": {


### PR DESCRIPTION
Step2 validation: individuals accept only Tax Code; legal entities accept Tax Code or VAT Number, with updated labels and messages.
Personal detail fields (address, street number, ZIP code, nation, province, locality) have been made optional in Step2 of the debt position wizard.

#### List of Changes

Step2 schema: mandatory Tax Code for INDIVIDUAL; Tax Code or VAT Number for BUSINESS; personal info fields optional; ZIP code validation only when provided.

Step2 UI: updated fiscal label/placeholder for BUSINESS to “Codice fiscale / P. IVA”; removed required flags from personal detail fields.

Translations: added taxCodeBusiness.* keys; removed required strings no longer used for optional fields.

Tests: updated Step2AddDebtor and useStep2Form to cover the new Tax Code/VAT Number validation rules.

#### How Has This Been Tested?

-visual testing
-unit tests


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
