### PR TITLE
feat: [P4ADEV-4693]  a11y export wizard

### DIFF
--- a/src/components/ExportFlowContainer/ExportFlowContainer.tsx
+++ b/src/components/ExportFlowContainer/ExportFlowContainer.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Grid,
   Typography,
   FormControl,
+  FormHelperText,
   InputLabel,
   Select,
   MenuItem,
@@ -38,19 +39,31 @@ type ExportFlowContainerProps = {
   }>;
   formData: Record<string, string>;
   onSelectChange: (field: string, value: string) => void;
+  // set once the user tries to submit: surfaces errors on fields never touched
+  submitted?: boolean;
 };
+
+const selectFieldId = (fieldKey: string) => `select-${fieldKey}`;
 
 const ExportFlowContainer = ({
   section,
   formData,
-  onSelectChange
+  onSelectChange,
+  submitted = false
 }: ExportFlowContainerProps) => {
   const theme = useTheme();
   const { t } = useTranslation();
+  const [touched, setTouched] = useState<Record<string, boolean>>({});
+
+  const markTouched = (fieldKey: string) =>
+    setTouched((prev) => ({ ...prev, [fieldKey]: true }));
 
   type SectionItem = ExportFlowContainerProps['section'][number];
 
-  const renderFields = (item: SectionItem): JSX.Element => {
+  const renderFields = (
+    item: SectionItem,
+    sectionIndex: number
+  ): JSX.Element => {
     if (item.dateRange) {
       return <React.Fragment>{item.dateRange}</React.Fragment>;
     }
@@ -58,32 +71,54 @@ const ExportFlowContainer = ({
     if (item.selectOptions) {
       return (
         <React.Fragment>
-          {item.inputFields.map((field, index) => (
-            <FormControl key={index} fullWidth size="small">
-              <InputLabel
-                required={field?.required}
-                id={`select-label-${index}`}
-              >
-                {field.label}
-              </InputLabel>
-              <Select
-                fullWidth
-                required={field?.required}
-                labelId={`select-label-${index}`}
-                value={formData[field?.fieldKey || ''] ?? ''}
-                onChange={(event) =>
-                  onSelectChange(field?.fieldKey ?? '', event.target.value)
-                }
-                label={field.label}
-              >
-                {item?.selectOptions?.map((option, index) => (
-                  <MenuItem key={index} value={option.value}>
-                    {option.label}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          ))}
+          {item.inputFields.map((field, index) => {
+            const fieldKey = field?.fieldKey ?? '';
+            const hasError =
+              !!field?.required &&
+              (!!touched[fieldKey] || submitted) &&
+              !formData[fieldKey];
+            // ids must stay unique across sections: the field index alone repeats
+            const labelId = `select-label-${sectionIndex}-${index}`;
+            const helperId = `select-helper-${sectionIndex}-${index}`;
+
+            return (
+              <FormControl key={index} fullWidth size="small" error={hasError}>
+                <InputLabel required={field?.required} id={labelId}>
+                  {field.label}
+                </InputLabel>
+                <Select
+                  fullWidth
+                  required={field?.required}
+                  id={selectFieldId(fieldKey)}
+                  labelId={labelId}
+                  aria-describedby={hasError ? helperId : undefined}
+                  // MUI puts required/invalid on the hidden native input only:
+                  // the element screen readers focus is this display div
+                  SelectDisplayProps={{
+                    'aria-required': field?.required || undefined,
+                    'aria-invalid': hasError || undefined
+                  }}
+                  value={formData[fieldKey] ?? ''}
+                  onChange={(event) =>
+                    onSelectChange(fieldKey, event.target.value)
+                  }
+                  onBlur={() => markTouched(fieldKey)}
+                  label={field.label}
+                >
+                  {item?.selectOptions?.map((option, index) => (
+                    <MenuItem key={index} value={option.value}>
+                      {option.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+                {hasError && (
+                  <FormHelperText id={helperId}>
+                    {t('commons.required')}
+                  </FormHelperText>
+                )}
+              </FormControl>
+            );
+          })}
         </React.Fragment>
       );
     }
@@ -164,7 +199,7 @@ const ExportFlowContainer = ({
             </Grid>
             <Grid container spacing={2}>
               <Grid item lg={12}>
-                {renderFields(item)}
+                {renderFields(item, index)}
               </Grid>
             </Grid>
           </Grid>

--- a/src/components/ExportFlowPage/ExportFlowPage.test.tsx
+++ b/src/components/ExportFlowPage/ExportFlowPage.test.tsx
@@ -45,6 +45,11 @@ vi.mock('../../api/createExportFile', () => ({
 }));
 vi.mock('../../hooks/useDateRange');
 
+const selectFileVersion = async () => {
+  fireEvent.mouseDown(screen.getAllByRole('combobox')[0]);
+  fireEvent.click(await screen.findByRole('option', { name: '1.0' }));
+};
+
 describe('ExportFlow', () => {
   const mockUseParams = vi.mocked(useParams);
   const mockUseNavigate = vi.mocked(useNavigate);
@@ -87,12 +92,21 @@ describe('ExportFlow', () => {
       expect(screen.getByTestId('success-button')).toBeDefined();
     });
 
-    it('keeps success button disabled initially', () => {
+    it('keeps success button enabled and reports missing dates on click', async () => {
       render(<ExportFlow />);
-      expect(screen.getByTestId('success-button')).toHaveProperty(
-        'disabled',
-        true
-      );
+
+      const successButton = screen.getByTestId('success-button');
+      expect(successButton).toHaveProperty('disabled', false);
+
+      fireEvent.click(successButton);
+
+      // both date fields are empty: the click must surface them, not export
+      await waitFor(() => {
+        expect(screen.getAllByText('commons.required').length).toBeGreaterThan(
+          0
+        );
+      });
+      expect(mockPaidExportMutate).not.toHaveBeenCalled();
     });
 
     it('initializes form data correctly', () => {
@@ -123,6 +137,7 @@ describe('ExportFlow', () => {
       });
 
       render(<ExportFlow />);
+      await selectFileVersion();
 
       const successButton = screen.getByTestId('success-button');
       fireEvent.click(successButton);
@@ -130,6 +145,69 @@ describe('ExportFlow', () => {
       await waitFor(() => {
         expect(mockPaidExportMutate).toHaveBeenCalled();
       });
+    });
+
+    it('reports the missing file version instead of exporting', async () => {
+      mockUseDateRange.mockReturnValue({
+        fromDate: new Date('2024-01-01'),
+        toDate: new Date('2024-01-31'),
+        setFromDate: vi.fn(),
+        setFromDateToday: vi.fn(),
+        setToDate: vi.fn(),
+        setToDateToday: vi.fn(),
+        setFromError: vi.fn(),
+        setToError: vi.fn(),
+        resetDates: vi.fn(),
+        isButtonDisabled: false
+      });
+
+      render(<ExportFlow />);
+
+      const successButton = screen.getByTestId('success-button');
+      // the button stays enabled: the click must be what surfaces the error
+      expect(successButton).toHaveProperty('disabled', false);
+
+      fireEvent.click(successButton);
+
+      const fileVersion = screen.getAllByRole('combobox')[0];
+      const error = await screen.findByText('commons.required');
+
+      expect(mockPaidExportMutate).not.toHaveBeenCalled();
+      expect(fileVersion.getAttribute('aria-describedby')).toBe(error.id);
+      // the combobox is what screen readers focus, so the state must live there
+      expect(fileVersion).toHaveAttribute('aria-required', 'true');
+      // focus moves to the offending field so screen readers announce it
+      expect(document.activeElement).toBe(fileVersion);
+
+      await selectFileVersion();
+      fireEvent.click(successButton);
+
+      await waitFor(() => {
+        expect(mockPaidExportMutate).toHaveBeenCalled();
+      });
+    });
+
+    it('shows an inline required error when file version is left empty', async () => {
+      render(<ExportFlow />);
+
+      const fileVersion = screen.getAllByRole('combobox')[0];
+      fireEvent.blur(fileVersion);
+
+      const error = await screen.findByText('commons.required');
+
+      // the error must be announced: linked to the combobox, not just visible
+      expect(fileVersion.getAttribute('aria-describedby')).toBe(error.id);
+      expect(fileVersion).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('gives each select a unique label id', () => {
+      render(<ExportFlow />);
+
+      const labelledBy = screen
+        .getAllByRole('combobox')
+        .map((combo) => combo.getAttribute('aria-labelledby'));
+
+      expect(new Set(labelledBy).size).toBe(labelledBy.length);
     });
 
     it('handles unknown category in handleExitButton', () => {
@@ -242,6 +320,7 @@ describe('ExportFlow', () => {
       });
 
       render(<ExportFlow />);
+      await selectFileVersion();
 
       const successButton = screen.getByTestId('success-button');
       fireEvent.click(successButton);
@@ -299,6 +378,7 @@ describe('ExportFlow', () => {
       });
 
       render(<ExportFlow />);
+      await selectFileVersion();
 
       const successButton = screen.getByTestId('success-button');
       fireEvent.click(successButton);
@@ -326,11 +406,11 @@ describe('ExportFlow', () => {
       expect(screen.queryByText('exportFlow.dueType')).toBeNull();
     });
 
-    it('success button is initially disabled', () => {
+    it('success button is never disabled', () => {
       render(<ExportFlow />);
       expect(screen.getByTestId('success-button')).toHaveProperty(
         'disabled',
-        true
+        false
       );
     });
   });

--- a/src/components/ExportFlowPage/ExportFlowPage.tsx
+++ b/src/components/ExportFlowPage/ExportFlowPage.tsx
@@ -36,6 +36,11 @@ export const ExportFlowPage = () => {
   }>({
     fileVersion: ''
   });
+  const [submitted, setSubmitted] = useState(false);
+
+  // conservation has no fileVersion select: version is fixed to v1.0
+  const isFileVersionMissing =
+    category !== 'conservation' && !formData.fileVersion;
 
   const {
     fromDate,
@@ -68,7 +73,15 @@ export const ExportFlowPage = () => {
   const createReceiptsArchivingExport = createReceiptsArchivingExportFile();
 
   const handleExportClick = () => {
-    if (!fromDate || !toDate) return;
+    // the button is never disabled: an incomplete form must report itself inline
+    // and move focus to the first offending field, so screen readers announce it
+    if (isButtonDisabled || isFileVersionMissing || !fromDate || !toDate) {
+      setSubmitted(true);
+      requestAnimationFrame(() => {
+        document.querySelector<HTMLElement>('[aria-invalid="true"]')?.focus();
+      });
+      return;
+    }
 
     const formattedFrom = new Date(fromDate).toISOString().split('T')[0];
     const formattedTo = new Date(toDate).toISOString().split('T')[0];
@@ -204,6 +217,8 @@ export const ExportFlowPage = () => {
                 }}
                 onFromErrorChange={setFromError}
                 onToErrorChange={setToError}
+                shouldValidate={submitted}
+                validationErrorMessage={t('commons.required')}
               />
             )
           },
@@ -245,6 +260,7 @@ export const ExportFlowPage = () => {
         ]}
         formData={formData}
         onSelectChange={handleChange}
+        submitted={submitted}
       />
 
       <Grid container direction={'row'} justifyContent={'space-between'}>
@@ -263,7 +279,6 @@ export const ExportFlowPage = () => {
         <Grid item>
           <Button
             data-testid="success-button"
-            disabled={isButtonDisabled}
             size="large"
             variant="contained"
             fullWidth

--- a/src/components/FormComponent/_ControlledSelect.tsx
+++ b/src/components/FormComponent/_ControlledSelect.tsx
@@ -1,4 +1,10 @@
-import { Controller, Control, Path, FieldValues } from 'react-hook-form';
+import {
+  Controller,
+  Control,
+  Path,
+  FieldValues,
+  RegisterOptions
+} from 'react-hook-form';
 import { _Select, _SelectProps, SelectOptions } from './_Select';
 import { UseQueryResult } from '@tanstack/react-query';
 import { ErrorMessage } from './ErrorMessage';
@@ -13,12 +19,14 @@ export type _ControlledSelectProps<T extends FieldValues> = _SelectProps & {
   fetchFn?: () => UseQueryResult<SelectOptions>;
   disabled?: boolean;
   required?: boolean;
+  rules?: RegisterOptions<T, Path<T>>;
 };
 
 export const _ControlledSelect = <T extends FieldValues>({
   name,
   control,
   fetchFn,
+  rules,
   ...props
 }: _ControlledSelectProps<T>) => {
   const { t } = useTranslation();
@@ -35,6 +43,7 @@ export const _ControlledSelect = <T extends FieldValues>({
     <Controller
       name={name}
       control={control}
+      rules={rules}
       render={({ field: { ref, value, onChange, onBlur }, fieldState }) => {
         const options = optionsResult.data ?? [];
 

--- a/src/hooks/useClassificationExport.tsx
+++ b/src/hooks/useClassificationExport.tsx
@@ -46,7 +46,9 @@ const DEFAULT_VALUES: ClassificationFormFields = {
 
 export const useClassificationExport = (organizationId: number) => {
   const formMethods = useForm<ClassificationFormFields>({
-    defaultValues: DEFAULT_VALUES
+    defaultValues: DEFAULT_VALUES,
+    // errors surface on blur too, not only on submit
+    mode: 'onTouched'
   });
 
   const dateToIso = useCallback((date: Date | null): string | undefined => {

--- a/src/routes/ClassificationExport/ClassificationExport.test.tsx
+++ b/src/routes/ClassificationExport/ClassificationExport.test.tsx
@@ -113,6 +113,13 @@ describe('ClassificationExportPage', () => {
       ).toBeInTheDocument();
     });
 
+    it('should keep the confirm button enabled', () => {
+      render(<ClassificationExportPage />);
+
+      // required fields are reported inline on submit, never by disabling
+      expect(screen.getByTestId('confirmButton')).not.toBeDisabled();
+    });
+
     it('should render all form sections correctly', () => {
       render(<ClassificationExportPage />);
 
@@ -716,7 +723,7 @@ describe('ClassificationExportPage', () => {
       }
     });
 
-    it('should test ALL_CLASSIFICATIONS_VALUE constant usage', () => {
+    it('should test ALL_CLASSIFICATIONS_VALUE constant usage', async () => {
       render(<ClassificationExportPage />);
 
       expect(
@@ -731,7 +738,10 @@ describe('ClassificationExportPage', () => {
 
       fireEvent.click(submitButton);
 
-      expect(mockValidateForm).toHaveBeenCalled();
+      // submit now runs through react-hook-form validation, which is async
+      await waitFor(() => {
+        expect(mockValidateForm).toHaveBeenCalled();
+      });
     });
 
     it('should handle form submission with different label processing', async () => {
@@ -810,7 +820,7 @@ describe('ClassificationExportPage', () => {
       }
     });
 
-    it('should test the processedFormData logic branch coverage', () => {
+    it('should test the processedFormData logic branch coverage', async () => {
       render(<ClassificationExportPage />);
 
       expect(
@@ -830,7 +840,9 @@ describe('ClassificationExportPage', () => {
       mockValidateForm.mockReturnValue(false);
       fireEvent.click(submitButton);
 
-      expect(mockValidateForm).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(mockValidateForm).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/src/routes/ClassificationExport/ClassificationExport.tsx
+++ b/src/routes/ClassificationExport/ClassificationExport.tsx
@@ -209,6 +209,7 @@ const ClassificationExportPage = () => {
               options={versionOptions}
               control={formMethods.control}
               required
+              rules={{ required: 'commons.required' }}
               data-testid="trace-section-version"
             />
           </FormSection>
@@ -363,7 +364,7 @@ const ClassificationExportPage = () => {
           <Grid item>
             <Button
               variant="contained"
-              onClick={handleSubmit}
+              onClick={formMethods.handleSubmit(handleSubmit)}
               type="button"
               data-testid="confirmButton"
             >


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- ExportFlowPage / ClassificationExport: submit button never disabled. Validation runs on click, missing dates or Versione Tracciato block the request, mark the fields inline and move focus to the first invalid one.
- ExportFlowContainer: required selects show an inline text, linked via aria-describedby, with aria-required/aria-invalid on the role="combobox" element (MUI sets them only on the hidden native input). Label ids now include the section index

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

- unit tests
- visual testing
- manual interaction
- screen reader

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
