### PR TITLE
feat: [P4ADEV-4392] Warning on Classification detail in case of tech debt position

### DIFF
--- a/src/components/ClassificationDetail/index.tsx
+++ b/src/components/ClassificationDetail/index.tsx
@@ -14,6 +14,7 @@ import { PageRoutes } from '../../routes';
 import { OpenInNew } from '@mui/icons-material';
 import { buildTelematicReceiptDetailPath } from '../../utils/receiptNavigation';
 import { ClassificationsEnum } from '../../../generated/data-contracts';
+import ReceiptDetailWarningBanner from '../ReceiptDetail/ReceiptDetailWarningBanner';
 
 export const ClassificationDetails = () => {
   const store = useStore();
@@ -294,35 +295,44 @@ export const ClassificationDetails = () => {
           >
             <Stack spacing={3}>
               {data.paid && (
-                <DetailContainer
-                  sections={[
-                    {
-                      inline: true,
-                      title: {
-                        textTransform: 'uppercase',
-                        fontWeight: 700,
-                        fontSize: '14px',
-                        label: t(`${targetTranslationDebtType}.title`)
-                      },
-                      data: debtTypeData,
-                      footerLink: {
-                        label: t(`${targetTranslationDebtType}.link`),
-                        icon: <OpenInNew />,
-                        iconPosition: 'right',
-                        onLinkClick: () => {
-                          if (data?.receiptPaymentRequestId && data?.iud) {
-                            navigate(
-                              buildTelematicReceiptDetailPath(
-                                data.receiptPaymentRequestId,
-                                data.iud
-                              )
-                            );
+                <>
+                  {data.receiptOrigin && data.debtPositionOrigin && (
+                    <ReceiptDetailWarningBanner
+                      sx={{ pt: 3 }}
+                      receiptOrigin={data.receiptOrigin}
+                      debtPositionOrigin={data.debtPositionOrigin}
+                    />
+                  )}
+                  <DetailContainer
+                    sections={[
+                      {
+                        inline: true,
+                        title: {
+                          textTransform: 'uppercase',
+                          fontWeight: 700,
+                          fontSize: '14px',
+                          label: t(`${targetTranslationDebtType}.title`)
+                        },
+                        data: debtTypeData,
+                        footerLink: {
+                          label: t(`${targetTranslationDebtType}.link`),
+                          icon: <OpenInNew />,
+                          iconPosition: 'right',
+                          onLinkClick: () => {
+                            if (data?.receiptPaymentRequestId && data?.iud) {
+                              navigate(
+                                buildTelematicReceiptDetailPath(
+                                  data.receiptPaymentRequestId,
+                                  data.iud
+                                )
+                              );
+                            }
                           }
                         }
                       }
-                    }
-                  ]}
-                />
+                    ]}
+                  />
+                </>
               )}
               {(data.flagPaymentNotification ||
                 (data.label == ClassificationsEnum.IUD_NO_RT &&

--- a/src/components/ReceiptDetail/ReceiptDetailWarningBanner.test.tsx
+++ b/src/components/ReceiptDetail/ReceiptDetailWarningBanner.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import ReceiptDetailWarningBanner from './ReceiptDetailWarningBanner';
+import { ReceiptDetailDTO } from '../../../generated/apiClient';
+
+describe('ReceiptDetailWarningBanner', () => {
+  const idAlertBanner = 'technical-debt-alert';
+
+  it('does not show the warning Banner', () => {
+    const { container } = render(
+      <ReceiptDetailWarningBanner
+        receiptOrigin={'RECEIPT_PAGOPA' as ReceiptDetailDTO['receiptOrigin']}
+        debtPositionOrigin={
+          'ORDINARY' as ReceiptDetailDTO['debtPositionOrigin']
+        }
+      />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows the warning Banner when receiptOrigin != RECEIPT_PAGOPA', () => {
+    render(
+      <ReceiptDetailWarningBanner
+        receiptOrigin={'RECEIPT_FILE' as ReceiptDetailDTO['receiptOrigin']}
+        debtPositionOrigin={
+          'ORDINARY' as ReceiptDetailDTO['debtPositionOrigin']
+        }
+      />
+    );
+
+    const alert = screen.getByTestId(idAlertBanner);
+    expect(alert).toBeInTheDocument();
+  });
+
+  it('shows the warning Banner when debtPositionOrigin == SECONDARY_ORG', () => {
+    render(
+      <ReceiptDetailWarningBanner
+        receiptOrigin={'RECEIPT_PAGOPA' as ReceiptDetailDTO['receiptOrigin']}
+        debtPositionOrigin={
+          'SECONDARY_ORG' as ReceiptDetailDTO['debtPositionOrigin']
+        }
+      />
+    );
+
+    const alert = screen.getByTestId(idAlertBanner);
+    expect(alert).toBeInTheDocument();
+  });
+
+  it('should use custom style on wrapper box', () => {
+    const customSx = { marginTop: '20px' };
+    render(
+      <ReceiptDetailWarningBanner
+        receiptOrigin={'RECEIPT_PAGOPA' as ReceiptDetailDTO['receiptOrigin']}
+        debtPositionOrigin={
+          'SECONDARY_ORG' as ReceiptDetailDTO['debtPositionOrigin']
+        }
+        sx={customSx}
+      />
+    );
+
+    const alert = screen.getByTestId(idAlertBanner);
+    expect(alert.parentElement?.parentElement).toBeInTheDocument();
+  });
+});

--- a/src/components/ReceiptDetail/ReceiptDetailWarningBanner.tsx
+++ b/src/components/ReceiptDetail/ReceiptDetailWarningBanner.tsx
@@ -1,0 +1,78 @@
+import { Alert, Box, SxProps, Theme } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { ReceiptDetailDTO } from '../../../generated/apiClient';
+
+type ReceiptDetailWarningBannerProps = {
+  receiptOrigin: ReceiptDetailDTO['receiptOrigin'];
+  debtPositionOrigin: ReceiptDetailDTO['debtPositionOrigin'];
+  sx?: SxProps<Theme>;
+};
+
+/**
+ *
+ * @param receiptOrigin Enum ReceiptDetailDTO["receiptOrigin"]
+ * @param debtPositionOrigin Enum ReceiptDetailDTO["debtPositionOrigin"]
+ * @param sx MUI SxProps for custom styling
+ * @returns A warning banner component to show technical debt position information
+ */
+export const ReceiptDetailWarningBanner = ({
+  receiptOrigin,
+  debtPositionOrigin,
+  sx
+}: ReceiptDetailWarningBannerProps) => {
+  const { t } = useTranslation();
+
+  /**
+   *
+   * @param receiptOrigin Enum ReceiptDetailDTO["receiptOrigin"]
+   * @param debtPositionOrigin Enum ReceiptDetailDTO["debtPositionOrigin"]
+   * @returns A string to use as key of Translation file
+   */
+  const i18nString = (
+    receiptOrigin?: ReceiptDetailDTO['receiptOrigin'],
+    debtPositionOrigin?: ReceiptDetailDTO['debtPositionOrigin']
+  ) => {
+    if (
+      receiptOrigin == 'RECEIPT_PAGOPA' &&
+      debtPositionOrigin == 'RECEIPT_PAGOPA'
+    ) {
+      return 'RECEIPT_PAGOPA__RECEIPT_PAGOPA';
+    }
+
+    return receiptOrigin || 'techDebtPositionDefault';
+  };
+
+  /**
+   *
+   * @param receiptOrigin Enum ReceiptDetailDTO["receiptOrigin"]
+   * @param debtPositionOrigin Enum ReceiptDetailDTO["debtPositionOrigin"]
+   * @returns If receiptOrigin as a value != RECEIPT_PAGOPA always return true. Otherwise checks debtPositionOrigin value.
+   */
+  const showWarning = (
+    receiptOrigin: ReceiptDetailDTO['receiptOrigin'],
+    debtPositionOrigin: ReceiptDetailDTO['debtPositionOrigin']
+  ): boolean =>
+    receiptOrigin !== 'RECEIPT_PAGOPA' ||
+    (
+      ['RECEIPT_PAGOPA', 'SECONDARY_ORG'] as Array<
+        ReceiptDetailDTO['debtPositionOrigin']
+      >
+    ).includes(debtPositionOrigin);
+
+  return (
+    showWarning(receiptOrigin, debtPositionOrigin) && (
+      <Box sx={{ ...sx }}>
+        <Alert severity="warning" data-testid="technical-debt-alert">
+          {t(
+            `telematicReceiptDetail.origin.${i18nString(receiptOrigin, debtPositionOrigin)}`,
+            {
+              defaultValue: t('telematicReceiptDetail.techDebtPositionDefault')
+            }
+          )}
+        </Alert>
+      </Box>
+    )
+  );
+};
+
+export default ReceiptDetailWarningBanner;

--- a/src/components/ReceiptDetail/index.tsx
+++ b/src/components/ReceiptDetail/index.tsx
@@ -1,4 +1,4 @@
-import { Alert, Grid } from '@mui/material';
+import { Grid } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import DetailContainer, {
   DetailData
@@ -7,6 +7,7 @@ import TitleComponent, {
   ActionMenuItem
 } from '../TitleComponent/TitleComponent';
 import { ReceiptDetailDTO } from '../../../generated/apiClient';
+import { ReceiptDetailWarningBanner } from './ReceiptDetailWarningBanner';
 
 type DetailProps = {
   pageTitle: string;
@@ -17,41 +18,6 @@ type DetailProps = {
   debtPositionOrigin?: ReceiptDetailDTO['debtPositionOrigin'];
   receiptOrigin?: ReceiptDetailDTO['receiptOrigin'];
 };
-/**
- *
- * @param receiptOrigin Enum ReceiptDetailDTO["receiptOrigin"]
- * @param debtPositionOrigin Enum ReceiptDetailDTO["debtPositionOrigin"]
- * @returns A string to use as key of Translation file
- */
-const i18nString = (
-  receiptOrigin?: ReceiptDetailDTO['receiptOrigin'],
-  debtPositionOrigin?: ReceiptDetailDTO['debtPositionOrigin']
-) => {
-  if (
-    receiptOrigin == 'RECEIPT_PAGOPA' &&
-    debtPositionOrigin == 'RECEIPT_PAGOPA'
-  ) {
-    return 'RECEIPT_PAGOPA__RECEIPT_PAGOPA';
-  }
-
-  return receiptOrigin || 'techDebtPositionDefault';
-};
-/**
- *
- * @param receiptOrigin Enum ReceiptDetailDTO["receiptOrigin"]
- * @param debtPositionOrigin Enum ReceiptDetailDTO["debtPositionOrigin"]
- * @returns If receiptOrigin as a value != RECEIPT_PAGOPA always return true. Otherwise checks debtPositionOrigin value.
- */
-const showWarning = (
-  receiptOrigin: ReceiptDetailDTO['receiptOrigin'],
-  debtPositionOrigin: ReceiptDetailDTO['debtPositionOrigin']
-): boolean =>
-  receiptOrigin !== 'RECEIPT_PAGOPA' ||
-  (
-    ['RECEIPT_PAGOPA', 'SECONDARY_ORG'] as Array<
-      ReceiptDetailDTO['debtPositionOrigin']
-    >
-  ).includes(debtPositionOrigin);
 
 const ReceiptDetail = ({
   pageTitle,
@@ -71,24 +37,14 @@ const ReceiptDetail = ({
         accessibleTitle={accessibleTitle}
         callToAction={callToAction ? [callToAction] : []}
       />
-      {receiptOrigin &&
-        debtPositionOrigin &&
-        showWarning(receiptOrigin, debtPositionOrigin) && (
-          <Alert
-            severity="warning"
-            data-testid="technical-debt-alert"
-            sx={{ mb: 3 }}
-          >
-            {t(
-              `telematicReceiptDetail.origin.${i18nString(receiptOrigin, debtPositionOrigin)}`,
-              {
-                defaultValue: t(
-                  'telematicReceiptDetail.techDebtPositionDefault'
-                )
-              }
-            )}
-          </Alert>
-        )}
+      {receiptOrigin && debtPositionOrigin && (
+        <ReceiptDetailWarningBanner
+          sx={{ mb: 3 }}
+          receiptOrigin={receiptOrigin}
+          debtPositionOrigin={debtPositionOrigin}
+        />
+      )}
+
       <Grid container spacing={3}>
         <Grid item md={6}>
           <DetailContainer


### PR DESCRIPTION
Add Banner to classification detail to warn user about a receipt with a technical debt position.

#### List of Changes
- refact warning banner on telematic receipt detail to use it in other component
- set banner on classification detail
- add unit tests

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
