### PR TITLE
feat: [P4ADEV-4275] Set a info banner when a tech debt position

### DIFF
--- a/src/components/DebtPositionsInstallmentDetail/DebtPositionsInstallmentDetail.test.tsx
+++ b/src/components/DebtPositionsInstallmentDetail/DebtPositionsInstallmentDetail.test.tsx
@@ -8,7 +8,10 @@ import { setOrganizationId } from '../../store/OrganizationIdStore';
 import { downloadBlob } from '../../utils/download';
 import utils from '../../utils';
 import { STATE } from '../../store/types';
-import { InstallmentStatus } from '../../../generated/apiClient';
+import {
+  DebtPositionOrigin,
+  InstallmentStatus
+} from '../../../generated/apiClient';
 import React from 'react';
 
 global.ResizeObserver = vi.fn().mockImplementation(() => ({
@@ -567,7 +570,7 @@ describe('DebtPositionsInstallmentDetail', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders REPORTED status installment correctly', () => {
+  it('renders REPORTED status installment correctly and NOT a tech debt position', () => {
     const reportedInstallment = {
       ...mockPaidInstallment,
       status: InstallmentStatus.REPORTED
@@ -580,6 +583,7 @@ describe('DebtPositionsInstallmentDetail', () => {
     render(<DebtPositionsInstallmentDetail />);
 
     expect(screen.getByText('commons.paymentInformation')).toBeInTheDocument();
+    expect(screen.queryByTestId('technical-debt-alert')).toBeNull();
   });
 
   it('handles download error with generic exception', async () => {
@@ -623,5 +627,20 @@ describe('DebtPositionsInstallmentDetail', () => {
     expect(
       screen.getByText('commons.routes.DEBT_POSITION_INSTALLMENT_DETAIL')
     ).toBeInTheDocument();
+  });
+
+  it('Check if is a technical debt position', () => {
+    const technicalDebtPosition = {
+      ...mockUnpaidInstallment,
+      debtPositionOrigin: DebtPositionOrigin.SECONDARY_ORG
+    };
+
+    vi.mocked(debtPositions.getInstallmentDetail).mockReturnValue({
+      data: technicalDebtPosition
+    } as any);
+
+    render(<DebtPositionsInstallmentDetail />);
+
+    expect(screen.getByTestId('technical-debt-alert')).toBeInTheDocument();
   });
 });

--- a/src/components/DebtPositionsInstallmentDetail/DebtPositionsInstallmentDetail.tsx
+++ b/src/components/DebtPositionsInstallmentDetail/DebtPositionsInstallmentDetail.tsx
@@ -1,5 +1,5 @@
 import { Download, History, ReadMore, Visibility } from '@mui/icons-material';
-import { Button, Divider, Grid, Typography } from '@mui/material';
+import { Alert, Button, Divider, Grid, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import TitleComponent from '../TitleComponent/TitleComponent';
 import DetailContainer, {
@@ -18,6 +18,7 @@ import { InstallmentDetailDrawer } from './InstallmentDetailDrawer';
 import { Timeline } from '../Timeline';
 import { setAppState } from '../../store/AppStateStore';
 import { downloadBlob } from '../../utils/download';
+import { isTechnicalDebtPosition } from '../../utils/debtpositions';
 import utils from '../../utils';
 import { useTimelineData } from '../../hooks/useTimelineData';
 import { stateColors } from '../../routes/DebtPositions/components/DebtPositionIUVDataGrid';
@@ -246,6 +247,23 @@ export const DebtPositionsInstallmentDetail = () => {
             : [])
         ]}
       />
+      {installment?.debtPositionOrigin &&
+        isTechnicalDebtPosition(installment?.debtPositionOrigin) && (
+          <Alert
+            severity="warning"
+            sx={{ mb: 3 }}
+            data-testid="technical-debt-alert"
+          >
+            {t(
+              `debtPositionInstallmentDetail.origin.${installment.debtPositionOrigin}`,
+              {
+                defaultValue: t(
+                  'debtPositionInstallmentDetail.techDebtPositionDefault'
+                )
+              }
+            )}
+          </Alert>
+        )}
       <Grid container spacing={3}>
         <Grid item md={6}>
           <DetailContainer

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -1403,6 +1403,13 @@
       "info": "Sono presenti altri beneficiari diversi dal tuo ente.",
       "title": "Beneficiari"
     },
+    "origin": {
+      "SECONDARY_ORG": "Vedi questo avviso perché sei beneficiario del pagamento di un avviso creato da un altro ente.",
+      "RECEIPT_FILE": "Questo avviso è stato generato automaticamente in seguito al caricamento di un flusso contenente ricevute di pagamenti effettuati tramite pagoPA.",
+      "RECEIPT_PAGOPA": "Questo avviso è stato generato automaticamente a seguito della ricezione di una ricevuta telematica di un pagamento non gestito in piattaforma.",
+      "REPORTING_PAGOPA": "Questo avviso è stato generato automaticamente in seguito alla ricezione di un flusso di rendicontazione con codice esito 8/9 (pagamento senza Ricevuta Telematica)."
+    },
+    "techDebtPositionDefault": "Posizione debitoria tecnica",
     "timeline": {
       "message": "È stato inviato un messaggio al cittadino su IO. ID messaggio",
       "title": "Storico Avviso"

--- a/src/utils/debtpositions.test.ts
+++ b/src/utils/debtpositions.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { DebtPositionOrigin } from '../../generated/apiClient';
+import { isTechnicalDebtPosition } from './debtpositions';
+
+describe('isTechnicalDebtPosition', () => {
+  it('should return true for all technical debt position origins', () => {
+    const technicalValues = [
+      DebtPositionOrigin.SECONDARY_ORG,
+      DebtPositionOrigin.RECEIPT_FILE,
+      DebtPositionOrigin.RECEIPT_PAGOPA,
+      DebtPositionOrigin.REPORTING_PAGOPA
+    ];
+
+    technicalValues.forEach((value) => {
+      expect(isTechnicalDebtPosition(value)).toBe(true);
+    });
+  });
+
+  it('should return false for non-technical debt position origins', () => {
+    const nonTechnicalValue = 'OTHER_ORIGIN' as DebtPositionOrigin;
+
+    expect(isTechnicalDebtPosition(nonTechnicalValue)).toBe(false);
+  });
+});

--- a/src/utils/debtpositions.ts
+++ b/src/utils/debtpositions.ts
@@ -1,0 +1,22 @@
+import { DebtPositionOrigin } from '../../generated/apiClient';
+
+/**
+ *
+ * @param debtPositionOrigin
+ * @returns If the debtPositionOrigin has a "technical" value, then returns true
+ */
+export const isTechnicalDebtPosition = (
+  debtPositionOrigin: DebtPositionOrigin
+): boolean => {
+  const technicalCodes: Array<DebtPositionOrigin> = [
+    DebtPositionOrigin.SECONDARY_ORG,
+    DebtPositionOrigin.RECEIPT_FILE,
+    DebtPositionOrigin.RECEIPT_PAGOPA,
+    DebtPositionOrigin.REPORTING_PAGOPA
+  ];
+  return technicalCodes.includes(debtPositionOrigin);
+};
+
+export default {
+  isTechnicalDebtPosition
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,6 +10,7 @@ import roles from './roles';
 import filtersValidation from './filtersValidation';
 import dialog from './dialog';
 import URI from './URI';
+import debtpositions from './debtpositions';
 import * as formatters from './formatters';
 
 export default {
@@ -32,5 +33,6 @@ export default {
   URI,
   roles,
   filtersValidation,
-  formatters
+  formatters,
+  debtpositions
 };


### PR DESCRIPTION
This PR adds an utility to check if a debtposition is a "technical debt position" and set a info banner on the installment detail

#### List of Changes
- add utility to check if the origin of a debt position could be a "technical" one
- set a banner on the installment detail view
- set unit test 

#### Motivation and Context
Help user to identify "tech debt positions"

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
