### PR TITLE
feat: [P4ADEV-4390] Add tech debt position warning on DP detail view

### DIFF
--- a/src/routes/DebtPositionDetail/DebtPositionDetail.tsx
+++ b/src/routes/DebtPositionDetail/DebtPositionDetail.tsx
@@ -7,7 +7,8 @@ import {
   ChipProps,
   Divider,
   Menu,
-  MenuItem
+  MenuItem,
+  Alert
 } from '@mui/material';
 import TitleComponent from '../../components/TitleComponent/TitleComponent';
 import {
@@ -48,6 +49,7 @@ import utils from '../../utils';
 import { downloadBlob } from '../../utils/download';
 import { useTimelineData } from '../../hooks/useTimelineData';
 import { isDateInPast, moneyFormat } from '../../utils/formatters';
+import { isTechnicalDebtPosition } from '../../utils/debtpositions';
 
 export type PaymentOptionDisplayData = {
   title: string;
@@ -577,6 +579,23 @@ const DebtPositionDetail = () => {
           </MenuItem>
         </>
       </Menu>
+
+      {debtPositionDetail?.debtPositionOrigin &&
+              isTechnicalDebtPosition(debtPositionDetail.debtPositionOrigin) && (
+                <Alert
+                  severity="warning"
+                  data-testid="technical-debt-alert"
+                >
+                  {t(
+                    `debtPositionDetail.origin.${debtPositionDetail.debtPositionOrigin}`,
+                    {
+                      defaultValue: t(
+                        'debtPositionDetail.techDebtPositionDefault'
+                      )
+                    }
+                  )}
+                </Alert>
+              )}
 
       <Box mt={4} mb={3}>
         <Accordion

--- a/src/routes/DebtPositionDetail/DebtPositionDetail.tsx
+++ b/src/routes/DebtPositionDetail/DebtPositionDetail.tsx
@@ -581,21 +581,16 @@ const DebtPositionDetail = () => {
       </Menu>
 
       {debtPositionDetail?.debtPositionOrigin &&
-              isTechnicalDebtPosition(debtPositionDetail.debtPositionOrigin) && (
-                <Alert
-                  severity="warning"
-                  data-testid="technical-debt-alert"
-                >
-                  {t(
-                    `debtPositionDetail.origin.${debtPositionDetail.debtPositionOrigin}`,
-                    {
-                      defaultValue: t(
-                        'debtPositionDetail.techDebtPositionDefault'
-                      )
-                    }
-                  )}
-                </Alert>
-              )}
+        isTechnicalDebtPosition(debtPositionDetail.debtPositionOrigin) && (
+          <Alert severity="warning" data-testid="technical-debt-alert">
+            {t(
+              `debtPositionDetail.origin.${debtPositionDetail.debtPositionOrigin}`,
+              {
+                defaultValue: t('debtPositionDetail.techDebtPositionDefault')
+              }
+            )}
+          </Alert>
+        )}
 
       <Box mt={4} mb={3}>
         <Accordion

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -1379,6 +1379,13 @@
       "title": "La posizione debitoria non può essere modificata",
       "description": "Siamo spiacenti, non è possibile modificare questa posizione debitoria."
     },
+    "origin": {
+      "SECONDARY_ORG": "Vedi questa posizione debitoria perché sei beneficiario del pagamento di un avviso creato da un altro ente.",
+      "RECEIPT_FILE": "Questa posizione debitoria è stata generata automaticamente in seguito al caricamento di un flusso contenente ricevute di pagamenti effettuati tramite pagoPA.",
+      "RECEIPT_PAGOPA": "Questa posizione debitoria è stata generata automaticamente a seguito della ricezione di una ricevuta telematica di un pagamento non gestito in piattaforma.",
+      "REPORTING_PAGOPA": "Questa posizione debitoria è stata generata automaticamente in seguito alla ricezione di un flusso di rendicontazione con codice esito 8/9 (pagamento senza Ricevuta Telematica)."
+    },
+    "techDebtPositionDefault": "Posizione debitoria tecnica",
     "toSyncEditErrorDialog": {
       "description": "Le posizioni debitorie in stato \"Da sincronizzare\" non possono essere modificate. Si prega di ricaricare la pagina o riprovare più tardi."
     },


### PR DESCRIPTION
This PR adds a warning banner on DP detail view to inform user if a debt position is "technical" 

#### List of Changes

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
