### PR TITLE
fix: [P4ADEV-4778] Set order by server instead client

### DIFF
--- a/src/components/DataGrid/CustomDataGrid.tsx
+++ b/src/components/DataGrid/CustomDataGrid.tsx
@@ -166,8 +166,8 @@ const CustomDataGrid = <T extends GridValidRowModel>({
         rows={rows}
         columns={columns}
         pagination
-        paginationMode="client"
-        sortingMode="client"
+        paginationMode="server"
+        sortingMode="server"
         sortModel={sortModel}
         onSortModelChange={handleSortModelChange}
         hideFooterSelectedRowCount


### PR DESCRIPTION
This FIX set "server" to datagrid props to use data returned by the BE without touch or manipulate them.

#### List of Changes

- change "server" instead "client" in datagrid props
-
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
