### PR TITLE
fix: [P4ADEV-4410] DRAFT Org required logo

### DIFF
--- a/src/routes/Organizations/OrganizationEditWizard/components/Step/sections/EntityProfileSection.test.tsx
+++ b/src/routes/Organizations/OrganizationEditWizard/components/Step/sections/EntityProfileSection.test.tsx
@@ -223,6 +223,20 @@ describe('EntityProfileSection', () => {
       expect(consoleSpy).toHaveBeenCalled();
       consoleSpy.mockRestore();
     });
+
+    it('should not show optional label for logo (logo is always required)', () => {
+      render(
+        <TestWrapper
+          data={baseData}
+          defaultValues={defaultFormValues}
+          t={mockT}
+        />
+      );
+
+      expect(
+        screen.queryByText('organizationEditWizard.step1.orgLogo.optional')
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe('Readonly and disabled behavior', () => {
@@ -307,50 +321,222 @@ describe('EntityProfileSection', () => {
     });
   });
 
-  describe('Logo optional label', () => {
-    it('should show optional label when organization status is not ACTIVE', () => {
+  describe('Logo validation (always required)', () => {
+    it('should require logo when organization status is DRAFT and no logo exists', async () => {
       const dataDraft: UnifiedFormData = {
         ...baseData,
-        organizationStatus: 'DRAFT'
+        organizationStatus: 'DRAFT',
+        orgLogo: { value: null, readonly: false }
       };
 
       render(
         <TestWrapper
           data={dataDraft}
-          defaultValues={defaultFormValues}
+          defaultValues={{
+            ...defaultFormValues,
+            orgLogo: null
+          }}
           t={mockT}
         />
       );
 
-      const optionalTextElements = screen.queryAllByText(
-        (_content, element) => {
-          if (!element) return false;
-          const textContent = element.textContent || '';
-          return textContent.includes(
-            'organizationEditWizard.step1.orgLogo.optional'
-          );
-        }
-      );
-      expect(optionalTextElements.length).toBeGreaterThan(0);
+      const submitButton = screen.getByTestId('submit-entity-profile');
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockT).toHaveBeenCalledWith(
+          'organizationEditWizard.step1.orgLogo.required'
+        );
+      });
     });
 
-    it('should not show optional label when organization status is ACTIVE', () => {
+    it('should require logo when organization status is ACTIVE and no logo exists', async () => {
       const dataActive: UnifiedFormData = {
         ...baseData,
-        organizationStatus: 'ACTIVE'
+        organizationStatus: 'ACTIVE',
+        orgLogo: { value: null, readonly: false }
       };
 
       render(
         <TestWrapper
           data={dataActive}
-          defaultValues={defaultFormValues}
+          defaultValues={{
+            ...defaultFormValues,
+            orgLogo: null
+          }}
           t={mockT}
         />
       );
 
-      expect(
-        screen.queryByText('organizationEditWizard.step1.orgLogo.optional')
-      ).not.toBeInTheDocument();
+      const submitButton = screen.getByTestId('submit-entity-profile');
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockT).toHaveBeenCalledWith(
+          'organizationEditWizard.step1.orgLogo.required'
+        );
+      });
+    });
+
+    it('should NOT allow logo removal when organization status is DRAFT', async () => {
+      const dataDraftWithLogo: UnifiedFormData = {
+        ...baseData,
+        organizationStatus: 'DRAFT',
+        orgLogo: {
+          value: 'data:image/png;base64,existingLogo',
+          readonly: false
+        }
+      };
+
+      render(
+        <TestWrapper
+          data={dataDraftWithLogo}
+          defaultValues={{
+            ...defaultFormValues,
+            orgLogo: null
+          }}
+          t={mockT}
+        />
+      );
+
+      const submitButton = screen.getByTestId('submit-entity-profile');
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockT).toHaveBeenCalledWith(
+          'organizationEditWizard.step1.orgLogo.required'
+        );
+      });
+    });
+
+    it('should NOT allow logo removal when organization status is ACTIVE', async () => {
+      const dataActiveWithLogo: UnifiedFormData = {
+        ...baseData,
+        organizationStatus: 'ACTIVE',
+        orgLogo: {
+          value: 'data:image/png;base64,existingLogo',
+          readonly: false
+        }
+      };
+
+      render(
+        <TestWrapper
+          data={dataActiveWithLogo}
+          defaultValues={{
+            ...defaultFormValues,
+            orgLogo: null
+          }}
+          t={mockT}
+        />
+      );
+
+      const submitButton = screen.getByTestId('submit-entity-profile');
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockT).toHaveBeenCalledWith(
+          'organizationEditWizard.step1.orgLogo.required'
+        );
+      });
+    });
+
+    it('should pass validation when logo file is present for DRAFT', async () => {
+      const dataDraft: UnifiedFormData = {
+        ...baseData,
+        organizationStatus: 'DRAFT',
+        orgLogo: { value: null, readonly: false }
+      };
+
+      const mockFile = new File(['logo'], 'logo.png', { type: 'image/png' });
+
+      render(
+        <TestWrapper
+          data={dataDraft}
+          defaultValues={{
+            ...defaultFormValues,
+            orgLogo: mockFile
+          }}
+          t={mockT}
+        />
+      );
+
+      const submitButton = screen.getByTestId('submit-entity-profile');
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        const requiredCalls = mockT.mock.calls.filter(
+          // eslint-disable-next-line sonarjs/no-nested-functions
+          (call) => call[0] === 'organizationEditWizard.step1.orgLogo.required'
+        );
+        expect(requiredCalls.length).toBe(0);
+      });
+    });
+
+    it('should pass validation when logo file is present for ACTIVE', async () => {
+      const dataActive: UnifiedFormData = {
+        ...baseData,
+        organizationStatus: 'ACTIVE',
+        orgLogo: { value: null, readonly: false }
+      };
+
+      const mockFile = new File(['logo'], 'logo.png', { type: 'image/png' });
+
+      render(
+        <TestWrapper
+          data={dataActive}
+          defaultValues={{
+            ...defaultFormValues,
+            orgLogo: mockFile
+          }}
+          t={mockT}
+        />
+      );
+
+      const submitButton = screen.getByTestId('submit-entity-profile');
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        const requiredCalls = mockT.mock.calls.filter(
+          // eslint-disable-next-line sonarjs/no-nested-functions
+          (call) => call[0] === 'organizationEditWizard.step1.orgLogo.required'
+        );
+        expect(requiredCalls.length).toBe(0);
+      });
+    });
+
+    it('should pass validation when existing logo is present and not removed', async () => {
+      const dataWithExistingLogo: UnifiedFormData = {
+        ...baseData,
+        organizationStatus: 'ACTIVE',
+        orgLogo: {
+          value: 'data:image/png;base64,existingLogo',
+          readonly: false
+        }
+      };
+
+      const mockFile = new File(['logo'], 'logo.png', { type: 'image/png' });
+
+      render(
+        <TestWrapper
+          data={dataWithExistingLogo}
+          defaultValues={{
+            ...defaultFormValues,
+            orgLogo: mockFile // New logo uploaded (replacing existing)
+          }}
+          t={mockT}
+        />
+      );
+
+      const submitButton = screen.getByTestId('submit-entity-profile');
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        const requiredCalls = mockT.mock.calls.filter(
+          // eslint-disable-next-line sonarjs/no-nested-functions
+          (call) => call[0] === 'organizationEditWizard.step1.orgLogo.required'
+        );
+        expect(requiredCalls.length).toBe(0);
+      });
     });
   });
 

--- a/src/routes/Organizations/OrganizationEditWizard/components/Step/sections/EntityProfileSection.tsx
+++ b/src/routes/Organizations/OrganizationEditWizard/components/Step/sections/EntityProfileSection.tsx
@@ -145,15 +145,6 @@ export const EntityProfileSection = ({
               sx={{ mb: 1 }}
             >
               {t('organizationEditWizard.step1.orgLogo.title')}
-              {data.organizationStatus !== 'ACTIVE' && (
-                <Typography
-                  component="span"
-                  color="textSecondary"
-                  sx={{ ml: 1, fontWeight: 400 }}
-                >
-                  - {t('organizationEditWizard.step1.orgLogo.optional')}
-                </Typography>
-              )}
             </Typography>
 
             <Typography variant="body2" color="textSecondary">
@@ -165,18 +156,16 @@ export const EntityProfileSection = ({
               control={control}
               rules={{
                 validate: (value: File | null) => {
-                  if (data.organizationStatus === 'ACTIVE') {
-                    const logoWasRemoved =
-                      data.orgLogo.value !== null && value === null;
-                    const hasLogo =
-                      value !== null ||
-                      (data.orgLogo.value !== null && !logoWasRemoved);
-                    if (!hasLogo) {
-                      return t('organizationEditWizard.step1.orgLogo.required');
-                    }
-                    if (logoWasRemoved) {
-                      return t('organizationEditWizard.step1.orgLogo.required');
-                    }
+                  const logoWasRemoved =
+                    data.orgLogo.value !== null && value === null;
+                  const hasLogo =
+                    value !== null ||
+                    (data.orgLogo.value !== null && !logoWasRemoved);
+                  if (!hasLogo) {
+                    return t('organizationEditWizard.step1.orgLogo.required');
+                  }
+                  if (logoWasRemoved) {
+                    return t('organizationEditWizard.step1.orgLogo.required');
                   }
                   return true;
                 }

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -2148,7 +2148,6 @@
       },
       "orgLogo": {
         "title": "CARICA IL LOGO DEL SERVIZIO",
-        "optional": "Facoltativo",
         "description": "Inserisci solo il logo del tuo ente. Aiuterà a rendere legittime le ricevute telematiche e gli avvisi.",
         "uploadDescription": "Trascina qui il file o seleziona dal computer",
         "requirements": "Hai dubbi su formato o dimensioni?",


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This fix is required to align with the OpenAPI specifications. To transition an Organization from DRAFT to ACTIVE, there was a mismatch between the fields marked as mandatory in the frontend and those actually required by the backend.

#### List of Changes

- fix: now the orgLogo is always required in Organization Wizard
- fix: unit tests

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

- unit tests
- visual testing
- manual interaction

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
