### PR TITLE
feat: [P4ADEV-4411] Remove IUV from multi-filter options and associated test.

### DIFF
--- a/src/hooks/useMultiFilters.test.tsx
+++ b/src/hooks/useMultiFilters.test.tsx
@@ -87,7 +87,6 @@ describe('useMultiFilters', () => {
         'AMOUNT',
         'BILL_CODE',
         'DOCUMENT_CODE',
-        'IUV',
         'PAYER',
         'REPORT_ID',
         'VALUE_DATE'

--- a/src/hooks/useMultiFilters.tsx
+++ b/src/hooks/useMultiFilters.tsx
@@ -144,7 +144,6 @@ export const useMultiFilters = (props?: {
     'AMOUNT',
     'BILL_CODE',
     'DOCUMENT_CODE',
-    'IUV',
     'PAYER',
     'REPORT_ID',
     'VALUE_DATE'


### PR DESCRIPTION

#### List of Changes
- Removed the `IUV` (Identificativo Unico di Versamento) option from the `useMultiFilters` hook.
- Updated the `useMultiFilters.test.tsx` to reflect the removal of the `IUV` option from the available filter list.
- 
#### Motivation and Context
The `IUV` filter is being removed from the multi-filter selection as it is no longer required in the current scope of the Treasury/Flows search components. This simplifies the user interface and ensures only relevant filters are presented to the user.

#### How Has This Been Tested?
- **Automated Tests**: Updated and ran the existing unit test suite for `useMultiFilters`.
  - Command: `npm test src/hooks/useMultiFilters.test.tsx`
- **Manual Verification**: Verified that the `IUV` option no longer appears in the filter dropdowns of components using this hook (e.g., Treasury search).

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.