### PR TITLE
feat: [P4ADEV-4325] set Orgname in breadcrumbs when in operator's detail page

### DIFF
--- a/src/routes/OperatorsDetail/hooks/useBreadcrumbs.test.ts
+++ b/src/routes/OperatorsDetail/hooks/useBreadcrumbs.test.ts
@@ -27,7 +27,7 @@ describe('useBreadcrumbs', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Set default mocks
-    mockUseParams.mockReturnValue({ organizationId: '42', orgName: 'TestOrg' });
+    mockUseParams.mockReturnValue({ organizationId: '42' });
     mockGeneratePath.mockImplementation(
       (path, params) => `${path}/${params.organizationId}/${params.orgName}`
     );
@@ -39,7 +39,8 @@ describe('useBreadcrumbs', () => {
         isSuccess: true,
         data: {
           operatorName: 'Maria',
-          operatorLastName: 'Rossi'
+          operatorLastName: 'Rossi',
+          orgName: 'TestOrg'
         } as OperatorsDetail
       })
     );
@@ -60,7 +61,12 @@ describe('useBreadcrumbs', () => {
   });
 
   it('sets breadcrumbs without operator detail when isSuccess false', () => {
-    renderHook(() => useBreadcrumbs({ isSuccess: false, data: undefined }));
+    renderHook(() =>
+      useBreadcrumbs({
+        isSuccess: false,
+        data: { orgName: 'TestOrg' } as OperatorsDetail
+      })
+    );
 
     expect(mockSetCustomBreadcrumbsItems).toHaveBeenCalledWith([
       { pathname: PageRoutes.OPERATORS_LIST, id: 'OPERATORS_LIST' },
@@ -80,7 +86,8 @@ describe('useBreadcrumbs', () => {
         isSuccess: true,
         data: {
           operatorName: 'Maria',
-          operatorLastName: 'Rossi'
+          operatorLastName: 'Rossi',
+          orgName: undefined
         } as OperatorsDetail
       })
     );

--- a/src/routes/OperatorsDetail/hooks/useBreadcrumbs.ts
+++ b/src/routes/OperatorsDetail/hooks/useBreadcrumbs.ts
@@ -12,10 +12,11 @@ export const useBreadcrumbs = ({
   isSuccess: boolean;
   data: OperatorsDetail | undefined;
 }) => {
-  const { organizationId, orgName } = useParams();
+  const { organizationId } = useParams();
 
   useEffect(() => {
     const breadcrumbs: Array<BredcrumbItem> = [];
+    const orgName = data?.orgName;
 
     breadcrumbs.push({
       pathname: PageRoutes.OPERATORS_LIST,
@@ -45,5 +46,5 @@ export const useBreadcrumbs = ({
     }
 
     setCustomBreadcrumbsItems(breadcrumbs);
-  }, [orgName, isSuccess]);
+  }, [isSuccess, data, organizationId]);
 };


### PR DESCRIPTION
This PR refact the useBreadcrumbs hook in the operator detail setting the orgName retrieved from service data.

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- drop orgName passed via querypath
- set orgName using the data object
- fix unit test

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
