### PR TITLE
feat: [P4ADEV-4674] a11y debtType dataGrid detail button

### DIFF
--- a/src/routes/DebtTypesCreated/MyOrg/MyOrg.test.tsx
+++ b/src/routes/DebtTypesCreated/MyOrg/MyOrg.test.tsx
@@ -7,14 +7,15 @@ import {
   fireEvent
 } from '../../../__tests__/renderers';
 import { MyOrg } from './MyOrg';
-import { useNavigate, generatePath } from 'react-router';
+import { useNavigate, generatePath, useParams } from 'react-router';
 import { i18nTestSetup } from '../../../__tests__/i18nTestSetup';
 
-// Mock react-router's useNavigate and generatePath
+// Mock react-router's useNavigate, generatePath and useParams
 vi.mock('react-router', async (importActual) => ({
   ...(await importActual()),
   useNavigate: vi.fn(),
-  generatePath: vi.fn()
+  generatePath: vi.fn(),
+  useParams: vi.fn()
 }));
 
 // Mock your store hook
@@ -35,6 +36,7 @@ import { useSearch } from '../../../hooks/useSearch';
 describe('MyOrg', () => {
   const mockNavigate = vi.fn();
   const mockGeneratePath = generatePath as unknown as ReturnType<typeof vi.fn>;
+  const mockUseParams = useParams as unknown as ReturnType<typeof vi.fn>;
   const mockMutateAsync = vi.fn();
   const mockApplyFilters = vi.fn();
 
@@ -45,6 +47,11 @@ describe('MyOrg', () => {
       'debtTypesCreated.myOrganizationDataGrid.lastUpdateDate': 'Last Update',
       'debtTypesCreated.myOrganizationDataGrid.enabledOperators':
         'Enabled Operators',
+      'debtTypesCreated.myOrganizationDataGrid.detailMyOrg':
+        'Detail of my organization debt type',
+      'debtTypesCreated.myOrganizationDataGrid.detailManagedOrg':
+        'Detail of managed organization debt type',
+      'debtTypesCreated.myOrganizationDataGrid.detailColumn': 'Detail',
       'commons.status.ACTIVE': 'Active',
       'commons.status.DISABLED': 'Disabled',
       'commons.state': 'State',
@@ -59,6 +66,7 @@ describe('MyOrg', () => {
       mockNavigate
     );
     mockGeneratePath.mockReturnValue('/mock-path');
+    mockUseParams.mockReturnValue({});
 
     // Setup useSearch mock to return expected structure used by MyOrg
     (useSearch as unknown as Mock).mockReturnValue({
@@ -137,5 +145,60 @@ describe('MyOrg', () => {
     expect(mockGeneratePath).toHaveBeenCalledWith(expect.any(String), {
       debtPositionTypeOrgId: 1
     });
+  });
+
+  it('exposes the detail arrow as a named button', async () => {
+    render(<MyOrg />);
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole('button', {
+          name: 'Detail of my organization debt type'
+        })
+      ).toHaveLength(2);
+    });
+    expect(
+      screen.getByRole('columnheader', { name: 'Detail' })
+    ).toBeInTheDocument();
+
+    // The grid delegates focus from the cell to the first tabbable descendant,
+    // so the arrow must stay a real, tabbable <button>.
+    const arrow = screen.getByTestId('navigate-icon-1');
+    expect(arrow.tagName).toBe('BUTTON');
+    expect(arrow).toHaveAttribute('tabindex', '0');
+  });
+
+  it('names the detail button after the managed organization section', async () => {
+    mockUseParams.mockReturnValue({ organizationId: '7' });
+    render(<MyOrg />);
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole('button', {
+          name: 'Detail of managed organization debt type'
+        })
+      ).toHaveLength(2);
+    });
+  });
+
+  it('hands focus to the detail button when arrowing across the row', async () => {
+    const { container } = render(<MyOrg />);
+    await waitFor(() => screen.getByTestId('navigate-icon-1'));
+
+    const firstCell = container.querySelector(
+      '[role="gridcell"][data-field="code"]'
+    ) as HTMLElement;
+    firstCell.focus();
+    fireEvent.focus(firstCell);
+
+    // 5 columns to the right of "code" sits the actions cell
+    for (let i = 0; i < 5; i++) {
+      fireEvent.keyDown(document.activeElement as HTMLElement, {
+        key: 'ArrowRight'
+      });
+    }
+
+    // The grid must land on the button itself, not on the wrapping gridcell:
+    // only then does the screen reader announce a name and role, and only then
+    // does Enter reach a native <button>.
+    expect(document.activeElement).toBe(screen.getByTestId('navigate-icon-1'));
   });
 });

--- a/src/routes/DebtTypesCreated/MyOrg/MyOrg.tsx
+++ b/src/routes/DebtTypesCreated/MyOrg/MyOrg.tsx
@@ -1,4 +1,5 @@
-import { Chip, IconButton } from '@mui/material';
+import { Box, Chip, IconButton } from '@mui/material';
+import { visuallyHidden } from '@mui/utils';
 import { useTranslation } from 'react-i18next';
 import { GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
 import { useState } from 'react';
@@ -112,6 +113,11 @@ export const MyOrg = () => {
       sortable: false,
       align: 'right',
       headerAlign: 'right',
+      renderHeader: () => (
+        <Box component="span" sx={visuallyHidden}>
+          {t('debtTypesCreated.myOrganizationDataGrid.detailColumn')}
+        </Box>
+      ),
       renderCell: (
         params: GridRenderCellParams<DebtPositionTypeOrgWithCount>
       ) => (
@@ -119,7 +125,11 @@ export const MyOrg = () => {
           data-testid={`navigate-icon-${params.row.debtPositionTypeOrgId}`}
           size="small"
           color="primary"
-          aria-label={t('commons.goToDetail')}
+          aria-label={t(
+            organizationIdByURL
+              ? 'debtTypesCreated.myOrganizationDataGrid.detailManagedOrg'
+              : 'debtTypesCreated.myOrganizationDataGrid.detailMyOrg'
+          )}
           onClick={() => handleRowClick(params.row)}
         >
           <ArrowForwardIos fontSize="small" />

--- a/src/translations/it/translations.json
+++ b/src/translations/it/translations.json
@@ -1893,6 +1893,9 @@
       "debtTypesSet": "Tipi dovuti impostati attivi"
     },
     "myOrganizationDataGrid": {
+      "detailManagedOrg": "Dettaglio Tipo Dovuto Impostato di Enti gestiti",
+      "detailMyOrg": "Dettaglio Tipo Dovuto Impostato del mio ente",
+      "detailColumn": "Dettaglio",
       "code": "Cod. Gestionale",
       "debtType": "Tipo dovuto",
       "description": "Descrizione",


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- MyOrg.tsx: the detail arrow in the "Tipi dovuti impostati" grid now has a descriptive aria-label instead of the generic commons.goToDetail. The label depends on the context the grid is rendered in - :organizationId in the URL means the user came from "Enti gestiti".
- MyOrg.tsx: the action column has headerName: ' ', so screen readers fell back to the column index. Added a renderHeader with visuallyHidden text — no visual change.

<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

- unit test
- visual testing
- manual interaction
- manual screen reader pass on the page

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
